### PR TITLE
Add SessionStart hook to install superpowers plugin in web sessions

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -euo pipefail
+
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+MARKETPLACE="obra/superpowers-marketplace"
+MARKETPLACE_NAME="superpowers-marketplace"
+PLUGIN="superpowers"
+
+if ! claude plugin marketplace list 2>/dev/null | grep -q "$MARKETPLACE_NAME"; then
+  claude plugin marketplace add "$MARKETPLACE"
+fi
+
+if ! claude plugin list 2>/dev/null | grep -q "^  > ${PLUGIN}@"; then
+  claude plugin install "${PLUGIN}@${MARKETPLACE_NAME}"
+fi

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- Cloud sessions start with an ephemeral home directory, so user-scope plugin installs do not persist between Claude Code on the web sessions.
- Adds `.claude/hooks/session-start.sh` which (re)adds the `obra/superpowers-marketplace` marketplace and installs the `superpowers` plugin on every remote session start.
- Registers the hook in `.claude/settings.json` so future web sessions pick it up automatically.

## Notes
- The hook only runs when `CLAUDE_CODE_REMOTE=true`, so it's a no-op for local sessions where the plugin is already persisted in `~/.claude/`.
- The hook is idempotent — it skips marketplace add and plugin install if they're already present.
- Runs synchronously: session start waits for the install (a few seconds), but guarantees the plugin is available before the agent loop begins. Can switch to async later if startup latency becomes an issue.

## Test plan
- [x] Ran `CLAUDE_CODE_REMOTE=true ./.claude/hooks/session-start.sh` from a clean state — successfully added marketplace and installed plugin.
- [x] Re-ran the hook to confirm idempotency — no-op on second run.
- [ ] After merge, verify a fresh Claude Code on the web session has `superpowers` available without manual install.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Efy9yHYaMgxfRqkW9p3MkM)_