### PR TITLE
correlate: residualize, shrink, stratify, and add --rebuild-correlations

### DIFF
--- a/src/sportstradamus/data/.gitignore
+++ b/src/sportstradamus/data/.gitignore
@@ -9,3 +9,6 @@ features_to_filter.json
 book_weights.json
 training_report.txt
 *_comps.json
+*_corr_same_team.csv
+*_corr_opposing.csv
+correlations/

--- a/src/sportstradamus/prediction/correlation.py
+++ b/src/sportstradamus/prediction/correlation.py
@@ -2,8 +2,9 @@
 
 :func:`find_correlation` takes the flat list of scored offers produced by
 :func:`process_offers`, groups them by game, looks up the pre-computed
-``{LEAGUE}_corr.csv`` correlation matrix, and annotates each offer with
-its most correlated team-mate and opponent legs.  It also calls
+stratified correlation matrices (``{LEAGUE}_corr_same_team.csv`` and
+``{LEAGUE}_corr_opposing.csv``), and annotates each offer with its most
+correlated team-mate and opponent legs.  It also calls
 :func:`beam_search_parlays` to enumerate the top parlay combinations.
 """
 
@@ -26,6 +27,70 @@ from tqdm import tqdm
 from sportstradamus import data
 from sportstradamus.helpers import banned, stat_cv, stat_map, stat_std
 from sportstradamus.spiderLogger import logger
+
+# Legacy weighting from the unified-matrix era: same-team and cross pairs
+# (where the team is the offensive actor) are weighted higher than the
+# team's view of the opposing team's same-team pairs.
+_OFFENSIVE_PAIR_WEIGHT: float = 0.75
+_DEFENSIVE_PAIR_WEIGHT: float = 1.0 - _OFFENSIVE_PAIR_WEIGHT
+
+
+def _team_slice(corr_df: pd.DataFrame, team: str) -> pd.Series:
+    """Return the R series for one team from a stratified correlation DataFrame.
+
+    Args:
+        corr_df: Stratified correlation DataFrame with MultiIndex
+            ``(team, market_a, market_b)`` and a single ``R`` column.
+        team: Team abbreviation to look up.
+
+    Returns:
+        A Series indexed by ``(market_a, market_b)`` for the requested team,
+        empty if the team has no entries.
+    """
+    try:
+        return corr_df.loc[team]["R"]
+    except KeyError:
+        return pd.Series([], dtype=float)
+
+
+def _build_game_corr_map(
+    team: str,
+    opp: str,
+    c_same: pd.DataFrame,
+    c_opp: pd.DataFrame,
+) -> dict[tuple[str, str], float]:
+    """Combine same-team and opposing matrices into one pair-keyed lookup.
+
+    Keys preserve the legacy ``_OPP_`` prefix convention so the rest of
+    :func:`find_correlation` can keep using string-keyed lookups:
+
+    * ``(a, b)`` — same-team pair on ``team``.
+    * ``(_OPP_a, _OPP_b)`` — same-team pair on ``opp`` (i.e. ``team`` faces it).
+    * ``(a, _OPP_b)`` — cross pair where ``a`` is on ``team`` and ``b`` on ``opp``.
+
+    Cross pairs are summed across the two perspectives (team's gamelog and
+    opp's gamelog) to mirror the legacy unified-matrix arithmetic.
+    """
+    c_map: dict[tuple[str, str], float] = {}
+
+    for (a, b), r in _team_slice(c_same, team).items():
+        key = (a, b)
+        c_map[key] = c_map.get(key, 0.0) + r * _OFFENSIVE_PAIR_WEIGHT
+
+    for (a, b), r in _team_slice(c_same, opp).items():
+        key = (f"_OPP_{a}", f"_OPP_{b}")
+        c_map[key] = c_map.get(key, 0.0) + r * _DEFENSIVE_PAIR_WEIGHT
+
+    for (a, b), r in _team_slice(c_opp, team).items():
+        key = (a, f"_OPP_{b}")
+        c_map[key] = c_map.get(key, 0.0) + r * _OFFENSIVE_PAIR_WEIGHT
+
+    for (a, b), r in _team_slice(c_opp, opp).items():
+        # opp file convention: level 1 is opp's market, level 2 is team's market.
+        key = (b, f"_OPP_{a}")
+        c_map[key] = c_map.get(key, 0.0) + r * _OFFENSIVE_PAIR_WEIGHT
+
+    return c_map
 
 
 @line_profiler.profile
@@ -63,9 +128,7 @@ def find_correlation(offers, stats, platform):
 
     combo_mask = df["Team"].apply(lambda x: len(set(x.split("/"))) == 1)
     df.loc[combo_mask, "Team"] = df.loc[combo_mask, "Team"].apply(lambda x: x.split("/")[0])
-    df.loc[combo_mask, "Opponent"] = df.loc[combo_mask, "Opponent"].apply(
-        lambda x: x.split("/")[0]
-    )
+    df.loc[combo_mask, "Opponent"] = df.loc[combo_mask, "Opponent"].apply(lambda x: x.split("/")[0])
 
     df["Team Correlation"] = ""
     df["Opp Correlation"] = ""
@@ -117,9 +180,18 @@ def find_correlation(offers, stats, platform):
         league_df = df.loc[df["League"] == league]
         if league_df.empty:
             continue
-        c = pd.read_csv(pkg_resources.files(data) / (f"{league}_corr.csv"), index_col=[0, 1, 2])
-        c.rename_axis(["team", "market", "correlation"], inplace=True)
-        c.columns = ["R"]
+        c_same = pd.read_csv(
+            pkg_resources.files(data) / f"{league}_corr_same_team.csv",
+            index_col=[0, 1, 2],
+        )
+        c_same.rename_axis(["team", "market", "correlation"], inplace=True)
+        c_same.columns = ["R"]
+        c_opp = pd.read_csv(
+            pkg_resources.files(data) / f"{league}_corr_opposing.csv",
+            index_col=[0, 1, 2],
+        )
+        c_opp.rename_axis(["team", "market", "correlation"], inplace=True)
+        c_opp.columns = ["R"]
         stat_data = stats.get(league)
         team_mod_map = banned[platform][league]["team"]
         opp_mod_map = banned[platform][league]["opponent"]
@@ -128,9 +200,11 @@ def find_correlation(offers, stats, platform):
 
         if league != "MLB":
             league_df["Player position"] = league_df["Player position"].apply(
-                lambda x: positions[league][x - 1]
-                if isinstance(x, int)
-                else [positions[league][i - 1] for i in x]
+                lambda x: (
+                    positions[league][x - 1]
+                    if isinstance(x, int)
+                    else [positions[league][i - 1] for i in x]
+                )
             )
             combo_df = league_df.loc[league_df.Player.str.contains(r"\+|vs.")]
             league_df = league_df.loc[~league_df.index.isin(combo_df.index)]
@@ -162,9 +236,11 @@ def find_correlation(offers, stats, platform):
             league_df["Player position"] = league_df.Player.map(player_df)
         else:
             league_df["Player position"] = league_df["Player position"].apply(
-                lambda x: ("B" + str(x) if x > 0 else "P")
-                if isinstance(x, int)
-                else ["B" + str(i) if i > 0 else "P" for i in x]
+                lambda x: (
+                    ("B" + str(x) if x > 0 else "P")
+                    if isinstance(x, int)
+                    else ["B" + str(i) if i > 0 else "P" for i in x]
+                )
             )
 
         if league == "NHL":
@@ -173,18 +249,20 @@ def find_correlation(offers, stats, platform):
             new_map.update({"Fantasy Points": "fantasy points prizepicks"})
 
         league_df["cMarket"] = league_df.apply(
-            lambda x: [
-                x["Player position"]
-                + "."
-                + new_map.get(x["Market"].replace("H2H ", ""), x["Market"].replace("H2H ", ""))
-            ]
-            if isinstance(x["Player position"], str)
-            else [
-                p
-                + "."
-                + new_map.get(x["Market"].replace("H2H ", ""), x["Market"].replace("H2H ", ""))
-                for p in x["Player position"]
-            ],
+            lambda x: (
+                [
+                    x["Player position"]
+                    + "."
+                    + new_map.get(x["Market"].replace("H2H ", ""), x["Market"].replace("H2H ", ""))
+                ]
+                if isinstance(x["Player position"], str)
+                else [
+                    p
+                    + "."
+                    + new_map.get(x["Market"].replace("H2H ", ""), x["Market"].replace("H2H ", ""))
+                    for p in x["Player position"]
+                ]
+            ),
             axis=1,
         )
 
@@ -231,25 +309,7 @@ def find_correlation(offers, stats, platform):
             checked_teams.append(team)
             checked_teams.append(opp)
 
-            off_weight = 0.75
-            team_c = c.loc[team] * 0.5
-            def_mask = ["_OPP_" in x and "_OPP_" in y for x, y in team_c.index]
-            off_mask = [not x for x in def_mask]
-            team_c.loc[off_mask] = team_c.loc[off_mask] * 2 * off_weight
-            team_c.loc[def_mask] = team_c.loc[def_mask] * 2 * (1 - off_weight)
-            opp_c = c.loc[opp] * 0.5
-            def_mask = ["_OPP_" in x and "_OPP_" in y for x, y in opp_c.index]
-            off_mask = [not x for x in def_mask]
-            opp_c.loc[off_mask] = opp_c.loc[off_mask] * 2 * off_weight
-            opp_c.loc[def_mask] = opp_c.loc[def_mask] * 2 * (1 - off_weight)
-            opp_c.index = pd.MultiIndex.from_tuples(
-                [
-                    (f"_OPP_{x}".replace("_OPP__OPP_", ""), f"_OPP_{y}".replace("_OPP__OPP_", ""))
-                    for x, y in opp_c.index
-                ],
-                names=("market", "correlation"),
-            )
-            c_map = team_c["R"].add(opp_c["R"], fill_value=0).to_dict()
+            c_map = _build_game_corr_map(team, opp, c_same, c_opp)
 
             game_df.reset_index(drop=True, inplace=True)
             game_dict = game_df.to_dict("index")

--- a/src/sportstradamus/training/cli.py
+++ b/src/sportstradamus/training/cli.py
@@ -38,7 +38,12 @@ np.seterr(divide="ignore", invalid="ignore")
     default="",
     help="Comma-separated league:market pairs (or just market for active league) to clear from Filtered before training",
 )
-def meditate(force, league, rebuild_filter, reset_markets):
+@click.option(
+    "--rebuild-correlations/--no-rebuild-correlations",
+    default=False,
+    help="Rebuild only the per-league correlation matrices and exit; skip the per-market training loop",
+)
+def meditate(force, league, rebuild_filter, reset_markets, rebuild_correlations):
     """Train or retrain LightGBMLSS models for each configured market."""
     np.random.seed(69)
 
@@ -71,7 +76,6 @@ def meditate(force, league, rebuild_filter, reset_markets):
     # nhl = StatsNHL()
 
     stat_structs = {}
-    archive = Archive()
 
     if (
         league == "All" and datetime.today().date() > (nba.season_start - timedelta(days=7))
@@ -103,6 +107,17 @@ def meditate(force, league, rebuild_filter, reset_markets):
     active_markets = dict(ALL_MARKETS)
     if league != "All":
         active_markets = {league: ALL_MARKETS[league]}
+
+    if rebuild_correlations:
+        for lg in active_markets:
+            stat_data = stat_structs.get(lg)
+            if stat_data is None:
+                continue
+            stat_data.update_player_comps()
+            correlate(lg, stat_data, force)
+        return
+
+    archive = Archive()
 
     for lg, markets in active_markets.items():
         stat_data = stat_structs.get(lg)

--- a/src/sportstradamus/training/correlate.py
+++ b/src/sportstradamus/training/correlate.py
@@ -1,13 +1,57 @@
-"""Per-league player-stat correlation matrix builder."""
+"""Per-league player-stat correlation matrix builder.
+
+Produces *stratified* Spearman correlation matrices on residualized per-game
+stats with sample-size-aware shrinkage, plus a metadata sidecar for
+reproducibility.
+
+Outputs (per league):
+
+* ``data/{LEAGUE}_corr_same_team.csv`` — within-team pair correlations
+  indexed by ``(team, market_a, market_b)``.
+* ``data/{LEAGUE}_corr_opposing.csv`` — cross-team pair correlations
+  indexed by ``(team, team_market, opp_market)``. Both sides keyed by their
+  raw (un-prefixed) market names; the file structure encodes the
+  team-vs-opponent relationship.
+* ``data/correlations/{LEAGUE}_corr_metadata.json`` — date range covered,
+  per-team observation counts, generation timestamp, git SHA.
+
+The intermediate per-game record at ``data/training_data/{LEAGUE}_corr.csv``
+is still written (warm-start cache) but no longer used by the prediction
+pipeline.
+"""
 
 import importlib.resources as pkg_resources
-from datetime import datetime, timedelta
+import json
+import subprocess
+from datetime import UTC, datetime, timedelta
 
 import numpy as np
 import pandas as pd
 from tqdm import tqdm
 
 from sportstradamus import data
+
+# Lookback window for game inclusion. ~1 calendar year covers a full regular
+# season + post-season for the major leagues.
+LOOKBACK_DAYS: int = 300
+
+# Rolling window for per-player residualization. Eight games trades off bias
+# (longer windows mask form swings) and variance (shorter windows leak
+# per-game noise into the "mean").
+ROLLING_WINDOW_GAMES: int = 8
+
+# Minimum prior-game observations required for a residual to be defined.
+# Below this, the residual is left as NaN rather than fit on near-zero history.
+MIN_ROLLING_OBSERVATIONS: int = 3
+
+# Minimum shared-game count for a pair to keep its raw correlation. Pairs with
+# fewer shared games are shrunk toward zero proportionally to the deficit;
+# below this floor a single noisy game can dominate the estimate.
+MIN_OVERLAP_FOR_FULL_WEIGHT: int = 30
+
+# Pairs with absolute (post-shrinkage) correlation below this magnitude are
+# dropped from the output — keeps the on-disk matrix sparse.
+CORR_MAGNITUDE_FLOOR: float = 0.05
 
 _TRACKED_STATS: dict[str, dict] = {
     "NFL": {
@@ -120,54 +164,198 @@ _TRACKED_STATS: dict[str, dict] = {
     },
     "NBA": {
         "C": [
-            "PTS", "REB", "AST", "PRA", "PR", "RA", "PA", "FG3M",
-            "fantasy points prizepicks", "fantasy points underdog",
-            "TOV", "BLK", "STL", "BLST", "FG3A", "FTM", "FGM", "FGA",
-            "OREB", "DREB", "PF", "MIN",
+            "PTS",
+            "REB",
+            "AST",
+            "PRA",
+            "PR",
+            "RA",
+            "PA",
+            "FG3M",
+            "fantasy points prizepicks",
+            "fantasy points underdog",
+            "TOV",
+            "BLK",
+            "STL",
+            "BLST",
+            "FG3A",
+            "FTM",
+            "FGM",
+            "FGA",
+            "OREB",
+            "DREB",
+            "PF",
+            "MIN",
         ],
         "P": [
-            "PTS", "REB", "AST", "PRA", "PR", "RA", "PA", "FG3M",
-            "fantasy points prizepicks", "fantasy points underdog",
-            "TOV", "BLK", "STL", "BLST", "FG3A", "FTM", "FGM", "FGA",
-            "OREB", "DREB", "PF", "MIN",
+            "PTS",
+            "REB",
+            "AST",
+            "PRA",
+            "PR",
+            "RA",
+            "PA",
+            "FG3M",
+            "fantasy points prizepicks",
+            "fantasy points underdog",
+            "TOV",
+            "BLK",
+            "STL",
+            "BLST",
+            "FG3A",
+            "FTM",
+            "FGM",
+            "FGA",
+            "OREB",
+            "DREB",
+            "PF",
+            "MIN",
         ],
         "B": [
-            "PTS", "REB", "AST", "PRA", "PR", "RA", "PA", "FG3M",
-            "fantasy points prizepicks", "fantasy points underdog",
-            "TOV", "BLK", "STL", "BLST", "FG3A", "FTM", "FGM", "FGA",
-            "OREB", "DREB", "PF", "MIN",
+            "PTS",
+            "REB",
+            "AST",
+            "PRA",
+            "PR",
+            "RA",
+            "PA",
+            "FG3M",
+            "fantasy points prizepicks",
+            "fantasy points underdog",
+            "TOV",
+            "BLK",
+            "STL",
+            "BLST",
+            "FG3A",
+            "FTM",
+            "FGM",
+            "FGA",
+            "OREB",
+            "DREB",
+            "PF",
+            "MIN",
         ],
         "F": [
-            "PTS", "REB", "AST", "PRA", "PR", "RA", "PA", "FG3M",
-            "fantasy points prizepicks", "fantasy points underdog",
-            "TOV", "BLK", "STL", "BLST", "FG3A", "FTM", "FGM", "FGA",
-            "OREB", "DREB", "PF", "MIN",
+            "PTS",
+            "REB",
+            "AST",
+            "PRA",
+            "PR",
+            "RA",
+            "PA",
+            "FG3M",
+            "fantasy points prizepicks",
+            "fantasy points underdog",
+            "TOV",
+            "BLK",
+            "STL",
+            "BLST",
+            "FG3A",
+            "FTM",
+            "FGM",
+            "FGA",
+            "OREB",
+            "DREB",
+            "PF",
+            "MIN",
         ],
         "W": [
-            "PTS", "REB", "AST", "PRA", "PR", "RA", "PA", "FG3M",
-            "fantasy points prizepicks", "fantasy points underdog",
-            "TOV", "BLK", "STL", "BLST", "FG3A", "FTM", "FGM", "FGA",
-            "OREB", "DREB", "PF", "MIN",
+            "PTS",
+            "REB",
+            "AST",
+            "PRA",
+            "PR",
+            "RA",
+            "PA",
+            "FG3M",
+            "fantasy points prizepicks",
+            "fantasy points underdog",
+            "TOV",
+            "BLK",
+            "STL",
+            "BLST",
+            "FG3A",
+            "FTM",
+            "FGM",
+            "FGA",
+            "OREB",
+            "DREB",
+            "PF",
+            "MIN",
         ],
     },
     "WNBA": {
         "G": [
-            "PTS", "REB", "AST", "PRA", "PR", "RA", "PA", "FG3M",
-            "fantasy points prizepicks", "fantasy points underdog",
-            "TOV", "BLK", "STL", "BLST", "FG3A", "FTM", "FGM", "FGA",
-            "OREB", "DREB", "PF", "MIN",
+            "PTS",
+            "REB",
+            "AST",
+            "PRA",
+            "PR",
+            "RA",
+            "PA",
+            "FG3M",
+            "fantasy points prizepicks",
+            "fantasy points underdog",
+            "TOV",
+            "BLK",
+            "STL",
+            "BLST",
+            "FG3A",
+            "FTM",
+            "FGM",
+            "FGA",
+            "OREB",
+            "DREB",
+            "PF",
+            "MIN",
         ],
         "F": [
-            "PTS", "REB", "AST", "PRA", "PR", "RA", "PA", "FG3M",
-            "fantasy points prizepicks", "fantasy points underdog",
-            "TOV", "BLK", "STL", "BLST", "FG3A", "FTM", "FGM", "FGA",
-            "OREB", "DREB", "PF", "MIN",
+            "PTS",
+            "REB",
+            "AST",
+            "PRA",
+            "PR",
+            "RA",
+            "PA",
+            "FG3M",
+            "fantasy points prizepicks",
+            "fantasy points underdog",
+            "TOV",
+            "BLK",
+            "STL",
+            "BLST",
+            "FG3A",
+            "FTM",
+            "FGM",
+            "FGA",
+            "OREB",
+            "DREB",
+            "PF",
+            "MIN",
         ],
         "C": [
-            "PTS", "REB", "AST", "PRA", "PR", "RA", "PA", "FG3M",
-            "fantasy points prizepicks", "fantasy points underdog",
-            "TOV", "BLK", "STL", "BLST", "FG3A", "FTM", "FGM", "FGA",
-            "OREB", "DREB", "PF", "MIN",
+            "PTS",
+            "REB",
+            "AST",
+            "PRA",
+            "PR",
+            "RA",
+            "PA",
+            "FG3M",
+            "fantasy points prizepicks",
+            "fantasy points underdog",
+            "TOV",
+            "BLK",
+            "STL",
+            "BLST",
+            "FG3A",
+            "FTM",
+            "FGM",
+            "FGA",
+            "OREB",
+            "DREB",
+            "PF",
+            "MIN",
         ],
     },
     "MLB": {
@@ -203,28 +391,97 @@ _TRACKED_STATS: dict[str, dict] = {
 }
 
 
-def correlate(league: str, stat_data, force: bool = False) -> None:
-    """Calculate feature correlations with outcomes for feature engineering."""
-    print(f"Correlating {league}...")
+def _git_sha() -> str:
+    """Return the short git SHA of the current HEAD, or ``"unknown"`` if not in a repo."""
+    try:
+        return subprocess.check_output(
+            ["git", "rev-parse", "--short", "HEAD"], stderr=subprocess.DEVNULL, text=True
+        ).strip()
+    except (subprocess.SubprocessError, FileNotFoundError):
+        return "unknown"
+
+
+def _residualize_gamelog(
+    gamelog: pd.DataFrame,
+    player_col: str,
+    date_col: str,
+    stat_cols: list[str],
+) -> pd.DataFrame:
+    """Subtract each player's leak-free rolling-N-game mean from each stat column.
+
+    For each player, sort by date and replace ``stat[t]`` with
+    ``stat[t] - mean(stat[t-ROLLING_WINDOW_GAMES : t-1])``. The first few games
+    of each player's history (less than ``MIN_ROLLING_OBSERVATIONS`` priors)
+    yield NaN residuals, which are propagated through the correlation step
+    via pairwise-complete observation counting.
+
+    Args:
+        gamelog: Per-player per-game DataFrame.
+        player_col: Column name holding the player identifier.
+        date_col: Column name holding the game date (string or date).
+        stat_cols: Stat columns to residualize. Missing columns are skipped.
+
+    Returns:
+        A new DataFrame with the same shape and index where each ``stat_cols``
+        column has been replaced by its per-player residual.
+    """
+    present = [c for c in stat_cols if c in gamelog.columns]
+    if not present:
+        return gamelog.copy()
+
+    out = gamelog.copy()
+    order = out[[player_col, date_col]].astype({player_col: "string", date_col: "string"})
+    sort_idx = order.sort_values([player_col, date_col], kind="stable").index
+
+    sorted_view = out.loc[sort_idx, [player_col, *present]]
+    grouped = sorted_view.groupby(player_col, sort=False)
+    for stat in present:
+        prior_mean = grouped[stat].transform(
+            lambda s: (
+                s.shift(1)
+                .rolling(ROLLING_WINDOW_GAMES, min_periods=MIN_ROLLING_OBSERVATIONS)
+                .mean()
+            )
+        )
+        # Align back to the original index order.
+        out.loc[sort_idx, stat] = (sorted_view[stat] - prior_mean).to_numpy()
+    return out
+
+
+def _build_team_game_records(
+    league: str,
+    log,
+    latest_date: datetime,
+) -> list[dict]:
+    """Iterate the gamelog and emit one record per (team, game) with residualized stats.
+
+    Args:
+        league: League key into ``_TRACKED_STATS``.
+        log: ``Stats``-shaped instance with ``gamelog``, ``log_strings``,
+            ``profile_market``, and ``playerProfile``.
+        latest_date: Floor on game dates — earlier games are skipped.
+
+    Returns:
+        A list of dicts ready for ``pd.json_normalize``. Each dict has
+        ``TEAM``, ``DATE``, plus position-keyed stat values for the team and
+        ``_OPP_``-prefixed values for the opposing team.
+    """
     stats = _TRACKED_STATS[league]
-    log = stat_data
     log_str = log.log_strings
 
-    filepath = pkg_resources.files(data) / f"training_data/{league}_corr.csv"
-    if filepath.is_file() and not force:
-        matrix = pd.read_csv(filepath, index_col=0)
-        matrix.DATE = pd.to_datetime(matrix.DATE, format="mixed")
-        latest_date = matrix.DATE.max()
-        matrix = matrix.loc[datetime.today() - timedelta(days=300) <= matrix.DATE]
-    else:
-        matrix = pd.DataFrame()
-        latest_date = datetime.today() - timedelta(days=300)
+    flat_stats = sorted({s for col_lists in stats.values() for s in col_lists})
+    residualized = _residualize_gamelog(
+        log.gamelog,
+        log_str["player"],
+        log_str["date"],
+        flat_stats,
+    )
 
-    games = log.gamelog[log_str["game"]].unique()
-    game_data = []
+    games = residualized[log_str["game"]].unique()
+    records: list[dict] = []
 
     for gameId in tqdm(games):
-        game_df = log.gamelog.loc[log.gamelog[log_str["game"]] == gameId]
+        game_df = residualized.loc[residualized[log_str["game"]] == gameId]
         gameDate = datetime.fromisoformat(game_df.iloc[0][log_str["date"]])
         if gameDate < latest_date or len(game_df[log_str["team"]].unique()) != 2:
             continue
@@ -250,7 +507,10 @@ def correlate(league: str, stat_data, force: bool = False) -> None:
             usage.reset_index(inplace=True)
             game_df = game_df.merge(usage, how="left")
             game_df = game_df.loc[game_df[log_str["position"]].apply(lambda x: isinstance(x, str))]
-            game_df = game_df.fillna(0).infer_objects(copy=False)
+            # Usage columns are non-stat metadata; safe to fill NaN here.
+            for usage_col in (f"{log_str.get('usage')} short", f"{log_str.get('usage_sec')} short"):
+                if usage_col in game_df.columns:
+                    game_df[usage_col] = game_df[usage_col].fillna(0)
             ranks = (
                 game_df.sort_values(f"{log_str.get('usage_sec')} short", ascending=False)
                 .groupby([log_str["team"], log_str["position"]])
@@ -260,8 +520,8 @@ def correlate(league: str, stat_data, force: bool = False) -> None:
             game_df[log_str["position"]] = game_df[log_str["position"]] + ranks.astype(str)
             game_df.index = game_df[log_str["position"]]
 
-        homeStats = {}
-        awayStats = {}
+        homeStats: dict = {}
+        awayStats: dict = {}
         for position in stats:
             homeStats.update(
                 game_df.loc[
@@ -278,35 +538,200 @@ def correlate(league: str, stat_data, force: bool = False) -> None:
                 ].to_dict("index")
             )
 
-        game_data.append(
+        records.append(
             {"TEAM": home_team}
             | {"DATE": gameDate.date()}
             | homeStats
             | {"_OPP_" + k: v for k, v in awayStats.items()}
         )
-        game_data.append(
+        records.append(
             {"TEAM": away_team}
             | {"DATE": gameDate.date()}
             | awayStats
             | {"_OPP_" + k: v for k, v in homeStats.items()}
         )
+    return records
 
-    matrix = pd.concat([matrix, pd.json_normalize(game_data)], ignore_index=True)
-    matrix.to_csv(filepath)
 
-    big_c = {}
-    matrix.drop(columns="DATE", inplace=True)
-    matrix.fillna(0, inplace=True)
-    for team in matrix.TEAM.unique():
-        team_matrix = matrix.loc[team == matrix.TEAM].drop(columns="TEAM")
-        team_matrix = team_matrix.loc[:, ((team_matrix == 0).mean() < 0.5)]
+def _shrink_correlations(
+    corr: pd.DataFrame,
+    overlap: pd.DataFrame,
+) -> pd.DataFrame:
+    """Pull pair correlations toward zero in proportion to the overlap deficit.
+
+    For pairs with at least ``MIN_OVERLAP_FOR_FULL_WEIGHT`` shared games, the
+    correlation is unchanged. Below that floor, the correlation is multiplied
+    by ``overlap / MIN_OVERLAP_FOR_FULL_WEIGHT`` (a credibility weight that
+    hits zero when no games overlap).
+
+    Args:
+        corr: Square pairwise correlation DataFrame.
+        overlap: Square pairwise overlap-count DataFrame, same shape and labels.
+
+    Returns:
+        Correlation DataFrame with shrinkage applied in place of zero-padding
+        for low-sample pairs.
+    """
+    weight = (overlap / MIN_OVERLAP_FOR_FULL_WEIGHT).clip(upper=1.0)
+    return corr * weight
+
+
+def _stratify_team_pairs(team_corr: pd.Series) -> tuple[pd.Series, pd.Series]:
+    """Split a team's stacked pair series into same-team and opposing series.
+
+    Args:
+        team_corr: Series indexed by ``(market_a, market_b)`` for one team's
+            pairs. Markets prefixed with ``_OPP_`` denote opponent stats.
+
+    Returns:
+        ``(same_team, opposing)`` where:
+            * ``same_team`` keeps pairs where neither marker has the ``_OPP_``
+              prefix; the opposite-side ``(_OPP_a, _OPP_b)`` pairs are dropped
+              because they are the same team's opponent's same-team
+              correlations and belong to ``same_team`` keyed under the
+              opponent's row, not this team's.
+            * ``opposing`` keeps pairs with exactly one ``_OPP_`` side,
+              normalized so the team's market is the first index level and
+              the opp's market (without the ``_OPP_`` prefix) is the second.
+    """
+    is_opp_a = team_corr.index.get_level_values(0).str.startswith("_OPP_")
+    is_opp_b = team_corr.index.get_level_values(1).str.startswith("_OPP_")
+
+    same_mask = ~is_opp_a & ~is_opp_b
+    cross_mask = is_opp_a ^ is_opp_b
+
+    same = team_corr[same_mask]
+
+    cross = team_corr[cross_mask].copy()
+    cross_idx_a = cross.index.get_level_values(0).to_numpy()
+    cross_idx_b = cross.index.get_level_values(1).to_numpy()
+    cross_is_opp_a = is_opp_a[cross_mask]
+
+    team_market = np.where(cross_is_opp_a, cross_idx_b, cross_idx_a)
+    opp_market = np.where(cross_is_opp_a, cross_idx_a, cross_idx_b)
+    opp_market = np.array([s.removeprefix("_OPP_") for s in opp_market])
+
+    cross.index = pd.MultiIndex.from_arrays([team_market, opp_market], names=team_corr.index.names)
+    cross = cross[~cross.index.duplicated(keep="first")]
+    return same, cross
+
+
+def correlate(league: str, stat_data, force: bool = False) -> None:
+    """Build stratified per-league correlation matrices and metadata sidecar.
+
+    Process per league:
+
+    1. Load (or warm-start) the per-game record cache; trim to the
+       ``LOOKBACK_DAYS`` window.
+    2. Replace each stat with its per-player ``ROLLING_WINDOW_GAMES``-game
+       residual.
+    3. Build per-team matrices, computing pairwise Spearman correlations
+       and pairwise overlap counts.
+    4. Apply shrinkage proportional to the overlap deficit below
+       ``MIN_OVERLAP_FOR_FULL_WEIGHT``.
+    5. Stratify into same-team and opposing pair series; drop pairs below
+       ``CORR_MAGNITUDE_FLOOR``.
+    6. Write the two CSVs and the metadata JSON sidecar.
+
+    Args:
+        league: One of NFL/NBA/MLB/NHL/WNBA.
+        stat_data: A loaded ``Stats`` instance with ``gamelog``,
+            ``log_strings``, ``profile_market``, and ``playerProfile``.
+        force: When True, rebuilds the per-game record cache from scratch
+            instead of reusing the prior run's CSV.
+    """
+    print(f"Correlating {league}...")
+    log = stat_data
+
+    training_data_dir = pkg_resources.files(data) / "training_data"
+    training_data_dir.mkdir(parents=True, exist_ok=True)
+    raw_filepath = training_data_dir / f"{league}_corr.csv"
+    if raw_filepath.is_file() and not force:
+        matrix = pd.read_csv(raw_filepath, index_col=0)
+        if "DATE" in matrix.columns:
+            matrix["DATE"] = pd.to_datetime(matrix["DATE"], format="mixed")
+            latest_date = matrix["DATE"].max()
+            matrix = matrix.loc[datetime.today() - timedelta(days=LOOKBACK_DAYS) <= matrix["DATE"]]
+        else:
+            matrix = pd.DataFrame()
+            latest_date = datetime.today() - timedelta(days=LOOKBACK_DAYS)
+    else:
+        matrix = pd.DataFrame()
+        latest_date = datetime.today() - timedelta(days=LOOKBACK_DAYS)
+
+    new_records = _build_team_game_records(league, log, latest_date)
+    matrix = pd.concat([matrix, pd.json_normalize(new_records)], ignore_index=True)
+    matrix.to_csv(raw_filepath)
+
+    matrix_for_corr = matrix.drop(columns="DATE", errors="ignore")
+
+    same_team_blocks: dict = {}
+    opposing_blocks: dict = {}
+    per_team_obs: dict[str, int] = {}
+
+    teams_iter = matrix_for_corr["TEAM"].unique() if "TEAM" in matrix_for_corr.columns else []
+    for team in teams_iter:
+        team_matrix = matrix_for_corr.loc[team == matrix_for_corr["TEAM"]].drop(columns="TEAM")
+        # Drop columns that are entirely NaN (residuals never defined for any
+        # game) — they cannot contribute to a correlation estimate.
+        team_matrix = team_matrix.loc[:, team_matrix.notna().any(axis=0)]
+        if team_matrix.shape[1] < 2 or len(team_matrix) < 2:
+            continue
         team_matrix = team_matrix.reindex(sorted(team_matrix.columns), axis=1)
-        c_spearman = team_matrix.corr(
-            method="spearman", min_periods=int(len(team_matrix) * 0.75)
-        ).unstack()
-        c = 2 * np.sin(np.pi / 6 * c_spearman)
-        c = c.reindex(c.abs().sort_values(ascending=False).index).dropna()
-        c = c.loc[c.abs() > 0.05]
-        big_c.update({team: c})
 
-    pd.concat(big_c).to_csv(pkg_resources.files(data) / f"{league}_corr.csv")
+        per_team_obs[str(team)] = len(team_matrix)
+
+        # Pairwise overlap = number of games where both columns have a defined residual.
+        present = team_matrix.notna().astype(int)
+        overlap = present.T @ present
+
+        c_spearman = team_matrix.corr(method="spearman")
+        c_remap = 2 * np.sin(np.pi / 6 * c_spearman)
+        c_shrunk = _shrink_correlations(c_remap, overlap)
+
+        c_stack = c_shrunk.unstack().dropna()
+        c_stack = c_stack.loc[c_stack.abs() > CORR_MAGNITUDE_FLOOR]
+        c_stack = c_stack.reindex(c_stack.abs().sort_values(ascending=False).index)
+
+        same, opposing = _stratify_team_pairs(c_stack)
+        if not same.empty:
+            same_team_blocks[team] = same
+        if not opposing.empty:
+            opposing_blocks[team] = opposing
+
+    same_path = pkg_resources.files(data) / f"{league}_corr_same_team.csv"
+    opposing_path = pkg_resources.files(data) / f"{league}_corr_opposing.csv"
+    if same_team_blocks:
+        pd.concat(same_team_blocks).to_csv(same_path)
+    else:
+        pd.DataFrame(columns=["R"]).to_csv(same_path)
+    if opposing_blocks:
+        pd.concat(opposing_blocks).to_csv(opposing_path)
+    else:
+        pd.DataFrame(columns=["R"]).to_csv(opposing_path)
+
+    metadata_dir = pkg_resources.files(data) / "correlations"
+    metadata_dir.mkdir(parents=True, exist_ok=True)
+    metadata_path = metadata_dir / f"{league}_corr_metadata.json"
+    dates = (
+        pd.to_datetime(matrix.DATE)
+        if "DATE" in matrix.columns
+        else pd.Series(dtype="datetime64[ns]")
+    )
+    metadata = {
+        "league": league,
+        "generated_at": datetime.now(UTC).isoformat(timespec="seconds"),
+        "git_sha": _git_sha(),
+        "lookback_days": LOOKBACK_DAYS,
+        "rolling_window_games": ROLLING_WINDOW_GAMES,
+        "min_overlap_for_full_weight": MIN_OVERLAP_FOR_FULL_WEIGHT,
+        "corr_magnitude_floor": CORR_MAGNITUDE_FLOOR,
+        "date_range": {
+            "start": dates.min().date().isoformat() if not dates.empty else None,
+            "end": dates.max().date().isoformat() if not dates.empty else None,
+        },
+        "total_team_game_observations": len(matrix),
+        "per_team_observations": per_team_obs,
+    }
+    with open(metadata_path, "w") as fh:
+        json.dump(metadata, fh, indent=2)

--- a/tests/golden/fixtures/meditate_help.txt
+++ b/tests/golden/fixtures/meditate_help.txt
@@ -12,4 +12,8 @@ Options:
   --reset-markets TEXT            Comma-separated league:market pairs (or just
                                   market for active league) to clear from
                                   Filtered before training
+  --rebuild-correlations / --no-rebuild-correlations
+                                  Rebuild only the per-league correlation
+                                  matrices and exit; skip the per-market
+                                  training loop
   --help                          Show this message and exit.

--- a/tests/golden/test_correlate.py
+++ b/tests/golden/test_correlate.py
@@ -1,0 +1,209 @@
+"""Behavioral tests for ``training/correlate.py``.
+
+These exercise the residualization, sample-size shrinkage, metadata
+side-car, and the ``--rebuild-correlations`` CLI flag added in the
+methodology audit follow-up. They lean on synthetic gamelogs and a stub
+Stats class so they can run without league-API credentials.
+"""
+
+from __future__ import annotations
+
+import importlib.resources as pkg_resources
+import json
+from datetime import date, timedelta
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+from click.testing import CliRunner
+
+from sportstradamus import data
+from sportstradamus.training import correlate as correlate_module
+from sportstradamus.training.cli import meditate
+from sportstradamus.training.correlate import (
+    MIN_OVERLAP_FOR_FULL_WEIGHT,
+    ROLLING_WINDOW_GAMES,
+    _residualize_gamelog,
+    _shrink_correlations,
+    correlate,
+)
+
+
+def test_residualization_breaks_shared_trends() -> None:
+    """A trend shared by two players is removed; only their independent noise remains."""
+    rng = np.random.default_rng(0)
+    n_games = 60
+    dates = pd.date_range("2026-01-01", periods=n_games, freq="D").astype(str).tolist()
+    trend = np.linspace(0.0, 50.0, n_games)
+    a_noise = rng.standard_normal(n_games)
+    b_noise = rng.standard_normal(n_games)
+    a_values = trend + a_noise
+    b_values = trend + b_noise
+
+    raw_corr = float(np.corrcoef(a_values, b_values)[0, 1])
+    assert raw_corr > 0.9, f"setup invalid: raw correlation should be near 1, got {raw_corr}"
+
+    gamelog = pd.DataFrame(
+        {
+            "player": ["A"] * n_games + ["B"] * n_games,
+            "date": dates + dates,
+            "stat": np.concatenate([a_values, b_values]),
+        }
+    )
+
+    out = _residualize_gamelog(gamelog, "player", "date", ["stat"])
+    a_resid = out.loc[out.player == "A", "stat"].to_numpy()
+    b_resid = out.loc[out.player == "B", "stat"].to_numpy()
+    valid = ~np.isnan(a_resid) & ~np.isnan(b_resid)
+    assert valid.sum() >= n_games - ROLLING_WINDOW_GAMES, "too many residuals are NaN"
+
+    resid_corr = float(np.corrcoef(a_resid[valid], b_resid[valid])[0, 1])
+    assert abs(resid_corr) < 0.4, (
+        f"residual correlation should be much smaller than raw ({raw_corr:.2f}), got {resid_corr:.2f}"
+    )
+
+
+def test_low_overlap_pairs_shrink_toward_zero() -> None:
+    """Pairs with few shared games get shrunk; pairs with full overlap pass through."""
+    raw = 0.6
+    corr = pd.DataFrame(
+        [[1.0, raw, raw], [raw, 1.0, raw], [raw, raw, 1.0]],
+        index=["a", "b", "c"],
+        columns=["a", "b", "c"],
+    )
+    overlap = pd.DataFrame(
+        [
+            [100, 5, 100],
+            [5, 100, 100],
+            [100, 100, 100],
+        ],
+        index=["a", "b", "c"],
+        columns=["a", "b", "c"],
+    )
+    shrunk = _shrink_correlations(corr, overlap)
+
+    full_overlap = shrunk.loc["a", "c"]
+    low_overlap = shrunk.loc["a", "b"]
+
+    assert full_overlap == pytest.approx(raw, abs=1e-9)
+    assert abs(low_overlap) < abs(full_overlap), "low-overlap pair should be closer to zero"
+    expected_low = raw * (5 / MIN_OVERLAP_FOR_FULL_WEIGHT)
+    assert low_overlap == pytest.approx(expected_low, abs=1e-9)
+
+
+class _StubStats:
+    """Minimal Stats-shaped object that ``correlate`` can iterate over.
+
+    The gamelog is empty — enough to walk every code path and emit the
+    metadata sidecar without needing league-API access.
+    """
+
+    def __init__(self) -> None:
+        self.season_start = date(2026, 1, 1)
+        self.gamelog = pd.DataFrame(
+            columns=[
+                "GAME_ID",
+                "GAME_DATE",
+                "PLAYER_NAME",
+                "TEAM_ABBREVIATION",
+                "OPP",
+                "HOME",
+                "POS",
+                "MIN",
+                "USG_PCT",
+            ]
+        )
+        self.log_strings = {
+            "game": "GAME_ID",
+            "date": "GAME_DATE",
+            "player": "PLAYER_NAME",
+            "team": "TEAM_ABBREVIATION",
+            "opponent": "OPP",
+            "home": "HOME",
+            "position": "POS",
+            "usage": "MIN",
+            "usage_sec": "USG_PCT",
+        }
+        self.playerProfile = pd.DataFrame()
+
+    def load(self) -> None:
+        pass
+
+    def update(self) -> None:
+        pass
+
+    def update_player_comps(self) -> None:
+        pass
+
+    def profile_market(self, *_args, **_kwargs) -> None:
+        pass
+
+
+def _models_snapshot() -> dict[str, float]:
+    models_dir = pkg_resources.files(data) / "models"
+    if not Path(str(models_dir)).is_dir():
+        return {}
+    return {f.name: f.stat().st_mtime for f in Path(str(models_dir)).iterdir() if f.is_file()}
+
+
+def test_metadata_written_with_required_keys(tmp_path) -> None:
+    """correlate() emits the metadata side-car with the documented keys."""
+    stub = _StubStats()
+    metadata_path = pkg_resources.files(data) / "correlations" / "NBA_corr_metadata.json"
+
+    correlate("NBA", stub, force=True)
+
+    assert Path(str(metadata_path)).is_file(), "metadata side-car missing"
+    metadata = json.loads(Path(str(metadata_path)).read_text())
+
+    required = {
+        "league",
+        "generated_at",
+        "git_sha",
+        "lookback_days",
+        "rolling_window_games",
+        "min_overlap_for_full_weight",
+        "corr_magnitude_floor",
+        "date_range",
+        "total_team_game_observations",
+        "per_team_observations",
+    }
+    missing = required - set(metadata)
+    assert not missing, f"metadata missing keys: {missing}"
+    assert metadata["league"] == "NBA"
+    assert isinstance(metadata["per_team_observations"], dict)
+
+
+def test_rebuild_correlations_does_not_touch_models(monkeypatch) -> None:
+    """``--rebuild-correlations`` runs the correlation step only — no model files written."""
+    before = _models_snapshot()
+
+    calls: list[tuple[str, bool]] = []
+
+    def fake_correlate(league: str, stat_data, force: bool = False) -> None:
+        calls.append((league, force))
+
+    monkeypatch.setattr("sportstradamus.training.cli.StatsNBA", _StubStats)
+    monkeypatch.setattr("sportstradamus.training.cli.StatsNFL", _StubStats)
+    monkeypatch.setattr("sportstradamus.training.cli.StatsWNBA", _StubStats)
+    monkeypatch.setattr("sportstradamus.training.cli.correlate", fake_correlate)
+
+    sentinel = "training pipeline must not run when --rebuild-correlations is set"
+
+    def fail_train_market(*_args, **_kwargs):
+        raise AssertionError(sentinel)
+
+    monkeypatch.setattr("sportstradamus.training.cli.train_market", fail_train_market)
+
+    runner = CliRunner()
+    result = runner.invoke(meditate, ["--rebuild-correlations", "--league", "NBA"])
+
+    assert result.exit_code == 0, f"meditate exited {result.exit_code}: {result.output}"
+    assert calls == [("NBA", False)], f"expected single NBA correlate call, got {calls}"
+    assert _models_snapshot() == before, "model files were modified during --rebuild-correlations"
+
+
+# Make sure the module reference stays imported (ruff F401 guard).
+_ = correlate_module
+_ = timedelta


### PR DESCRIPTION
## Summary

Implements the methodology fixes called out in `docs/CORRELATE_AUDIT.md`. Branched off `claude/audit-correlate-methodology-ngi1x`.

### Methodology changes (`training/correlate.py`)

- **Residualization.** Each per-game stat is now replaced by `value - mean(prior ROLLING_WINDOW_GAMES games)` per player before correlations are computed. Default `ROLLING_WINDOW_GAMES = 8`. The shift-then-rolling formulation is leak-free; the first `MIN_ROLLING_OBSERVATIONS = 3` games of each player produce NaN residuals that propagate as missing observations into the pairwise correlation, not as zeros.
- **Sample-size-aware shrinkage.** The previous hard `min_periods=int(0.75 * n_team_rows)` cutoff (which silently dropped low-overlap pairs) is replaced by a credibility-weighted shrinkage: `corr_shrunk = corr * min(1, overlap / MIN_OVERLAP_FOR_FULL_WEIGHT)` with `MIN_OVERLAP_FOR_FULL_WEIGHT = 30`. Pairs with 30+ shared games keep their estimate verbatim; below 30 they're shrunk linearly toward zero.
- **Stratified outputs.** Replaced the single `data/{LEAGUE}_corr.csv` with two files: `data/{LEAGUE}_corr_same_team.csv` (within-team pairs, raw market keys) and `data/{LEAGUE}_corr_opposing.csv` (cross-team pairs, both sides un-prefixed since the file structure encodes the relationship). The `_OPP_` string-matching that the prediction code relied on is now reconstructed inside `_build_game_corr_map` so downstream lookup logic is unchanged.
- **Metadata side-car.** `data/correlations/{LEAGUE}_corr_metadata.json` carries `league`, `generated_at` (UTC), `git_sha`, the four configuration constants, the date range, total observations, and per-team observation counts.
- **Magic numbers eliminated.** `LOOKBACK_DAYS = 300`, `ROLLING_WINDOW_GAMES = 8`, `MIN_ROLLING_OBSERVATIONS = 3`, `MIN_OVERLAP_FOR_FULL_WEIGHT = 30`, `CORR_MAGNITUDE_FLOOR = 0.05` are module-level constants per STYLE_GUIDE §8.

### CLI (`training/cli.py`)

- New `--rebuild-correlations` flag runs only the per-league correlation step and exits, skipping the per-market training loop and Archive initialization. Useful when the player pool changes (trades, injuries, season start) without needing a full retrain.

### Prediction (`prediction/correlation.py`)

- `find_correlation` now reads the two stratified CSVs and assembles the pair-keyed `c_map` via the new `_build_game_corr_map` helper. The signature and downstream lookup semantics are preserved.

### Audit findings that did NOT need a fix

- **Spearman + sin remap.** Methodology audit flagged it as the most recent meaningful change but did not call it out as wrong; left as-is.
- **Per-team granularity.** The audit notes there's no league-pooled or position-pair-pooled estimate. Out of scope; per-team is still the default unit of estimation.
- **Time-decay weighting.** Noted as absent. Not requested in the implementation brief; left as flat weights inside the lookback window.
- **Column-level zero-density filter.** The legacy `(team_matrix == 0).mean() < 0.5` filter was removed implicitly: with residuals (where zero is a meaningful value) we now drop only fully-NaN columns and rely on shrinkage for low-overlap pairs.

## Test plan

- [x] `tests/golden/test_correlate.py` — residualization removes shared trends, low-overlap shrinkage pulls toward zero, metadata side-car carries the right keys, `--rebuild-correlations` runs without touching `data/models/`.
- [x] `poetry run ruff check src/sportstradamus/training/ src/sportstradamus/prediction/ tests/golden/` — clean.
- [x] `poetry run pytest tests/golden/` — 23 passed, 3 skipped.
- [x] CLI snapshot regenerated for the new `--rebuild-correlations` flag.
- [x] End-to-end `meditate --rebuild-correlations --league NBA` produces `NBA_corr_same_team.csv`, `NBA_corr_opposing.csv`, and `correlations/NBA_corr_metadata.json` (validated against a stub Stats; sandbox lacks the real NBA data files).


---
_Generated by [Claude Code](https://claude.ai/code/session_01C8Bt8Rc45eZCbgpRePAFvX)_