### PR TITLE
scripts: empirical comparison of old vs new correlation methodology

### DIFF
--- a/scripts/test_correlation_predictive_power.py
+++ b/scripts/test_correlation_predictive_power.py
@@ -430,7 +430,7 @@ def _per_team_overlap(matrix: pd.DataFrame) -> dict[str, pd.DataFrame]:
 
 def run_synthetic(seed: int, n_games: int) -> None:
     rng = np.random.default_rng(seed)
-    click.echo("[1/2] Synthetic ground-truth experiment")
+    click.echo("[1/3] Synthetic latent-corr recovery experiment")
     click.echo(f"      seed={seed} n_games={n_games} n_teams={DEFAULT_N_TEAMS}")
     click.echo("      simulating gamelog with per-player AR(1) skill drift + 20% missing rows")
 
@@ -518,7 +518,235 @@ def _print_recovery_table(old: dict[str, float], new: dict[str, float]) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Experiment 2 — real gamelog holdout
+# Experiment 2 — beat-line conditional probability (production-relevant)
+# ---------------------------------------------------------------------------
+#
+# Production cares about a downstream conditional, not the latent stat
+# correlation in the abstract: if Player A beats their line in market X,
+# is Player B more likely to beat their line in market Y? The correlation
+# matrix gets multiplied into parlay EV in
+# ``prediction/correlation.py:389-402`` — positive value between two "Over"
+# legs raises joint probability, negative lowers it. So the right ground
+# truth is the empirical correlation of {beat-line indicator}, not the
+# Pearson correlation of the raw stat values.
+#
+# We approximate bookmaker line-setting with each player's leak-free rolling
+# 8-game mean (same window the production residualization uses). That makes
+# the test slightly favorable to residualization by construction — the line
+# is exactly what residualization subtracts — but it's also the most honest
+# proxy for what real lines do, so the comparison still tells us which
+# method's output best matches the conditional we actually consume.
+
+
+def _beat_line_team_matrix(
+    gamelog: pd.DataFrame,
+    stat_cols: list[str],
+) -> pd.DataFrame:
+    """Build per-team-per-game beat-line booleans (1 / 0 / NaN per stat).
+
+    For each (player, stat) we set the line equal to the player's
+    leak-free rolling-N-game mean — the same window used by
+    ``_residualize_gamelog``. ``hit[t] = 1`` if ``stat[t] > line[t]``,
+    ``0`` otherwise; ``NaN`` when there isn't enough history yet (so the
+    line is undefined and the player would not have a posted line in
+    real life either).
+
+    The empirical correlation of these per-team boolean columns IS the
+    quantity production cares about — it's the realized conditional
+    structure of "did A beat its line jointly with B beating its line".
+    """
+    line_df = _residualize_gamelog(gamelog, "player", "DATE", stat_cols)
+    hits = line_df.copy()
+    for stat in stat_cols:
+        if stat not in line_df.columns:
+            continue
+        # Residual = stat - rolling_line, so beat-line iff residual > 0.
+        # Residuals that are exactly 0 (continuous data: never) count as
+        # "not beat" same as the bookmaker convention.
+        hits[stat] = (line_df[stat] > 0).astype("float")
+        hits.loc[line_df[stat].isna(), stat] = np.nan
+    return _gamelog_to_team_matrix(hits, stat_cols)
+
+
+def _empirical_beat_line_corr(matrix: pd.DataFrame) -> dict[str, pd.DataFrame]:
+    """Per-team Pearson correlation of beat-line booleans across games.
+
+    Pearson on 0/1 indicators is the phi coefficient — exactly the binary
+    co-occurrence structure production wants the matrix to predict.
+    """
+    matrix = matrix.drop(columns="DATE", errors="ignore")
+    out: dict[str, pd.DataFrame] = {}
+    for team in matrix["TEAM"].unique():
+        team_matrix = matrix.loc[matrix["TEAM"] == team].drop(columns="TEAM")
+        team_matrix = team_matrix.loc[:, team_matrix.notna().any(axis=0)]
+        # Need at least 2 games and 2 stats with non-degenerate variance.
+        if team_matrix.shape[1] < 2 or len(team_matrix) < 2:
+            continue
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            out[team] = cast(pd.DataFrame, team_matrix.corr(method="pearson"))
+    return out
+
+
+def _score_against_beat_line(
+    estimate_per_team: dict[str, pd.DataFrame],
+    beat_line_per_team: dict[str, pd.DataFrame],
+) -> dict[str, float]:
+    """Compare each method's predicted pair correlations to beat-line truth.
+
+    We also bucket pairs by predicted-correlation magnitude and report the
+    mean realized beat-line correlation per bucket — this is the most
+    directly interpretable answer to the user's question. If the method's
+    output is meaningful, "high predicted" pairs should have higher mean
+    realized beat-line correlation than "low predicted" pairs.
+    """
+    pred: list[float] = []
+    actual: list[float] = []
+    sign_match = 0
+    sign_total = 0
+
+    for team, truth in beat_line_per_team.items():
+        est = estimate_per_team.get(team)
+        cols = list(truth.columns)
+        for i, a in enumerate(cols):
+            for b in cols[i + 1 :]:
+                t = float(truth.loc[a, b])
+                if pd.isna(t):
+                    continue
+                if est is not None and a in est.index and b in est.columns:
+                    p = float(est.loc[a, b])
+                else:
+                    p = 0.0
+                pred.append(p)
+                actual.append(t)
+                if abs(p) >= SIGN_AGREEMENT_MAG_FLOOR and abs(t) >= SIGN_AGREEMENT_MAG_FLOOR:
+                    sign_total += 1
+                    if np.sign(p) == np.sign(t):
+                        sign_match += 1
+
+    pa = np.array(pred)
+    aa = np.array(actual)
+    if len(pa) == 0:
+        return {"n_pairs": 0.0}
+
+    # Bucket realized lift by predicted-correlation magnitude. Buckets
+    # are: |pred| < 0.05 (background), 0.05-0.20 (weak), 0.20-0.40
+    # (moderate), > 0.40 (strong). For a method with predictive power,
+    # bucket means of |actual| should rise monotonically.
+    from itertools import pairwise
+
+    abs_pred = np.abs(pa)
+    bucket_edges = [0.0, 0.05, 0.20, 0.40, np.inf]
+    bucket_labels = ["bg(<.05)", "weak(.05-.20)", "mod(.20-.40)", "strong(>.40)"]
+    bucket_means = []
+    bucket_counts = []
+    for lo, hi in pairwise(bucket_edges):
+        mask = (abs_pred >= lo) & (abs_pred < hi)
+        if mask.any():
+            # Use signed actual but matched-direction: when predicted is
+            # positive we want actual positive; when negative, we want
+            # negative. Equivalent to: predicted * actual > 0 for "match".
+            signed_actual = np.where(pa[mask] >= 0, aa[mask], -aa[mask])
+            bucket_means.append(float(np.mean(signed_actual)))
+        else:
+            bucket_means.append(float("nan"))
+        bucket_counts.append(int(mask.sum()))
+
+    return {
+        "n_pairs": float(len(pa)),
+        "mae_vs_beat_line": float(np.mean(np.abs(pa - aa))),
+        "rho_pred_vs_actual": (
+            float(spearmanr(pa, aa).statistic) if len(pa) > 1 else float("nan")
+        ),
+        "sign_agreement": (sign_match / sign_total) if sign_total else float("nan"),
+        "n_sign_pairs": float(sign_total),
+        # Per-bucket mean of direction-matched realized beat-line correlation.
+        # Higher (positive) = predictions in this bucket really do correspond
+        # to legs that co-occur more often (or, for negative predictions, to
+        # legs that anti-correlate as predicted).
+        "bucket_labels": bucket_labels,
+        "bucket_means": bucket_means,
+        "bucket_counts": bucket_counts,
+    }
+
+
+def run_beat_line(seed: int, n_games: int) -> None:
+    """Score each method against the empirical beat-line correlation.
+
+    We reuse the synthetic gamelog generator from experiment 1 — same
+    seed, same data — so the only thing that changes is the ground-truth
+    target. Now we measure how well each method predicts the realized
+    pairwise beat-line correlation, which is what the parlay EV
+    multiplication consumes downstream.
+    """
+    rng = np.random.default_rng(seed)
+    click.echo("[2/3] Beat-line conditional-probability experiment")
+    click.echo(f"      seed={seed} n_games={n_games}")
+    click.echo("      ground truth = empirical Pearson corr of beat-line booleans per team")
+
+    gamelog, _truth_latent = _simulate_gamelog(DEFAULT_N_TEAMS, n_games, rng)
+    stat_cols = [c for c in gamelog.columns if c.startswith("P")]
+
+    raw_team_matrix = _gamelog_to_team_matrix(gamelog, stat_cols)
+    residualized_log = _residualize_gamelog(gamelog, "player", "DATE", stat_cols)
+    res_team_matrix = _gamelog_to_team_matrix(residualized_log, stat_cols)
+    beat_line_matrix = _beat_line_team_matrix(gamelog, stat_cols)
+
+    beat_line_truth = _empirical_beat_line_corr(beat_line_matrix)
+
+    variants = [
+        ("OLD", build_corr_old(raw_team_matrix)),
+        ("PAIRWISE_ONLY", build_corr_pairwise_only(raw_team_matrix)),
+        ("RESIDUAL_ONLY", build_corr_residual_only(res_team_matrix)),
+        ("NEW", build_corr_new(res_team_matrix)),
+    ]
+    metrics_per_variant: dict[str, dict] = {}
+    for name, stacked in variants:
+        per_team = _stacked_to_per_team(stacked)
+        metrics_per_variant[name] = _score_against_beat_line(per_team, beat_line_truth)
+
+    _print_beat_line_table(metrics_per_variant)
+
+
+def _print_beat_line_table(metrics_per_variant: dict[str, dict]) -> None:
+    rows = [
+        ("pairs scored", "n_pairs", "{:>14.0f}"),
+        ("MAE vs beat-line corr (lower better)", "mae_vs_beat_line", "{:>14.4f}"),
+        ("Spearman rho pred vs actual (higher better)", "rho_pred_vs_actual", "{:>14.4f}"),
+        ("sign agreement (higher better)", "sign_agreement", "{:>14.4f}"),
+        ("n sign-comparable pairs", "n_sign_pairs", "{:>14.0f}"),
+    ]
+    names = list(metrics_per_variant.keys())
+    click.echo("")
+    click.echo("      " + f"{'metric':<46}" + "  " + "  ".join(f"{n:>14}" for n in names))
+    click.echo("      " + "-" * 46 + "  " + "  ".join("-" * 14 for _ in names))
+    for label, key, fmt in rows:
+        cells = []
+        for n in names:
+            v = metrics_per_variant[n].get(key, float("nan"))
+            cells.append(fmt.format(v))
+        click.echo(f"      {label:<46}  " + "  ".join(cells))
+
+    # Bucketed realized lift: shows whether higher predicted correlation
+    # actually corresponds to higher realized beat-line co-occurrence.
+    click.echo("")
+    click.echo("      direction-matched realized beat-line corr by predicted-magnitude bucket")
+    click.echo("      (positive = pred direction agrees with realized direction; higher = better)")
+    bucket_labels = metrics_per_variant[names[0]]["bucket_labels"]
+    header = "      " + f"{'bucket':<14}" + "  " + "  ".join(f"{n:>14}" for n in names)
+    click.echo(header)
+    click.echo("      " + "-" * 14 + "  " + "  ".join("-" * 14 for _ in names))
+    for i, label in enumerate(bucket_labels):
+        cells = []
+        for n in names:
+            mean = metrics_per_variant[n]["bucket_means"][i]
+            count = metrics_per_variant[n]["bucket_counts"][i]
+            cells.append(f"{mean:>+8.4f} (n={count:>3d})")
+        click.echo(f"      {label:<14}  " + "  ".join(cells))
+
+
+# ---------------------------------------------------------------------------
+# Experiment 3 — real gamelog holdout
 # ---------------------------------------------------------------------------
 
 
@@ -621,7 +849,7 @@ def _holdout_metrics(
 
 
 def run_real(league: str) -> bool:
-    click.echo(f"[2/2] Real-data holdout for league={league}")
+    click.echo(f"[3/3] Real-data holdout for league={league}")
     stats = _try_load_stats(league)
     if stats is None:
         return False
@@ -728,12 +956,23 @@ def _print_holdout_table(old: dict[str, float], new: dict[str, float]) -> None:
 @click.option("--seed", type=int, default=DEFAULT_SEED)
 @click.option("--n-games", type=int, default=DEFAULT_N_GAMES)
 @click.option("--skip-real", is_flag=True, help="Skip the real-data holdout experiment.")
-@click.option("--skip-synthetic", is_flag=True, help="Skip the synthetic experiment.")
-def main(league: str, seed: int, n_games: int, skip_real: bool, skip_synthetic: bool) -> None:
+@click.option("--skip-synthetic", is_flag=True, help="Skip both synthetic experiments.")
+@click.option("--skip-beat-line", is_flag=True, help="Skip the beat-line conditional experiment.")
+def main(
+    league: str,
+    seed: int,
+    n_games: int,
+    skip_real: bool,
+    skip_synthetic: bool,
+    skip_beat_line: bool,
+) -> None:
     click.echo("Correlation methodology comparison: OLD vs NEW")
     click.echo("=" * 72)
     if not skip_synthetic:
         run_synthetic(seed=seed, n_games=n_games)
+    if not skip_synthetic and not skip_beat_line:
+        click.echo("")
+        run_beat_line(seed=seed, n_games=n_games)
     if not skip_real:
         click.echo("")
         ran = run_real(league=league)

--- a/scripts/test_correlation_predictive_power.py
+++ b/scripts/test_correlation_predictive_power.py
@@ -1,0 +1,683 @@
+"""Empirically test whether the new correlation methodology beats the old.
+
+Two experiments:
+
+1. Synthetic ground truth (always runs). Generates per-game stats from a known
+   correlation structure plus per-player skill drift and missing-game noise,
+   then scores how well each method recovers the truth.
+2. Real-data time-based holdout (runs only if a Stats gamelog is available
+   locally). Splits the user's gamelog 70/30 by date, builds correlations on
+   train, scores against the empirical correlation on test.
+
+Usage:
+
+    poetry run python scripts/test_correlation_predictive_power.py --skip-real
+    poetry run python scripts/test_correlation_predictive_power.py --league NBA
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import warnings
+from pathlib import Path
+from typing import cast
+
+import click
+import numpy as np
+import pandas as pd
+from scipy.stats import spearmanr
+
+
+def _load_correlate_module():
+    """Load src/sportstradamus/training/correlate.py without importing the package.
+
+    The package's __init__ chain pulls in optional ML deps and reads
+    credentials at import time, which we don't have in this test env.
+    correlate.py itself only depends on numpy/pandas/tqdm and a tiny
+    ``from sportstradamus import data`` (a namespace package, no code),
+    so we load it directly by file path.
+    """
+    repo_root = Path(__file__).resolve().parent.parent
+    correlate_path = repo_root / "src/sportstradamus/training/correlate.py"
+
+    # Stub the package paths the module imports so ``from sportstradamus
+    # import data`` resolves without triggering the real package init.
+    src_root = repo_root / "src"
+    if str(src_root) not in sys.path:
+        sys.path.insert(0, str(src_root))
+    for pkg_name, pkg_path in [
+        ("sportstradamus", src_root / "sportstradamus"),
+        ("sportstradamus.data", src_root / "sportstradamus" / "data"),
+    ]:
+        if pkg_name in sys.modules:
+            continue
+        spec = importlib.util.spec_from_file_location(
+            pkg_name, pkg_path / "__init__.py", submodule_search_locations=[str(pkg_path)]
+        )
+        # No __init__.py for some — fall back to a bare namespace module.
+        if spec is None or spec.loader is None:
+            mod = importlib.util.module_from_spec(
+                importlib.util.spec_from_loader(pkg_name, loader=None)
+            )
+            mod.__path__ = [str(pkg_path)]
+            sys.modules[pkg_name] = mod
+        else:
+            mod = importlib.util.module_from_spec(spec)
+            sys.modules[pkg_name] = mod
+            try:
+                spec.loader.exec_module(mod)
+            except Exception:
+                # Some sub-packages have heavy __init__ — fall back to a
+                # bare namespace so submodule imports still work.
+                mod = importlib.util.module_from_spec(
+                    importlib.util.spec_from_loader(pkg_name, loader=None)
+                )
+                mod.__path__ = [str(pkg_path)]
+                sys.modules[pkg_name] = mod
+
+    spec = importlib.util.spec_from_file_location(
+        "sportstradamus.training.correlate", correlate_path
+    )
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["sportstradamus.training.correlate"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_correlate = _load_correlate_module()
+CORR_MAGNITUDE_FLOOR = _correlate.CORR_MAGNITUDE_FLOOR
+MIN_OVERLAP_FOR_FULL_WEIGHT = _correlate.MIN_OVERLAP_FOR_FULL_WEIGHT
+_residualize_gamelog = _correlate._residualize_gamelog
+_shrink_correlations = _correlate._shrink_correlations
+
+# Synthetic experiment defaults — small enough to finish in seconds, large
+# enough that low-overlap pairs actually appear after we drop ~20% of rows.
+DEFAULT_SEED: int = 42
+DEFAULT_N_GAMES: int = 200
+DEFAULT_N_TEAMS: int = 20
+N_PLAYERS_PER_TEAM: int = 6
+N_STATS_PER_PLAYER: int = 2
+PLAYER_DROP_PROB: float = 0.20
+SKILL_DRIFT_AR1_PHI: float = 0.95
+SKILL_DRIFT_INNOVATION_SD: float = 0.4
+
+# How we judge "the methods agreed with the holdout" in experiment 2 — we
+# only count pairs with non-trivial magnitude on both sides.
+SIGN_AGREEMENT_MAG_FLOOR: float = 0.05
+
+# Fraction of games used for the train slice in the real-data experiment.
+TRAIN_FRACTION: float = 0.70
+
+
+# ---------------------------------------------------------------------------
+# Methodology implementations (pure: matrix -> stacked Series)
+# ---------------------------------------------------------------------------
+
+
+def build_corr_old(matrix: pd.DataFrame) -> pd.Series:
+    """Replicate the legacy logic from ``src/deprecated/correlation.py:442-457``.
+
+    Drops the DATE column, fills NaN with 0, drops columns with >=50% zeros
+    per team, runs Spearman with a 75% min_periods cutoff, applies the
+    Fisher-style remap, and keeps pairs above a tiny magnitude floor. No
+    residualization, no shrinkage.
+    """
+    matrix = matrix.drop(columns="DATE", errors="ignore").copy()
+    matrix = matrix.fillna(0)
+    blocks: dict = {}
+    for team in matrix["TEAM"].unique():
+        team_matrix = matrix.loc[matrix["TEAM"] == team].drop(columns="TEAM")
+        team_matrix = team_matrix.loc[:, ((team_matrix == 0).mean() < 0.5)]
+        if team_matrix.shape[1] < 2 or len(team_matrix) < 2:
+            continue
+        team_matrix = team_matrix.reindex(sorted(team_matrix.columns), axis=1)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            c_spearman = team_matrix.corr(
+                method="spearman",
+                min_periods=int(len(team_matrix) * 0.75),
+            )
+        c = 2 * np.sin(np.pi / 6 * c_spearman)
+        c_stack = c.unstack().dropna()
+        c_stack = c_stack.loc[c_stack.abs() > 0.001]
+        if not c_stack.empty:
+            blocks[team] = c_stack
+    if not blocks:
+        return pd.Series([], dtype=float, name="R")
+    out = pd.concat(blocks)
+    out.name = "R"
+    return out
+
+
+def build_corr_new(matrix_residualized: pd.DataFrame) -> pd.Series:
+    """Run the new methodology on a pre-residualized team-game matrix.
+
+    Residualization happens upstream because it operates on the per-player
+    gamelog (one row per player-game), not the per-team matrix. Per team:
+    Spearman on residuals (pairwise-complete), Fisher remap, sample-size
+    shrinkage toward zero below MIN_OVERLAP_FOR_FULL_WEIGHT, magnitude
+    floor.
+    """
+    matrix = matrix_residualized.drop(columns="DATE", errors="ignore").copy()
+    blocks: dict = {}
+    for team in matrix["TEAM"].unique():
+        team_matrix = matrix.loc[matrix["TEAM"] == team].drop(columns="TEAM")
+        team_matrix = team_matrix.loc[:, team_matrix.notna().any(axis=0)]
+        if team_matrix.shape[1] < 2 or len(team_matrix) < 2:
+            continue
+        team_matrix = team_matrix.reindex(sorted(team_matrix.columns), axis=1)
+        present = team_matrix.notna().astype(int)
+        overlap = present.T @ present
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            c_spearman = team_matrix.corr(method="spearman")
+        c_remap = 2 * np.sin(np.pi / 6 * c_spearman)
+        c_shrunk = _shrink_correlations(c_remap, overlap)
+        c_stack = c_shrunk.unstack().dropna()
+        c_stack = c_stack.loc[c_stack.abs() > CORR_MAGNITUDE_FLOOR]
+        if not c_stack.empty:
+            blocks[team] = c_stack
+    if not blocks:
+        return pd.Series([], dtype=float, name="R")
+    out = pd.concat(blocks)
+    out.name = "R"
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Experiment 1 — synthetic ground truth
+# ---------------------------------------------------------------------------
+
+
+def _make_true_corr(n_stats: int, rng: np.random.Generator) -> np.ndarray:
+    """Build a positive-definite ground-truth correlation matrix.
+
+    Uses a low-rank-plus-diagonal construction so we get a realistic mix of
+    near-zero and ±0.3-0.6 entries instead of a uniform random sprinkle.
+    """
+    rank = max(2, n_stats // 4)
+    loadings = rng.normal(scale=0.6, size=(n_stats, rank))
+    cov = loadings @ loadings.T + np.eye(n_stats) * 0.5
+    sd = np.sqrt(np.diag(cov))
+    return cov / np.outer(sd, sd)
+
+
+def _simulate_gamelog(
+    n_teams: int,
+    n_games: int,
+    rng: np.random.Generator,
+) -> tuple[pd.DataFrame, dict[str, np.ndarray]]:
+    """Simulate a per-player gamelog with a known per-team correlation matrix.
+
+    Each team has its own (identical-shape) latent stat correlation. Each
+    game we draw a team-level multivariate-normal vector, then assign the
+    components to player-stat slots. Per-player AR(1) skill drift is added
+    on top — the OLD method picks this up as spurious cross-stat correlation
+    on the same player; residualization should remove it.
+
+    Returns:
+        (gamelog_df, true_corr_per_team) where gamelog has columns
+        ``player``, ``team``, ``DATE``, ``gameId``, plus one column per
+        stat slot and ``true_corr_per_team`` maps team -> matrix indexed by
+        the stat column names.
+    """
+    n_stat_slots = N_PLAYERS_PER_TEAM * N_STATS_PER_PLAYER
+
+    teams = [f"T{i:02d}" for i in range(n_teams)]
+    stat_cols = [
+        f"P{p}_S{s}" for p in range(N_PLAYERS_PER_TEAM) for s in range(N_STATS_PER_PLAYER)
+    ]
+
+    true_per_team: dict[str, np.ndarray] = {}
+    for team in teams:
+        true_per_team[team] = _make_true_corr(n_stat_slots, rng)
+
+    # Fixed home/away rotation — every team plays once per "game day".
+    # We pair teams across the league each day so each team logs n_games rows.
+    perm_order = np.array(teams)
+    skills = np.zeros((n_teams, N_PLAYERS_PER_TEAM))
+
+    rows: list[dict] = []
+    for game_idx in range(n_games):
+        # AR(1) drift on per-player skill (shared across that player's stats).
+        skills = (
+            SKILL_DRIFT_AR1_PHI * skills
+            + SKILL_DRIFT_INNOVATION_SD
+            * rng.standard_normal(size=(n_teams, N_PLAYERS_PER_TEAM))
+        )
+        rng.shuffle(perm_order)
+        for pair_idx in range(0, n_teams, 2):
+            home, away = perm_order[pair_idx], perm_order[pair_idx + 1]
+            game_id = f"G{game_idx:04d}_{home}_{away}"
+            for team in (home, away):
+                team_i = teams.index(team)
+                draw = rng.multivariate_normal(
+                    mean=np.zeros(n_stat_slots),
+                    cov=true_per_team[team],
+                )
+                # Add per-player drift to that player's stat slots.
+                drift = np.repeat(skills[team_i], N_STATS_PER_PLAYER)
+                draw = draw + drift
+                for p in range(N_PLAYERS_PER_TEAM):
+                    if rng.random() < PLAYER_DROP_PROB:
+                        continue  # player out for this game
+                    row = {
+                        "player": f"{team}_P{p}",
+                        "team": team,
+                        "DATE": pd.Timestamp("2024-01-01") + pd.Timedelta(days=game_idx),
+                        "gameId": game_id,
+                    }
+                    for s in range(N_STATS_PER_PLAYER):
+                        slot = p * N_STATS_PER_PLAYER + s
+                        row[f"P{p}_S{s}"] = draw[slot]
+                    rows.append(row)
+    gamelog = pd.DataFrame(rows)
+    # Map each per-team latent matrix into a labeled DataFrame for scoring.
+    labeled = {team: pd.DataFrame(true_per_team[team], index=stat_cols, columns=stat_cols)
+               for team in teams}
+    return gamelog, labeled
+
+
+def _gamelog_to_team_matrix(gamelog: pd.DataFrame, stat_cols: list[str]) -> pd.DataFrame:
+    """Pivot a per-player gamelog into per-team-per-game rows.
+
+    For each (gameId, team), the stats from each player slot become columns
+    keyed ``{player_slot}.{stat}``. We don't include opponent (_OPP_*)
+    columns here — the synthetic experiment only judges within-team
+    correlations, which is the comparison we care about.
+    """
+    rows = []
+    grouped = gamelog.groupby(["gameId", "team"])
+    for (game_id, team), g in grouped:
+        # Map player to their per-team slot index P0..P{N-1} from the
+        # player name suffix (synthetic players are named T01_P3 etc.).
+        row = {"TEAM": team, "DATE": g["DATE"].iloc[0]}
+        for _, prow in g.iterrows():
+            slot = prow["player"].split("_")[1]  # "P3"
+            for stat in stat_cols:
+                if not stat.startswith(slot + "_"):
+                    continue
+                row[stat] = prow[stat]
+        rows.append(row)
+    return pd.DataFrame(rows)
+
+
+def _stacked_to_per_team(stacked: pd.Series) -> dict[str, pd.DataFrame]:
+    """Inflate a stacked (team, a, b) -> R series back into per-team matrices."""
+    out: dict[str, pd.DataFrame] = {}
+    if stacked.empty:
+        return out
+    for team, sub in stacked.groupby(level=0):
+        s = sub.droplevel(0)
+        cols = sorted({*s.index.get_level_values(0), *s.index.get_level_values(1)})
+        m = pd.DataFrame(0.0, index=cols, columns=cols)
+        for (a, b), r in s.items():
+            m.loc[a, b] = r
+        out[team] = m
+    return out
+
+
+def _score_recovery(
+    estimate_per_team: dict[str, pd.DataFrame],
+    truth_per_team: dict[str, pd.DataFrame],
+    overlap_per_team: dict[str, pd.DataFrame] | None = None,
+) -> dict[str, float]:
+    """Compute MAE / Spearman / subset MAE between estimate and truth.
+
+    We unroll the upper triangle (i < j) to avoid double-counting and skip
+    diagonal self-correlations.
+    """
+    all_pred: list[float] = []
+    all_true: list[float] = []
+    low_overlap_pred: list[float] = []
+    low_overlap_true: list[float] = []
+    confounded_pred: list[float] = []
+    confounded_true: list[float] = []
+
+    for team, truth in truth_per_team.items():
+        est = estimate_per_team.get(team)
+        cols = list(truth.columns)
+        for i, a in enumerate(cols):
+            for b in cols[i + 1 :]:
+                t = float(truth.loc[a, b])
+                # Estimate may have dropped column or pair (sparse output).
+                if est is not None and a in est.index and b in est.columns:
+                    p = float(est.loc[a, b])
+                else:
+                    p = 0.0
+                all_pred.append(p)
+                all_true.append(t)
+                # Confounded == same player, different stats. Truth here is
+                # whatever the latent matrix said (often near zero), and the
+                # AR(1) drift inflates the OLD estimator's value.
+                if a.split("_")[0] == b.split("_")[0]:
+                    confounded_pred.append(p)
+                    confounded_true.append(t)
+                if overlap_per_team is not None:
+                    o = overlap_per_team.get(team)
+                    if (
+                        o is not None
+                        and a in o.index
+                        and b in o.columns
+                        and o.loc[a, b] < MIN_OVERLAP_FOR_FULL_WEIGHT
+                    ):
+                        low_overlap_pred.append(p)
+                        low_overlap_true.append(t)
+
+    pred_arr = np.array(all_pred)
+    true_arr = np.array(all_true)
+    metrics = {
+        "n_pairs": float(len(pred_arr)),
+        "mae": float(np.mean(np.abs(pred_arr - true_arr))) if len(pred_arr) else float("nan"),
+        "rmse": float(np.sqrt(np.mean((pred_arr - true_arr) ** 2))) if len(pred_arr) else float("nan"),
+        "spearman_rho": (
+            float(spearmanr(pred_arr, true_arr).statistic) if len(pred_arr) > 1 else float("nan")
+        ),
+        "confounded_mae": (
+            float(np.mean(np.abs(np.array(confounded_pred) - np.array(confounded_true))))
+            if confounded_pred
+            else float("nan")
+        ),
+        "n_confounded": float(len(confounded_pred)),
+        "low_overlap_mae": (
+            float(np.mean(np.abs(np.array(low_overlap_pred) - np.array(low_overlap_true))))
+            if low_overlap_pred
+            else float("nan")
+        ),
+        "n_low_overlap": float(len(low_overlap_pred)),
+    }
+    return metrics
+
+
+def _per_team_overlap(matrix: pd.DataFrame) -> dict[str, pd.DataFrame]:
+    """Pair-overlap counts per team — used to mark "low-overlap" pairs."""
+    matrix = matrix.drop(columns="DATE", errors="ignore")
+    out: dict[str, pd.DataFrame] = {}
+    for team in matrix["TEAM"].unique():
+        team_matrix = matrix.loc[matrix["TEAM"] == team].drop(columns="TEAM")
+        present = team_matrix.notna().astype(int)
+        out[team] = present.T @ present
+    return out
+
+
+def run_synthetic(seed: int, n_games: int) -> None:
+    rng = np.random.default_rng(seed)
+    click.echo("[1/2] Synthetic ground-truth experiment")
+    click.echo(f"      seed={seed} n_games={n_games} n_teams={DEFAULT_N_TEAMS}")
+    click.echo("      simulating gamelog with per-player AR(1) skill drift + 20% missing rows")
+
+    gamelog, truth = _simulate_gamelog(DEFAULT_N_TEAMS, n_games, rng)
+    stat_cols = [c for c in gamelog.columns if c.startswith("P")]
+
+    raw_team_matrix = _gamelog_to_team_matrix(gamelog, stat_cols)
+
+    # Residualize the per-player gamelog, then pivot — this is what the
+    # production new code does internally.
+    residualized_log = _residualize_gamelog(gamelog, "player", "DATE", stat_cols)
+    res_team_matrix = _gamelog_to_team_matrix(residualized_log, stat_cols)
+
+    overlap_new = _per_team_overlap(res_team_matrix)
+    overlap_old = _per_team_overlap(raw_team_matrix)
+
+    old_stacked = build_corr_old(raw_team_matrix)
+    new_stacked = build_corr_new(res_team_matrix)
+
+    old_per_team = _stacked_to_per_team(old_stacked)
+    new_per_team = _stacked_to_per_team(new_stacked)
+
+    metrics_old = _score_recovery(old_per_team, truth, overlap_old)
+    metrics_new = _score_recovery(new_per_team, truth, overlap_new)
+
+    _print_recovery_table(metrics_old, metrics_new)
+
+
+def _print_recovery_table(old: dict[str, float], new: dict[str, float]) -> None:
+    rows = [
+        ("pairs scored", "n_pairs", "{:>10.0f}"),
+        ("MAE (lower better)", "mae", "{:>10.4f}"),
+        ("RMSE (lower better)", "rmse", "{:>10.4f}"),
+        ("Spearman rank rho (higher better)", "spearman_rho", "{:>10.4f}"),
+        ("confounded-pair MAE (lower better)", "confounded_mae", "{:>10.4f}"),
+        ("low-overlap pair MAE (lower better)", "low_overlap_mae", "{:>10.4f}"),
+        ("n confounded", "n_confounded", "{:>10.0f}"),
+        ("n low overlap (<30 shared)", "n_low_overlap", "{:>10.0f}"),
+    ]
+    click.echo("")
+    click.echo(f"      {'metric':<38}  {'OLD':>10}  {'NEW':>10}  {'delta':>10}")
+    click.echo(f"      {'-'*38}  {'-'*10}  {'-'*10}  {'-'*10}")
+    for label, key, fmt in rows:
+        ov, nv = old[key], new[key]
+        delta = nv - ov
+        delta_str = (f"{delta:>+10.4f}") if "f" in fmt else f"{delta:>+10.0f}"
+        click.echo(f"      {label:<38}  {fmt.format(ov)}  {fmt.format(nv)}  {delta_str}")
+
+
+# ---------------------------------------------------------------------------
+# Experiment 2 — real gamelog holdout
+# ---------------------------------------------------------------------------
+
+
+def _try_load_stats(league: str):
+    """Try to import + load a Stats subclass for one league. None on failure."""
+    try:
+        from sportstradamus import stats as stats_pkg
+    except Exception as exc:
+        click.echo(f"      could not import sportstradamus.stats: {exc}")
+        return None
+    cls_name = f"Stats{league}"
+    cls = getattr(stats_pkg, cls_name, None)
+    if cls is None:
+        click.echo(f"      no Stats class named {cls_name} — skipping")
+        return None
+    try:
+        inst = cls()
+        inst.load()
+    except Exception as exc:
+        click.echo(f"      Stats{league}().load() failed: {exc}")
+        return None
+    if not hasattr(inst, "gamelog") or inst.gamelog is None or len(inst.gamelog) == 0:
+        click.echo(f"      Stats{league} loaded but gamelog is empty — skipping")
+        return None
+    return inst
+
+
+def _empirical_corr(matrix: pd.DataFrame) -> dict[str, pd.DataFrame]:
+    """Plain Spearman correlation per team — the holdout "ground truth"."""
+    matrix = matrix.drop(columns="DATE", errors="ignore")
+    out: dict[str, pd.DataFrame] = {}
+    for team in matrix["TEAM"].unique():
+        team_matrix = matrix.loc[matrix["TEAM"] == team].drop(columns="TEAM")
+        team_matrix = team_matrix.loc[:, team_matrix.notna().any(axis=0)]
+        if team_matrix.shape[1] < 2 or len(team_matrix) < 2:
+            continue
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            out[team] = cast(pd.DataFrame, team_matrix.corr(method="spearman"))
+    return out
+
+
+def _holdout_metrics(
+    train_per_team: dict[str, pd.DataFrame],
+    test_per_team: dict[str, pd.DataFrame],
+    train_overlap: dict[str, pd.DataFrame],
+) -> dict[str, float]:
+    pred: list[float] = []
+    actual: list[float] = []
+    low_overlap_pred: list[float] = []
+    low_overlap_actual: list[float] = []
+    sign_match = 0
+    sign_total = 0
+
+    for team, test_m in test_per_team.items():
+        train_m = train_per_team.get(team)
+        train_o = train_overlap.get(team)
+        cols = list(test_m.columns)
+        for i, a in enumerate(cols):
+            for b in cols[i + 1 :]:
+                t = float(test_m.loc[a, b])
+                if pd.isna(t):
+                    continue
+                if train_m is not None and a in train_m.index and b in train_m.columns:
+                    p = float(train_m.loc[a, b])
+                else:
+                    p = 0.0
+                pred.append(p)
+                actual.append(t)
+                if abs(p) >= SIGN_AGREEMENT_MAG_FLOOR and abs(t) >= SIGN_AGREEMENT_MAG_FLOOR:
+                    sign_total += 1
+                    if np.sign(p) == np.sign(t):
+                        sign_match += 1
+                if (
+                    train_o is not None
+                    and a in train_o.index
+                    and b in train_o.columns
+                    and train_o.loc[a, b] < MIN_OVERLAP_FOR_FULL_WEIGHT
+                ):
+                    low_overlap_pred.append(p)
+                    low_overlap_actual.append(t)
+
+    pa = np.array(pred)
+    aa = np.array(actual)
+    return {
+        "n_pairs": float(len(pa)),
+        "mae": float(np.mean(np.abs(pa - aa))) if len(pa) else float("nan"),
+        "spearman_rho": (
+            float(spearmanr(pa, aa).statistic) if len(pa) > 1 else float("nan")
+        ),
+        "sign_agreement": (sign_match / sign_total) if sign_total else float("nan"),
+        "n_sign_pairs": float(sign_total),
+        "low_overlap_mae": (
+            float(np.mean(np.abs(np.array(low_overlap_pred) - np.array(low_overlap_actual))))
+            if low_overlap_pred
+            else float("nan")
+        ),
+        "n_low_overlap": float(len(low_overlap_pred)),
+    }
+
+
+def run_real(league: str) -> bool:
+    click.echo(f"[2/2] Real-data holdout for league={league}")
+    stats = _try_load_stats(league)
+    if stats is None:
+        return False
+
+    _build_team_game_records = _correlate._build_team_game_records
+    _TRACKED_STATS = _correlate._TRACKED_STATS
+    if league not in _TRACKED_STATS:
+        click.echo(f"      league {league} not in _TRACKED_STATS — skipping")
+        return False
+
+    # Build the per-team-per-game matrix the same way the production
+    # correlate() does. _build_team_game_records already runs
+    # _residualize_gamelog internally, so this is effectively the "new"
+    # method's input. For the OLD method we re-pivot the raw gamelog from
+    # the same set of (gameId, team) rows so comparisons are apples-to-apples.
+    earliest = pd.to_datetime(stats.gamelog[stats.log_strings["date"]]).min().to_pydatetime()
+    res_records = _build_team_game_records(league, stats, earliest)
+    res_matrix = pd.DataFrame(pd.json_normalize(res_records))
+    if res_matrix.empty or "DATE" not in res_matrix.columns:
+        click.echo("      _build_team_game_records returned no usable rows — skipping")
+        return False
+
+    # Mirror the same pivot but skip residualization for the OLD path.
+    raw_records = _build_team_game_records_no_residual(league, stats, earliest)
+    raw_matrix = pd.DataFrame(pd.json_normalize(raw_records))
+
+    # Time-based 70/30 split on the residualized matrix; align the raw
+    # matrix to the same date cutoff.
+    res_matrix = res_matrix.sort_values("DATE").reset_index(drop=True)
+    raw_matrix = raw_matrix.sort_values("DATE").reset_index(drop=True)
+    n = len(res_matrix)
+    cutoff_date = res_matrix.loc[int(n * TRAIN_FRACTION), "DATE"]
+    click.echo(f"      train/test cutoff = {cutoff_date} ({int(n*TRAIN_FRACTION)}/{n} rows)")
+
+    res_train = res_matrix.loc[res_matrix["DATE"] <= cutoff_date]
+    res_test = res_matrix.loc[res_matrix["DATE"] > cutoff_date]
+    raw_train = raw_matrix.loc[raw_matrix["DATE"] <= cutoff_date]
+    raw_test = raw_matrix.loc[raw_matrix["DATE"] > cutoff_date]
+
+    if len(res_test) < 50:
+        click.echo(f"      only {len(res_test)} test rows — too few, skipping")
+        return False
+
+    old_stacked = build_corr_old(raw_train)
+    new_stacked = build_corr_new(res_train)
+
+    old_per_team = _stacked_to_per_team(old_stacked)
+    new_per_team = _stacked_to_per_team(new_stacked)
+
+    test_per_team = _empirical_corr(raw_test)
+    overlap_per_team = _per_team_overlap(res_train)
+
+    metrics_old = _holdout_metrics(old_per_team, test_per_team, overlap_per_team)
+    metrics_new = _holdout_metrics(new_per_team, test_per_team, overlap_per_team)
+
+    _print_holdout_table(metrics_old, metrics_new)
+    return True
+
+
+def _build_team_game_records_no_residual(league: str, stats, earliest_date) -> list[dict]:
+    """Same per-team-per-game pivot as production but without residualization.
+
+    Implemented by temporarily monkey-patching _residualize_gamelog to a
+    no-op so we don't fork the pivot logic. This keeps the OLD vs NEW
+    comparison using the *same* (game, team) row set — only the per-cell
+    transformation differs.
+    """
+    cmod = _correlate
+    orig = cmod._residualize_gamelog
+    cmod._residualize_gamelog = lambda gamelog, *a, **k: gamelog.copy()
+    try:
+        return cmod._build_team_game_records(league, stats, earliest_date)
+    finally:
+        cmod._residualize_gamelog = orig
+
+
+def _print_holdout_table(old: dict[str, float], new: dict[str, float]) -> None:
+    rows = [
+        ("pairs scored", "n_pairs", "{:>10.0f}"),
+        ("holdout MAE (lower better)", "mae", "{:>10.4f}"),
+        ("Spearman rho train vs test (higher better)", "spearman_rho", "{:>10.4f}"),
+        ("sign agreement (higher better)", "sign_agreement", "{:>10.4f}"),
+        ("n sign-comparable pairs", "n_sign_pairs", "{:>10.0f}"),
+        ("low-overlap MAE (lower better)", "low_overlap_mae", "{:>10.4f}"),
+        ("n low overlap pairs", "n_low_overlap", "{:>10.0f}"),
+    ]
+    click.echo("")
+    click.echo(f"      {'metric':<46}  {'OLD':>10}  {'NEW':>10}  {'delta':>10}")
+    click.echo(f"      {'-'*46}  {'-'*10}  {'-'*10}  {'-'*10}")
+    for label, key, fmt in rows:
+        ov, nv = old[key], new[key]
+        delta = nv - ov
+        delta_str = (f"{delta:>+10.4f}") if "f" in fmt else f"{delta:>+10.0f}"
+        click.echo(f"      {label:<46}  {fmt.format(ov)}  {fmt.format(nv)}  {delta_str}")
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+@click.command()
+@click.option("--league", type=click.Choice(["NFL", "NBA", "WNBA", "NHL", "MLB"]), default="NBA")
+@click.option("--seed", type=int, default=DEFAULT_SEED)
+@click.option("--n-games", type=int, default=DEFAULT_N_GAMES)
+@click.option("--skip-real", is_flag=True, help="Skip the real-data holdout experiment.")
+@click.option("--skip-synthetic", is_flag=True, help="Skip the synthetic experiment.")
+def main(league: str, seed: int, n_games: int, skip_real: bool, skip_synthetic: bool) -> None:
+    click.echo("Correlation methodology comparison: OLD vs NEW")
+    click.echo("=" * 72)
+    if not skip_synthetic:
+        run_synthetic(seed=seed, n_games=n_games)
+    if not skip_real:
+        click.echo("")
+        ran = run_real(league=league)
+        if not ran:
+            click.echo("      (real-data experiment skipped)")
+    click.echo("")
+    click.echo("Done.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/test_correlation_predictive_power.py
+++ b/scripts/test_correlation_predictive_power.py
@@ -150,16 +150,18 @@ def build_corr_old(matrix: pd.DataFrame) -> pd.Series:
     return out
 
 
-def build_corr_new(matrix_residualized: pd.DataFrame) -> pd.Series:
-    """Run the new methodology on a pre-residualized team-game matrix.
+def _team_corr_pairwise(
+    matrix: pd.DataFrame,
+    *,
+    shrink: bool,
+    magnitude_floor: float,
+) -> pd.Series:
+    """Per-team Spearman + Fisher remap with pairwise-complete handling.
 
-    Residualization happens upstream because it operates on the per-player
-    gamelog (one row per player-game), not the per-team matrix. Per team:
-    Spearman on residuals (pairwise-complete), Fisher remap, sample-size
-    shrinkage toward zero below MIN_OVERLAP_FOR_FULL_WEIGHT, magnitude
-    floor.
+    Used as a building block for the ablation variants. Skips fillna, drops
+    only fully-NaN columns, and (optionally) shrinks low-overlap pairs.
     """
-    matrix = matrix_residualized.drop(columns="DATE", errors="ignore").copy()
+    matrix = matrix.drop(columns="DATE", errors="ignore").copy()
     blocks: dict = {}
     for team in matrix["TEAM"].unique():
         team_matrix = matrix.loc[matrix["TEAM"] == team].drop(columns="TEAM")
@@ -173,9 +175,9 @@ def build_corr_new(matrix_residualized: pd.DataFrame) -> pd.Series:
             warnings.simplefilter("ignore")
             c_spearman = team_matrix.corr(method="spearman")
         c_remap = 2 * np.sin(np.pi / 6 * c_spearman)
-        c_shrunk = _shrink_correlations(c_remap, overlap)
-        c_stack = c_shrunk.unstack().dropna()
-        c_stack = c_stack.loc[c_stack.abs() > CORR_MAGNITUDE_FLOOR]
+        c = _shrink_correlations(c_remap, overlap) if shrink else c_remap
+        c_stack = c.unstack().dropna()
+        c_stack = c_stack.loc[c_stack.abs() > magnitude_floor]
         if not c_stack.empty:
             blocks[team] = c_stack
     if not blocks:
@@ -183,6 +185,31 @@ def build_corr_new(matrix_residualized: pd.DataFrame) -> pd.Series:
     out = pd.concat(blocks)
     out.name = "R"
     return out
+
+
+def build_corr_pairwise_only(matrix_raw: pd.DataFrame) -> pd.Series:
+    """Ablation A: same as OLD but with NaN handling like NEW.
+
+    Pairwise-complete Spearman on raw (non-residualized) values, no
+    fillna(0), no shrinkage. Isolates the contribution of dropping the
+    fillna step from residualization + shrinkage.
+    """
+    return _team_corr_pairwise(matrix_raw, shrink=False, magnitude_floor=0.001)
+
+
+def build_corr_residual_only(matrix_residualized: pd.DataFrame) -> pd.Series:
+    """Ablation B: residualization + pairwise NaN handling, no shrinkage.
+
+    Isolates the contribution of residualization on top of NaN handling.
+    """
+    return _team_corr_pairwise(matrix_residualized, shrink=False, magnitude_floor=0.001)
+
+
+def build_corr_new(matrix_residualized: pd.DataFrame) -> pd.Series:
+    """Full new methodology: residualize + pairwise NaN + shrinkage + floor."""
+    return _team_corr_pairwise(
+        matrix_residualized, shrink=True, magnitude_floor=CORR_MAGNITUDE_FLOOR
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -418,18 +445,55 @@ def run_synthetic(seed: int, n_games: int) -> None:
     res_team_matrix = _gamelog_to_team_matrix(residualized_log, stat_cols)
 
     overlap_new = _per_team_overlap(res_team_matrix)
-    overlap_old = _per_team_overlap(raw_team_matrix)
+    overlap_raw = _per_team_overlap(raw_team_matrix)
 
-    old_stacked = build_corr_old(raw_team_matrix)
-    new_stacked = build_corr_new(res_team_matrix)
+    # Four variants for the ablation:
+    #   OLD            = fillna(0) + drop>=50%-zero cols + min_periods spearman   (legacy)
+    #   PAIRWISE_ONLY  = pairwise-complete spearman on RAW values                 (NaN-handling delta only)
+    #   RESIDUAL_ONLY  = pairwise + residualization, no shrinkage                  (adds residualization)
+    #   NEW            = pairwise + residualization + shrinkage + 0.05 floor       (full new method)
+    variants = [
+        ("OLD", build_corr_old(raw_team_matrix), overlap_raw),
+        ("PAIRWISE_ONLY", build_corr_pairwise_only(raw_team_matrix), overlap_raw),
+        ("RESIDUAL_ONLY", build_corr_residual_only(res_team_matrix), overlap_new),
+        ("NEW", build_corr_new(res_team_matrix), overlap_new),
+    ]
+    metrics_per_variant: dict[str, dict[str, float]] = {}
+    for name, stacked, overlap in variants:
+        per_team = _stacked_to_per_team(stacked)
+        metrics_per_variant[name] = _score_recovery(per_team, truth, overlap)
 
-    old_per_team = _stacked_to_per_team(old_stacked)
-    new_per_team = _stacked_to_per_team(new_stacked)
+    _print_ablation_table(metrics_per_variant)
 
-    metrics_old = _score_recovery(old_per_team, truth, overlap_old)
-    metrics_new = _score_recovery(new_per_team, truth, overlap_new)
 
-    _print_recovery_table(metrics_old, metrics_new)
+def _print_ablation_table(metrics_per_variant: dict[str, dict[str, float]]) -> None:
+    """Side-by-side table for OLD / PAIRWISE_ONLY / RESIDUAL_ONLY / NEW.
+
+    Reading the columns left-to-right shows what each methodology change
+    contributed in isolation: PAIRWISE_ONLY isolates NaN handling,
+    RESIDUAL_ONLY adds residualization, NEW adds shrinkage + magnitude floor.
+    """
+    rows = [
+        ("pairs scored", "n_pairs", "{:>10.0f}"),
+        ("MAE (lower better)", "mae", "{:>10.4f}"),
+        ("RMSE (lower better)", "rmse", "{:>10.4f}"),
+        ("Spearman rank rho (higher better)", "spearman_rho", "{:>10.4f}"),
+        ("confounded-pair MAE (lower better)", "confounded_mae", "{:>10.4f}"),
+        ("low-overlap pair MAE (lower better)", "low_overlap_mae", "{:>10.4f}"),
+        ("n confounded", "n_confounded", "{:>10.0f}"),
+        ("n low overlap (<30 shared)", "n_low_overlap", "{:>10.0f}"),
+    ]
+    names = ["OLD", "PAIRWISE_ONLY", "RESIDUAL_ONLY", "NEW"]
+    click.echo("")
+    header = "      " + f"{'metric':<38}" + "  " + "  ".join(f"{n:>14}" for n in names)
+    click.echo(header)
+    click.echo("      " + "-" * 38 + "  " + "  ".join("-" * 14 for _ in names))
+    for label, key, fmt in rows:
+        cells = []
+        for n in names:
+            v = metrics_per_variant[n][key]
+            cells.append(fmt.replace(":>10", ":>14").format(v))
+        click.echo(f"      {label:<38}  " + "  ".join(cells))
 
 
 def _print_recovery_table(old: dict[str, float], new: dict[str, float]) -> None:


### PR DESCRIPTION
## Summary

Adds `scripts/test_correlation_predictive_power.py` — a `click` CLI that quantifies whether the residualize-and-shrink changes in 3bb43e1 actually improve the correlation matrix's predictive power, not just its methodology.

The script runs two experiments:

- **Synthetic ground truth (always runs).** Simulates a per-player gamelog from a known per-team latent correlation matrix plus per-player AR(1) skill drift and 20% missing-game noise — the two confounders the audit doc called out. Both methods score the same simulated data; reports MAE / RMSE / Spearman rank correlation against ground truth, plus subset MAE on confounded pairs and low-overlap (<30 shared games) pairs.
- **Real holdout (runs only if a `Stats` gamelog is present locally).** Splits the user's gamelog 70/30 by date, fits both methods on the train slice, and scores against the empirical correlation on test. Skips gracefully if no gamelog is loadable.

The new methodology is reimplemented in-script as a thin wrapper that calls `_residualize_gamelog` and `_shrink_correlations` from `sportstradamus.training.correlate` so we test what actually ships. The old methodology is reimplemented inline (the deprecated module runs `nfl.load()` at import time, so it can't be imported).

## Results (synthetic, default seed=42, n_games=200)

| metric | OLD | NEW | delta |
| --- | ---: | ---: | ---: |
| MAE | 0.2520 | **0.1388** | −0.1132 |
| RMSE | 0.3156 | **0.1766** | −0.1390 |
| Spearman rank rho | 0.4809 | **0.8583** | +0.3774 |
| confounded-pair MAE | 0.5722 | **0.3207** | −0.2516 |
| low-overlap MAE (n_games=60 run) | 0.1821 | **0.1730** | −0.0092 |

NEW wins on every metric across seeds 1, 7, 42, 99, 314.

## Test plan

- [x] `ruff check scripts/test_correlation_predictive_power.py` — clean
- [x] `python scripts/test_correlation_predictive_power.py --skip-real` — completes in <10s, prints synthetic table
- [x] `python scripts/test_correlation_predictive_power.py --league NBA` — prints synthetic + gracefully skips real-data when no gamelog
- [x] Multi-seed sanity (1, 7, 42, 99, 314) — direction is consistent

https://claude.ai/code/session_01FdyD1TeEgegE3AjgrBcqs3

---
_Generated by [Claude Code](https://claude.ai/code/session_01FdyD1TeEgegE3AjgrBcqs3)_