### PR TITLE
Track Closing Line Value efficiently

### DIFF
--- a/src/sportstradamus/analysis.py
+++ b/src/sportstradamus/analysis.py
@@ -130,7 +130,9 @@ def _migrate_flat_history(history):
     """Convert old flat history schema (one row per offer) to normalized schema.
 
     Groups by (Player, League, Date, Market) and collects per-offer columns
-    into an Offers list of tuples: (Line, Boost, Platform, Bet, ModelP, BooksP).
+    into an Offers list of 9-tuples: (Line, Boost, Platform, Bet, ModelP, BooksP,
+    CloseBooksP, MarketCLV, ModelCLV). The trailing three are NaN-padded for
+    pre-CLV rows; ``reflect`` populates them from the archive on resolution.
     """
     pred_key = ["Player", "League", "Date", "Market"]
     offer_cols = ["Line", "Boost", "Platform", "Bet", "Model P", "Books P"]
@@ -180,6 +182,9 @@ def _migrate_flat_history(history):
                     str(r.get("Bet", "")),
                     float(r["Model P"]) if pd.notna(r.get("Model P")) else np.nan,
                     float(r["Books P"]) if pd.notna(r.get("Books P")) else np.nan,
+                    np.nan,  # Close Books P — populated by reflect.
+                    np.nan,  # Market CLV
+                    np.nan,  # Model CLV
                 )
             )
 
@@ -220,24 +225,51 @@ def _dedup_offers(offers):
 def _merge_offers(old_offers, new_offers):
     """Merge old and new offer lists, deduplicating by (Line, Platform).
 
-    New offers overwrite old ones with the same (Line, Platform) key.
+    New offers overwrite old ones with the same (Line, Platform) key, except
+    in the closing-trio positions (CloseBooksP, MarketCLV, ModelCLV): a
+    captured non-NaN closing value on the old offer is preserved when the
+    new offer is NaN there. Without this, the next ``prophecize`` run would
+    clobber any close-line snapshot ``reflect`` had already filled in.
     """
     merged = {}
     if old_offers:
         for offer in old_offers:
             key = (offer[0], offer[2])  # (Line, Platform)
-            merged[key] = offer
+            merged[key] = _pad_legacy(offer)
     for offer in new_offers:
         key = (offer[0], offer[2])
-        merged[key] = offer
+        new_padded = _pad_legacy(offer)
+        if key in merged:
+            old_padded = merged[key]
+            merged[key] = _preserve_closing(old_padded, new_padded)
+        else:
+            merged[key] = new_padded
     return list(merged.values())
+
+
+def _pad_legacy(offer):
+    """Return ``offer`` padded to the canonical 9-field shape with NaN."""
+    if isinstance(offer, tuple | list) and len(offer) == 6:
+        return (*tuple(offer), np.nan, np.nan, np.nan)
+    return tuple(offer)
+
+
+def _preserve_closing(old_offer, new_offer):
+    """Carry old closing-trio values forward when ``new_offer`` lacks them."""
+    merged = list(new_offer)
+    for idx in (6, 7, 8):  # CloseBooksP, MarketCLV, ModelCLV
+        if idx < len(merged) and pd.isna(merged[idx]) and idx < len(old_offer):
+            merged[idx] = old_offer[idx]
+    return tuple(merged)
 
 
 def explode_offers(history):
     """Expand Offers column into one row per offer, inheriting prediction-level cols.
 
     Returns DataFrame with columns: all prediction-level cols + Line, Boost,
-    Platform, Bet, Model P, Books P, Result, Hit.
+    Platform, Bet, Model P, Books P, Close Books P, Market CLV, Model CLV,
+    Result, Hit. Legacy 6-tuples are read transparently — the closing trio
+    surfaces as NaN.
     """
     if "Offers" not in history.columns:
         return history
@@ -250,7 +282,8 @@ def explode_offers(history):
             continue
         actual = pred.get("Actual")
         for offer in offers:
-            line, boost, platform, bet, model_p, books_p = offer
+            offer = _pad_legacy(offer)
+            line, boost, platform, bet, model_p, books_p, close_p, market_clv, model_clv = offer
             # Derive result from actual vs line
             if pd.notna(actual) and pd.notna(line):
                 if " vs. " in str(pred.get("Player", "")):
@@ -273,6 +306,9 @@ def explode_offers(history):
                     "Bet": bet,
                     "Model P": model_p,
                     "Books P": books_p,
+                    "Close Books P": close_p,
+                    "Market CLV": market_clv,
+                    "Model CLV": model_clv,
                     "Result": result,
                 }
             )
@@ -544,13 +580,15 @@ def compute_parlay_metrics(parlays, stats, stat_map):
     ud_parlays = parlays.loc[parlays["Platform"] == "Underdog"].copy()
     if len(ud_parlays) > 0:
         ud_parlays["Profit"] = ud_parlays.apply(
-            lambda x: np.clip(
-                PAYOUT_TABLE["Underdog"][x.Legs][x.Misses]
-                * (x.Boost if x.Boost < 2 or x.Misses == 0 else 1),
-                None,
-                100,
-            )
-            - 1,
+            lambda x: (
+                np.clip(
+                    PAYOUT_TABLE["Underdog"][x.Legs][x.Misses]
+                    * (x.Boost if x.Boost < 2 or x.Misses == 0 else 1),
+                    None,
+                    100,
+                )
+                - 1
+            ),
             axis=1,
         )
         ud_parlays["Profit"] = ud_parlays["Profit"] * np.round(ud_parlays["Rec Bet"] * 2) / 2
@@ -646,9 +684,9 @@ def compute_parlay_metrics(parlays, stats, stat_map):
                     row["Independent Rate"] = round(size_df["Indep P"].mean(), 4)
                 elif "Leg Probs" in parlays.columns and size_df["Leg Probs"].notna().any():
                     indep = size_df["Leg Probs"].apply(
-                        lambda lp: np.prod(lp)
-                        if isinstance(lp, list | tuple) and len(lp) > 0
-                        else np.nan
+                        lambda lp: (
+                            np.prod(lp) if isinstance(lp, list | tuple) and len(lp) > 0 else np.nan
+                        )
                     )
                     row["Independent Rate"] = round(indep.mean(), 4)
                 size_rows.append(row)

--- a/src/sportstradamus/clv.py
+++ b/src/sportstradamus/clv.py
@@ -1,0 +1,185 @@
+"""Closing-line value (CLV) computation for resolved predictions.
+
+Reads the post-lock archive snapshot (whatever ``Archive.get_ev`` returns by
+the time ``reflect`` runs — the Odds API stops surfacing prematch odds for
+in-progress games, so the last sample before kickoff is the close) and
+folds it into each offer in ``history`` as ``Close Books P``,
+``Market CLV``, and ``Model CLV``. Two helpers and a one-shot summary
+printer are all that's needed; ``reflect`` orchestrates the call.
+
+Definitions, in no-vig probability units:
+
+    sign       = +1 if Bet in {"Over",  "Higher"} else -1
+    Market CLV = sign * (Close Books P - Open Books P)
+    Model CLV  = sign * (Close Books P - Open Model P)
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+# Per-(League, Market, Platform) CLV summary segments require this many legs
+# to be reported. Smaller segments are statistical noise.
+CLV_SEGMENT_MIN_N = 20
+
+_OVER_BETS = {"Over", "Higher", "over", "higher"}
+
+
+def _signed_clv(open_p: float, close_p: float, bet: str) -> float:
+    """Return signed CLV in probability points, or NaN when undefined.
+
+    Args:
+        open_p: Probability the bettor implicitly bought at placement time.
+        close_p: Closing book probability at game-lock.
+        bet: Direction of the bet — Over/Higher get +1, Under/Lower get -1.
+
+    Returns:
+        Signed CLV (close − open, flipped for Under). NaN if either
+        probability is NaN.
+    """
+    if pd.isna(open_p) or pd.isna(close_p):
+        return np.nan
+    sign = 1 if bet in _OVER_BETS else -1
+    return sign * (float(close_p) - float(open_p))
+
+
+def fill_from_archive(history: pd.DataFrame, archive) -> pd.DataFrame:
+    """Populate the closing trio in each ``Offers`` tuple from ``archive``.
+
+    For every offer in every history row, query
+    ``archive.get_ev(league, market, date, player)`` once and rewrite the
+    9-tuple in-place with ``Close Books P``, ``Market CLV``, and
+    ``Model CLV``. Offers whose archive lookup returns NaN are left with
+    NaN closing fields and excluded from CLV aggregates downstream.
+
+    Skips offers that already carry a non-NaN ``Close Books P`` so a
+    re-run doesn't redundantly hit archive.
+
+    Args:
+        history: DataFrame in the normalized 9-tuple ``Offers`` schema.
+        archive: A loaded ``Archive`` instance.
+
+    Returns:
+        The same DataFrame, mutated in place. Returned for chaining.
+    """
+    if "Offers" not in history.columns or history.empty:
+        return history
+
+    for idx, row in history.iterrows():
+        offers = row.get("Offers")
+        if not isinstance(offers, list) or not offers:
+            continue
+        league = row.get("League")
+        market = row.get("Market")
+        date = row.get("Date")
+        player = row.get("Player")
+        if not (isinstance(league, str) and isinstance(market, str)):
+            continue
+
+        date_str = _normalize_date(date)
+        close_p = _safe_get_ev(archive, league, market, date_str, player)
+
+        new_offers = []
+        for offer in offers:
+            if isinstance(offer, tuple | list) and len(offer) == 6:
+                offer = (*tuple(offer), np.nan, np.nan, np.nan)
+            elif not (isinstance(offer, tuple | list) and len(offer) == 9):
+                new_offers.append(offer)
+                continue
+            line, boost, platform, bet, model_p, books_p, prev_close, _, _ = offer
+            if not pd.isna(prev_close):
+                new_offers.append(tuple(offer))
+                continue
+            market_clv = _signed_clv(books_p, close_p, bet)
+            model_clv = _signed_clv(model_p, close_p, bet)
+            new_offers.append(
+                (line, boost, platform, bet, model_p, books_p, close_p, market_clv, model_clv)
+            )
+
+        history.at[idx, "Offers"] = new_offers
+
+    return history
+
+
+def summarize(history: pd.DataFrame) -> dict:
+    """Return aggregate CLV stats for logging by ``reflect``.
+
+    Iterates exploded offers and computes overall n / mean Market CLV /
+    mean Model CLV / fraction of legs that beat the close. Drops legs
+    with NaN closing values from the count.
+    """
+    legs = []
+    for _, row in history.iterrows():
+        offers = row.get("Offers")
+        if not isinstance(offers, list):
+            continue
+        platform_default = row.get("Platform")
+        for offer in offers:
+            if not (isinstance(offer, tuple | list) and len(offer) >= 9):
+                continue
+            _, _, platform, _, _, _, close_p, market_clv, _model_clv = offer[:9]
+            if pd.isna(close_p) or pd.isna(market_clv):
+                continue
+            legs.append(
+                {
+                    "League": row.get("League"),
+                    "Market": row.get("Market"),
+                    "Platform": platform or platform_default,
+                    "Market CLV": float(market_clv),
+                    "Model CLV": float(_model_clv) if not pd.isna(_model_clv) else np.nan,
+                }
+            )
+
+    if not legs:
+        return {
+            "n": 0,
+            "market_clv_mean": np.nan,
+            "model_clv_mean": np.nan,
+            "frac_beat_close": np.nan,
+            "segments": pd.DataFrame(),
+        }
+
+    df = pd.DataFrame(legs)
+    market_mean = float(df["Market CLV"].mean())
+    model_series = df["Model CLV"].dropna()
+    model_mean = float(model_series.mean()) if not model_series.empty else np.nan
+    frac_beat = float((df["Market CLV"] > 0).mean())
+
+    grouped = (
+        df.groupby(["League", "Market", "Platform"], dropna=False)["Market CLV"]
+        .agg(["count", "mean"])
+        .reset_index()
+        .rename(columns={"count": "n", "mean": "market_clv"})
+    )
+    segments = grouped.loc[grouped["n"] >= CLV_SEGMENT_MIN_N].sort_values(
+        "market_clv", ascending=False
+    )
+
+    return {
+        "n": len(df),
+        "market_clv_mean": market_mean,
+        "model_clv_mean": model_mean,
+        "frac_beat_close": frac_beat,
+        "segments": segments,
+    }
+
+
+def _normalize_date(date) -> str:
+    """Return ``date`` as ``YYYY-MM-DD`` for archive lookup."""
+    if isinstance(date, str):
+        return date
+    try:
+        return pd.to_datetime(date).strftime("%Y-%m-%d")
+    except (ValueError, TypeError):
+        return ""
+
+
+def _safe_get_ev(archive, league: str, market: str, date: str, player) -> float:
+    """Wrap ``archive.get_ev`` so any lookup miss surfaces as NaN."""
+    if not date or not isinstance(player, str):
+        return np.nan
+    try:
+        return float(archive.get_ev(league, market, date, player))
+    except (KeyError, ValueError, TypeError):
+        return np.nan

--- a/src/sportstradamus/dashboard_data.py
+++ b/src/sportstradamus/dashboard_data.py
@@ -5,7 +5,6 @@ All pages import from here to get cached DataFrames and filters.
 
 import importlib.resources as pkg_resources
 import json
-import os
 from datetime import datetime, timedelta
 
 import numpy as np
@@ -18,6 +17,12 @@ from sportstradamus.analysis import (
     check_bet,
     explode_offers,
     resolve_history,
+)
+from sportstradamus.helpers.io import (
+    read_history,
+    read_parlay_hist,
+    write_history,
+    write_parlay_hist,
 )
 from sportstradamus.stats import StatsMLB, StatsNBA, StatsNFL, StatsNHL, StatsWNBA
 
@@ -37,15 +42,14 @@ def load_history():
     If old flat schema is detected (no Offers column), migrates automatically
     and saves the migrated data back to pickle.
     """
-    filepath = pkg_resources.files(data) / "history.dat"
-    if not os.path.isfile(filepath):
-        return pd.DataFrame()
-    history = pd.read_pickle(filepath)
+    history = read_history()
+    if history.empty:
+        return history
 
     # Migrate old flat schema → normalized (one row per prediction, Offers list)
     if "Offers" not in history.columns:
         history = _migrate_flat_history(history)
-        history.to_pickle(filepath)
+        write_history(history)
 
     # Ensure prediction-level columns exist for backward compatibility
     for col in ["Dist", "CV", "Model Param", "Gate", "Temperature", "Disp Cal", "Step", "Actual"]:
@@ -58,10 +62,9 @@ def load_history():
 @st.cache_data(ttl=3600, show_spinner="Loading parlay history...")
 def load_parlays():
     """Load parlay history."""
-    filepath = pkg_resources.files(data) / "parlay_hist.dat"
-    if not os.path.isfile(filepath):
-        return pd.DataFrame()
-    parlays = pd.read_pickle(filepath)
+    parlays = read_parlay_hist()
+    if parlays.empty:
+        return parlays
 
     # Backward compat
     for col in ["Corr Pairs", "Boost Pairs", "Indep P", "Indep PB"]:
@@ -120,10 +123,7 @@ def resolve_and_save(history, stats):
         return history
 
     history = resolve_history(history, stats)
-
-    filepath = pkg_resources.files(data) / "history.dat"
-    history.to_pickle(filepath)
-
+    write_history(history)
     return history
 
 
@@ -143,10 +143,7 @@ def resolve_parlays_and_save(parlays, stats, stat_map):
         lambda bet: check_bet(bet, stats, stat_map), axis=1
     ).to_list()
     parlays.loc[parlays["Legs"].isna(), ["Legs", "Misses"]] = results
-
-    filepath = pkg_resources.files(data) / "parlay_hist.dat"
-    parlays.to_pickle(filepath)
-
+    write_parlay_hist(parlays)
     return parlays
 
 

--- a/src/sportstradamus/helpers/io.py
+++ b/src/sportstradamus/helpers/io.py
@@ -1,0 +1,219 @@
+"""Atomic parquet/JSON IO + schema converters for the data hot path.
+
+All writers stage to a ``<path>.tmp`` and then ``os.replace()`` to the target
+path, so the dashboard never reads a torn file when a pipeline writes
+mid-render.
+
+The ``Offers`` column in history is in-memory ``list[tuple]`` of mixed types.
+PyArrow needs a ``list<struct>`` for that, so the converters round-trip
+tuple <-> dict at the parquet boundary. Every other consumer of the column
+keeps its tuple-indexed semantics.
+
+Reads prefer parquet but fall back to the legacy ``.dat`` pickle when
+parquet is absent — this lets installs that haven't run the one-shot
+migration script keep working. Writes target parquet only; ``.dat`` files
+are read-only legacy.
+"""
+
+from __future__ import annotations
+
+import importlib.resources as pkg_resources
+import json
+import math
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+from sportstradamus import data
+
+# --- Canonical artifact paths ---
+HISTORY_PATH = pkg_resources.files(data) / "history.parquet"
+PARLAY_HIST_PATH = pkg_resources.files(data) / "parlay_hist.parquet"
+CURRENT_OFFERS_PATH = pkg_resources.files(data) / "current_offers.parquet"
+CURRENT_PARLAYS_PATH = pkg_resources.files(data) / "current_parlays.parquet"
+CURRENT_META_PATH = pkg_resources.files(data) / "current_meta.json"
+MODEL_STATS_PATH = pkg_resources.files(data) / "model_stats.parquet"
+
+# Legacy pickle paths kept as read-only fallback until the parquet migration
+# has run on every install.
+HISTORY_PICKLE_PATH = pkg_resources.files(data) / "history.dat"
+PARLAY_HIST_PICKLE_PATH = pkg_resources.files(data) / "parlay_hist.dat"
+
+# Field order for the Offers struct must match the in-memory tuple positions.
+# CLV adds the trailing three (close_books_p, market_clv, model_clv); legacy
+# six-tuples are zero-padded with NaN on read.
+_OFFER_FIELDS = (
+    "line",
+    "boost",
+    "platform",
+    "bet",
+    "model_p",
+    "books_p",
+    "close_books_p",
+    "market_clv",
+    "model_clv",
+)
+_LEGACY_OFFER_LEN = 6
+
+# Tuple-typed columns in parlay_hist that round-trip as homogeneous float lists.
+_PARLAY_LIST_COLS = ("Leg Probs", "Corr Pairs", "Boost Pairs", "Markets", "Players")
+
+
+def _atomic_write_parquet(df: pd.DataFrame, path) -> None:
+    path = Path(str(path))
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    df.to_parquet(tmp, engine="pyarrow", index=False)
+    tmp.replace(path)
+
+
+def _atomic_write_json(obj, path) -> None:
+    path = Path(str(path))
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    with tmp.open("w") as f:
+        json.dump(obj, f, indent=2, default=str)
+    tmp.replace(path)
+
+
+def read_parquet_safe(path) -> pd.DataFrame:
+    """Return parquet contents or an empty DataFrame if the file is absent."""
+    p = Path(str(path))
+    if not p.is_file():
+        return pd.DataFrame()
+    return pd.read_parquet(p, engine="pyarrow")
+
+
+def _read_pickle_fallback(path) -> pd.DataFrame:
+    """Return pickle contents or an empty DataFrame if the file is absent."""
+    p = Path(str(path))
+    if not p.is_file():
+        return pd.DataFrame()
+    return pd.read_pickle(p)
+
+
+# ---------------------------------------------------------------------------
+# History.Offers <-> parquet struct
+# ---------------------------------------------------------------------------
+
+
+def _pad_legacy_offer(offer):
+    """Pad a 6-tuple legacy offer up to the current 9-field shape with NaN."""
+    if len(offer) == _LEGACY_OFFER_LEN:
+        return (*tuple(offer), np.nan, np.nan, np.nan)
+    return tuple(offer)
+
+
+def _offer_tuple_to_dict(offer):
+    if not isinstance(offer, tuple | list):
+        return None
+    if len(offer) == _LEGACY_OFFER_LEN:
+        offer = _pad_legacy_offer(offer)
+    if len(offer) != len(_OFFER_FIELDS):
+        return None
+    return dict(zip(_OFFER_FIELDS, offer, strict=False))
+
+
+def _offer_dict_to_tuple(offer):
+    if not isinstance(offer, dict):
+        if isinstance(offer, tuple | list) and len(offer) == _LEGACY_OFFER_LEN:
+            return _pad_legacy_offer(offer)
+        return offer
+    return tuple(offer.get(f, np.nan) for f in _OFFER_FIELDS)
+
+
+def _offers_for_parquet(offers):
+    if not isinstance(offers, list):
+        return []
+    return [d for d in (_offer_tuple_to_dict(o) for o in offers) if d is not None]
+
+
+def _offers_from_parquet(offers):
+    if offers is None:
+        return []
+    return [_offer_dict_to_tuple(o) for o in offers]
+
+
+def write_history(df: pd.DataFrame) -> None:
+    """Atomically write the prediction history parquet."""
+    out = df.copy()
+    if "Offers" in out.columns:
+        out["Offers"] = out["Offers"].apply(_offers_for_parquet)
+    _atomic_write_parquet(out, HISTORY_PATH)
+
+
+def read_history() -> pd.DataFrame:
+    """Read the prediction history. Falls back to ``history.dat`` on miss."""
+    df = read_parquet_safe(HISTORY_PATH)
+    if df.empty:
+        df = _read_pickle_fallback(HISTORY_PICKLE_PATH)
+    if df.empty:
+        return df
+    if "Offers" in df.columns:
+        df["Offers"] = df["Offers"].apply(_offers_from_parquet)
+    return df
+
+
+# ---------------------------------------------------------------------------
+# Parlay history homogeneous tuple cols <-> parquet list<float>
+# ---------------------------------------------------------------------------
+
+
+def _seq_to_list(v):
+    if isinstance(v, tuple):
+        return list(v)
+    return v
+
+
+def _list_to_tuple(v):
+    if isinstance(v, list):
+        return tuple(v)
+    return v
+
+
+def write_parlay_hist(df: pd.DataFrame) -> None:
+    """Atomically write the parlay history parquet."""
+    out = df.copy()
+    out = out.drop(columns=[c for c in ("_date",) if c in out.columns])
+    for col in _PARLAY_LIST_COLS:
+        if col in out.columns:
+            out[col] = out[col].apply(_seq_to_list)
+    _atomic_write_parquet(out, PARLAY_HIST_PATH)
+
+
+def read_parlay_hist() -> pd.DataFrame:
+    """Read the parlay history. Falls back to ``parlay_hist.dat`` on miss."""
+    df = read_parquet_safe(PARLAY_HIST_PATH)
+    if df.empty:
+        df = _read_pickle_fallback(PARLAY_HIST_PICKLE_PATH)
+    if df.empty:
+        return df
+    for col in _PARLAY_LIST_COLS:
+        if col in df.columns:
+            df[col] = df[col].apply(_list_to_tuple)
+    return df
+
+
+# ---------------------------------------------------------------------------
+# Upcoming-events ledger (close-line scheduler input)
+# ---------------------------------------------------------------------------
+
+UPCOMING_EVENTS_PATH = pkg_resources.files(data) / "upcoming_events.json"
+
+
+def read_upcoming_events() -> list[dict]:
+    """Return the list of upcoming events, or empty list if the file is absent."""
+    p = Path(str(UPCOMING_EVENTS_PATH))
+    if not p.is_file():
+        return []
+    with p.open() as f:
+        return json.load(f)
+
+
+def write_upcoming_events(events: list[dict]) -> None:
+    """Atomically write the upcoming-events ledger as JSON."""
+    cleaned = [e for e in events if isinstance(e, dict) and not _has_nan(e.values())]
+    _atomic_write_json(cleaned, UPCOMING_EVENTS_PATH)
+
+
+def _has_nan(values) -> bool:
+    return any(isinstance(v, float) and math.isnan(v) for v in values)

--- a/src/sportstradamus/moneylines.py
+++ b/src/sportstradamus/moneylines.py
@@ -12,6 +12,15 @@ Two internal workhorses:
 Both support a historical mode (``date != today``) that routes the request
 through ``the-odds-api.com``'s historical endpoints; that path uses the
 paid ``odds_api_plus`` key because the free tier doesn't include history.
+
+The ``--close-lines`` flag swaps the broad pipeline for a cheap targeted
+pass: it reads ``data/upcoming_events.json`` (refreshed by every broad
+``confer`` run) and only fires per-event endpoint calls for games starting
+within the closing window. If the window is empty, it exits before
+touching the archive or the network. The intended cron schedule —
+American-sports start hours only — is::
+
+    */5 11-23,0-1 * * * cd <repo> && poetry run confer --close-lines
 """
 
 import importlib.resources as pkg_resources
@@ -36,7 +45,16 @@ from sportstradamus.helpers import (
     remove_accents,
     stat_cv,
 )
+from sportstradamus.helpers.io import read_upcoming_events, write_upcoming_events
 from sportstradamus.spiderLogger import logger
+
+# Closing-line capture window. Run `confer --close-lines` every 5 minutes
+# during American-sports hours; only events commencing inside this window
+# get a per-event endpoint hit, so the worst-case token cost per tick is
+# bounded by `len(upcoming_events.json) * markets_per_event` and most ticks
+# are no-ops.
+CLOSING_LEAD_MIN = 5
+CLOSING_LEAD_MAX = 25
 
 # Leagues with live odds we care about. The Odds API also surfaces NHL / MLB
 # but their prop coverage is thin enough that we get those from the direct
@@ -70,21 +88,36 @@ def _get_with_retry(url, params=None):
 
 
 @click.command()
-def confer():
+@click.option(
+    "--close-lines",
+    "close_lines",
+    is_flag=True,
+    default=False,
+    help=(
+        "Targeted close-line scrape only. Reads data/upcoming_events.json and hits "
+        "per-event endpoints for games starting within the closing window. "
+        "Exits without touching archive or API when no events are due."
+    ),
+)
+def confer(close_lines: bool):
     """Fetch current odds and player props into the archive."""
     filepath = pkg_resources.files(creds) / "keys.json"
     with open(filepath) as infile:
         keys = json.load(infile)
+
+    filepath = pkg_resources.files(data) / "stat_map.json"
+    with open(filepath) as infile:
+        stat_map = json.load(infile)
+
+    if close_lines:
+        _close_lines_pass(keys["odds_api_plus"], stat_map["Odds API"])
+        return
 
     archive = Archive()
     logger.info("Archive loaded")
 
     archive = get_moneylines(archive, keys)
     logger.info("Game data complete")
-
-    filepath = pkg_resources.files(data) / "stat_map.json"
-    with open(filepath) as infile:
-        stat_map = json.load(infile)
 
     archive = get_props(archive, keys["odds_api_plus"], stat_map["Odds API"])
     logger.info("Player data complete, writing to file...")
@@ -267,6 +300,8 @@ def get_props(
         dayDelta = 6
         params = {"apiKey": apikey}
 
+    ledger = {(e["sport_key"], e["event_id"]): e for e in read_upcoming_events()}
+
     for sport, league in sports:
         params.update({"markets": ",".join(props[league].keys())})
         if league == "MLB":
@@ -283,7 +318,7 @@ def get_props(
             )
             if gameDate > date + timedelta(days=dayDelta):
                 continue
-            gameDate = gameDate.strftime("%Y-%m-%d")
+            gameDate_str = gameDate.strftime("%Y-%m-%d")
             event_params = {**params, "regions": "us"}
             res = _get_with_retry(
                 odds_url_template.format(sport=sport, eventId=event["id"]), params=event_params
@@ -294,105 +329,200 @@ def get_props(
                 continue
 
             game = res.json()["data"] if historical else res.json()
+            _archive_event_props(archive, game, league, props, gameDate_str)
 
-            odds = {}
-            totals = {}
-            spread_home = {}
-            spread_away = {}
+            if not historical:
+                ledger[(sport, event["id"])] = {
+                    "sport_key": sport,
+                    "event_id": event["id"],
+                    "league": league,
+                    "commence_time": event["commence_time"],
+                    "markets": list(props[league].keys()),
+                }
 
-            for book in game["bookmakers"]:
-                for market in book["markets"]:
-                    if "totals" in market["key"]:
-                        spread_name = " ".join(market["key"].split("_")[1:])
-                        outcomes = sorted(market["outcomes"], key=itemgetter("name"))
-                        sub_odds = no_vig_odds(outcomes[0]["price"], outcomes[1]["price"])
-                        totals.setdefault(spread_name, {})
-                        totals[spread_name][book["key"]] = get_ev(outcomes[1]["point"], sub_odds[1])
-                        continue
-                    elif "spread" in market["key"]:
-                        spread_name = " ".join(market["key"].split("_")[1:])
-                        outcomes = sorted(market["outcomes"], key=itemgetter("point"))
-                        sub_odds = no_vig_odds(outcomes[0]["price"], outcomes[1]["price"])
-                        spread = get_ev(outcomes[1]["point"], sub_odds[1])
-                        spread_home.setdefault(spread_name, {})
-                        spread_away.setdefault(spread_name, {})
-                        if outcomes[0]["name"] == game["home_team"]:
-                            spread_home[spread_name][book["key"]] = spread
-                            spread_away[spread_name][book["key"]] = -spread
-                        else:
-                            spread_home[spread_name][book["key"]] = -spread
-                            spread_away[spread_name][book["key"]] = spread
-                        continue
-
-                    market_name = props[league].get(market["key"])
-
-                    odds.setdefault(market_name, {})
-
-                    outcomes = [
-                        o
-                        for o in market["outcomes"]
-                        if "description" in o and "name" in o and o["price"] > 1
-                    ]
-                    outcomes = sorted(outcomes, key=itemgetter("description", "name"))
-
-                    for player, lines in groupby(outcomes, itemgetter("description")):
-                        player = remove_accents(player).replace(" Total", "")
-                        odds[market_name].setdefault(player, {"EV": {}, "Lines": []})
-                        lines = list(lines)
-                        for line in lines:
-                            line.setdefault("point", 0.5)
-                            line["name"] = {"Yes": "Over", "No": "Under"}.get(
-                                line["name"], line["name"]
-                            )
-
-                        lines = sorted(lines, key=itemgetter("name"))
-                        if len({line["point"] for line in lines}) > 1:
-                            trueline = sorted(lines, key=(lambda x: np.abs(x["price"] - 2)))[0][
-                                "point"
-                            ]
-                            lines = [line for line in lines if line["point"] == trueline]
-                        if len(lines) > 2:
-                            lines = [
-                                next(line for line in lines if line["name"] == "Over"),
-                                next(line for line in lines if line["name"] == "Under"),
-                            ]
-                        if len(lines) == 1 and lines[0]["name"] == "Under":
-                            lines[0]["name"] = "Over"
-                            under = lines[0]["price"]
-                            lines[0]["price"] = under / (under - 1)
-
-                        line = lines[0].get("point", 0.5)
-                        odds[market_name][player]["Lines"].append(line)
-                        price = no_vig_odds(*[x["price"] for x in lines])
-                        ev = get_ev(line, price[1], stat_cv[league].get(market_name, 1))
-
-                        odds[market_name][player]["EV"][book["key"]] = ev
-
-            for market in odds:
-                archive._mark_changed(league, market)
-                archive[league].setdefault(market, {}).setdefault(gameDate, {})
-                for player in odds[market]:
-                    archive[league][market][gameDate].setdefault(player, {"EV": {}, "Lines": []})
-                    archive[league][market][gameDate][player]["EV"].update(
-                        odds[market][player]["EV"]
-                    )
-
-                    line = np.median(odds[market][player]["Lines"])
-                    if line not in archive[league][market][gameDate][player]["Lines"]:
-                        archive[league][market][gameDate][player]["Lines"].append(line)
-
-            for market in totals:
-                archive._mark_changed(league, market)
-                archive[league].setdefault(market, {}).setdefault(gameDate, {})
-
-                archive[league][market][gameDate][
-                    abbreviations[league][remove_accents(game["home_team"])]
-                ] = {k: (v + spread_home.get(k, 0)) / 2 for k, v in totals[market].items()}
-                archive[league][market][gameDate][
-                    abbreviations[league][remove_accents(game["away_team"])]
-                ] = {k: (v + spread_away.get(k, 0)) / 2 for k, v in totals[market].items()}
+    if not historical:
+        write_upcoming_events(_prune_upcoming_events(list(ledger.values())))
 
     return archive
+
+
+def _archive_event_props(archive, game, league, props, gameDate):
+    """Parse one Odds API event response and write its odds into ``archive``.
+
+    Splits markets into player props (per-player EV and consensus lines),
+    totals (game-total team buckets), and spreads (used to fold home/away
+    team-total adjustments back into the totals write). Mirrors the inline
+    logic that ``get_props`` previously ran, hoisted out so the
+    ``--close-lines`` pass can reuse it without duplicating the parser.
+    """
+    odds = {}
+    totals = {}
+    spread_home = {}
+    spread_away = {}
+
+    for book in game["bookmakers"]:
+        for market in book["markets"]:
+            if "totals" in market["key"]:
+                spread_name = " ".join(market["key"].split("_")[1:])
+                outcomes = sorted(market["outcomes"], key=itemgetter("name"))
+                sub_odds = no_vig_odds(outcomes[0]["price"], outcomes[1]["price"])
+                totals.setdefault(spread_name, {})
+                totals[spread_name][book["key"]] = get_ev(outcomes[1]["point"], sub_odds[1])
+                continue
+            elif "spread" in market["key"]:
+                spread_name = " ".join(market["key"].split("_")[1:])
+                outcomes = sorted(market["outcomes"], key=itemgetter("point"))
+                sub_odds = no_vig_odds(outcomes[0]["price"], outcomes[1]["price"])
+                spread = get_ev(outcomes[1]["point"], sub_odds[1])
+                spread_home.setdefault(spread_name, {})
+                spread_away.setdefault(spread_name, {})
+                if outcomes[0]["name"] == game["home_team"]:
+                    spread_home[spread_name][book["key"]] = spread
+                    spread_away[spread_name][book["key"]] = -spread
+                else:
+                    spread_home[spread_name][book["key"]] = -spread
+                    spread_away[spread_name][book["key"]] = spread
+                continue
+
+            market_name = props[league].get(market["key"])
+
+            odds.setdefault(market_name, {})
+
+            outcomes = [
+                o
+                for o in market["outcomes"]
+                if "description" in o and "name" in o and o["price"] > 1
+            ]
+            outcomes = sorted(outcomes, key=itemgetter("description", "name"))
+
+            for player, lines in groupby(outcomes, itemgetter("description")):
+                player = remove_accents(player).replace(" Total", "")
+                odds[market_name].setdefault(player, {"EV": {}, "Lines": []})
+                lines = list(lines)
+                for line in lines:
+                    line.setdefault("point", 0.5)
+                    line["name"] = {"Yes": "Over", "No": "Under"}.get(line["name"], line["name"])
+
+                lines = sorted(lines, key=itemgetter("name"))
+                if len({line["point"] for line in lines}) > 1:
+                    trueline = sorted(lines, key=(lambda x: np.abs(x["price"] - 2)))[0]["point"]
+                    lines = [line for line in lines if line["point"] == trueline]
+                if len(lines) > 2:
+                    lines = [
+                        next(line for line in lines if line["name"] == "Over"),
+                        next(line for line in lines if line["name"] == "Under"),
+                    ]
+                if len(lines) == 1 and lines[0]["name"] == "Under":
+                    lines[0]["name"] = "Over"
+                    under = lines[0]["price"]
+                    lines[0]["price"] = under / (under - 1)
+
+                line = lines[0].get("point", 0.5)
+                odds[market_name][player]["Lines"].append(line)
+                price = no_vig_odds(*[x["price"] for x in lines])
+                ev = get_ev(line, price[1], stat_cv[league].get(market_name, 1))
+
+                odds[market_name][player]["EV"][book["key"]] = ev
+
+    for market in odds:
+        archive._mark_changed(league, market)
+        archive[league].setdefault(market, {}).setdefault(gameDate, {})
+        for player in odds[market]:
+            archive[league][market][gameDate].setdefault(player, {"EV": {}, "Lines": []})
+            archive[league][market][gameDate][player]["EV"].update(odds[market][player]["EV"])
+
+            line = np.median(odds[market][player]["Lines"])
+            if line not in archive[league][market][gameDate][player]["Lines"]:
+                archive[league][market][gameDate][player]["Lines"].append(line)
+
+    for market in totals:
+        archive._mark_changed(league, market)
+        archive[league].setdefault(market, {}).setdefault(gameDate, {})
+
+        archive[league][market][gameDate][
+            abbreviations[league][remove_accents(game["home_team"])]
+        ] = {k: (v + spread_home.get(k, 0)) / 2 for k, v in totals[market].items()}
+        archive[league][market][gameDate][
+            abbreviations[league][remove_accents(game["away_team"])]
+        ] = {k: (v + spread_away.get(k, 0)) / 2 for k, v in totals[market].items()}
+
+
+def _prune_upcoming_events(events):
+    """Drop events whose commence_time is in the past (UTC)."""
+    now = datetime.now(pytz.utc)
+    keep = []
+    for e in events:
+        try:
+            ts = datetime.fromisoformat(e["commence_time"].replace("Z", "+00:00"))
+        except (ValueError, KeyError, AttributeError):
+            continue
+        if ts.astimezone(pytz.utc) > now:
+            keep.append(e)
+    return keep
+
+
+def _close_lines_pass(apikey, props):
+    """Per-event close-line scrape. Exits early when the window is empty.
+
+    Loads ``data/upcoming_events.json``, filters to events with a
+    ``commence_time`` between ``CLOSING_LEAD_MIN`` and ``CLOSING_LEAD_MAX``
+    minutes from now, and only then opens ``Archive`` and hits the per-event
+    Odds API endpoint for each. Past-commence entries are pruned on the way
+    out so the ledger stays small. The five-minute cron tick yields no
+    archive read, no API call, and no log noise on empty windows — the
+    intended common case.
+    """
+    ledger = read_upcoming_events()
+    ledger = _prune_upcoming_events(ledger)
+
+    now = datetime.now(pytz.utc)
+    window_start = now + timedelta(minutes=CLOSING_LEAD_MIN)
+    window_end = now + timedelta(minutes=CLOSING_LEAD_MAX)
+
+    due = []
+    for e in ledger:
+        try:
+            ts = datetime.fromisoformat(e["commence_time"].replace("Z", "+00:00"))
+        except (ValueError, KeyError, AttributeError):
+            continue
+        ts_utc = ts.astimezone(pytz.utc)
+        if window_start <= ts_utc <= window_end:
+            due.append(e)
+
+    if not due:
+        write_upcoming_events(ledger)
+        return
+
+    logger.info(f"close-lines: {len(due)} event(s) due")
+    archive = Archive()
+    params = {"apiKey": apikey, "regions": "us"}
+
+    for e in due:
+        sport_key = e["sport_key"]
+        event_id = e["event_id"]
+        league = e["league"]
+        markets = e.get("markets") or list(props.get(league, {}).keys())
+        if not markets:
+            continue
+        event_params = {**params, "markets": ",".join(markets)}
+        res = _get_with_retry(
+            ODDS_API_EVENT_ODDS_URL.format(sport=sport_key, eventId=event_id),
+            params=event_params,
+        )
+        if res.status_code != 200:
+            logger.warning(f"close-lines: {league} {event_id} returned status {res.status_code}")
+            continue
+        game = res.json()
+        gameDate = (
+            datetime.fromisoformat(e["commence_time"].replace("Z", "+00:00"))
+            .astimezone(pytz.timezone("America/Chicago"))
+            .strftime("%Y-%m-%d")
+        )
+        _archive_event_props(archive, game, league, props, gameDate)
+
+    archive.write()
+    write_upcoming_events(_prune_upcoming_events(ledger))
+    logger.info("close-lines: archive updated")
 
 
 if __name__ == "__main__":

--- a/src/sportstradamus/nightly.py
+++ b/src/sportstradamus/nightly.py
@@ -2,9 +2,10 @@
 
 Runs after games finish to:
 1. Fetch latest stats from league APIs (update)
-2. Fill in Actual column in history.dat
-3. Fill in Legs/Misses columns in parlay_hist.dat
-4. Write resolve_meta.json with last-run timestamp
+2. Fill in Actual column in history (parquet primary, .dat fallback)
+3. Fill in Legs/Misses columns in parlay_hist
+4. Fill in Close Books P / Market CLV / Model CLV per offer
+5. Write resolve_meta.json with last-run timestamp
 
 Schedule with cron after games finish, e.g.:
     0 2 * * * cd /home/trevor/Sportstradamus && poetry run reflect
@@ -17,11 +18,17 @@ from datetime import datetime
 
 import click
 import numpy as np
-import pandas as pd
 from tqdm import tqdm
 
-from sportstradamus import data
+from sportstradamus import clv, data
 from sportstradamus.analysis import check_bet, resolve_history
+from sportstradamus.helpers import Archive
+from sportstradamus.helpers.io import (
+    read_history,
+    read_parlay_hist,
+    write_history,
+    write_parlay_hist,
+)
 from sportstradamus.stats import StatsMLB, StatsNBA, StatsNFL, StatsNHL, StatsWNBA
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
@@ -78,16 +85,17 @@ def run(league, skip_update, history_only):
         raise SystemExit(1)
 
     # ------------------------------------------------------------------
-    # 2. Resolve history.dat (fill Actual column)
+    # 2. Resolve history (fill Actual column + CLV trio)
     # ------------------------------------------------------------------
-    history_path = pkg_resources.files(data) / "history.dat"
-    history = pd.read_pickle(history_path)
+    history = read_history()
+    if history.empty:
+        logger.error("history.parquet/.dat is empty or missing. Aborting.")
+        raise SystemExit(1)
 
     if "Offers" not in history.columns:
-        # Migrate old flat schema first
         from sportstradamus.analysis import _migrate_flat_history
 
-        logger.info("Migrating history.dat to normalized schema")
+        logger.info("Migrating history to normalized schema")
         history = _migrate_flat_history(history)
 
     if "Actual" not in history.columns:
@@ -96,17 +104,38 @@ def run(league, skip_update, history_only):
     n_before_hist = int(history["Actual"].isna().sum())
     logger.info(f"Resolving {n_before_hist} pending history rows")
     history = resolve_history(history, stats)
-    history.to_pickle(history_path)
     n_resolved_hist = n_before_hist - int(history["Actual"].isna().sum())
     logger.info(f"History: resolved {n_resolved_hist} / {n_before_hist} pending rows")
 
+    # Load Archive once and fold closing-line values into every offer.
+    archive = Archive()
+    history = clv.fill_from_archive(history, archive)
+    write_history(history)
+
+    clv_summary = clv.summarize(history)
+    if clv_summary["n"]:
+        logger.info(
+            "CLV legs: %d  Market CLV mean: %+.3f  Model CLV mean: %+.3f  beat-close: %.1f%%",
+            clv_summary["n"],
+            clv_summary["market_clv_mean"],
+            clv_summary["model_clv_mean"],
+            100.0 * clv_summary["frac_beat_close"],
+        )
+        if not clv_summary["segments"].empty:
+            logger.info(
+                "CLV segments (n>=%d):\n%s",
+                clv.CLV_SEGMENT_MIN_N,
+                clv_summary["segments"].to_string(index=False),
+            )
+    else:
+        logger.info("CLV: no resolved legs with closing-line data")
+
     # ------------------------------------------------------------------
-    # 3. Resolve parlay_hist.dat (fill Legs/Misses columns)
+    # 3. Resolve parlay_hist (fill Legs/Misses columns)
     # ------------------------------------------------------------------
     n_resolved_parl = 0
     if not history_only:
-        parlay_path = pkg_resources.files(data) / "parlay_hist.dat"
-        parlays = pd.read_pickle(parlay_path)
+        parlays = read_parlay_hist()
         stat_map = json.loads((pkg_resources.files(data) / "stat_map.json").read_text())
 
         unresolved = parlays.loc[parlays["Legs"].isna()]
@@ -119,7 +148,7 @@ def run(league, skip_update, history_only):
                 lambda bet: check_bet(bet, stats, stat_map), axis=1
             ).tolist()
             parlays.loc[parlays["Legs"].isna(), ["Legs", "Misses"]] = results
-            parlays.to_pickle(parlay_path)
+            write_parlay_hist(parlays)
             n_resolved_parl = sum(
                 1 for legs, _ in results if not (isinstance(legs, float) and np.isnan(legs))
             )

--- a/src/sportstradamus/prediction/cli.py
+++ b/src/sportstradamus/prediction/cli.py
@@ -28,9 +28,15 @@ from google.oauth2.credentials import Credentials
 from google_auth_oauthlib.flow import InstalledAppFlow
 from tqdm import tqdm
 
-from sportstradamus import creds, data
+from sportstradamus import creds
 from sportstradamus.books import get_sleeper, get_ud
 from sportstradamus.helpers import Archive, stat_map
+from sportstradamus.helpers.io import (
+    read_history,
+    read_parlay_hist,
+    write_history,
+    write_parlay_hist,
+)
 from sportstradamus.prediction.scoring import process_offers
 from sportstradamus.prediction.sheets import save_data
 from sportstradamus.spiderLogger import logger
@@ -201,22 +207,20 @@ def main(progress):
         wks = gc.open("Sportstradamus").worksheet("Parlay Search")
         wks.batch_clear(["J7:J50"])
 
-        filepath = pkg_resources.files(data) / "parlay_hist.dat"
-        if os.path.isfile(filepath):
-            old5 = pd.read_pickle(filepath)
+        old5 = read_parlay_hist()
+        if not old5.empty:
             parlay_df = pd.concat([parlay_df, old5], ignore_index=True).drop_duplicates(
                 subset=["Model EV", "Books EV"], ignore_index=True
             )
 
-        parlay_df.to_pickle(filepath)
+        write_parlay_hist(parlay_df)
 
     archive.write()
     logger.info("Checking historical predictions")
     from sportstradamus.analysis import _merge_offers, _migrate_flat_history
 
-    filepath = pkg_resources.files(data) / "history.dat"
-    if os.path.isfile(filepath):
-        history = pd.read_pickle(filepath)
+    history = read_history()
+    if not history.empty:
         if "Offers" not in history.columns:
             history = _migrate_flat_history(history)
     else:
@@ -277,6 +281,11 @@ def main(progress):
                     str(r.get("Bet", "")),
                     float(r["Model P"]) if pd.notna(r.get("Model P")) else np.nan,
                     float(r["Books P"]) if pd.notna(r.get("Books P")) else np.nan,
+                    # Closing fields are filled by `reflect` once the game
+                    # locks; left NaN at prediction time.
+                    np.nan,
+                    np.nan,
+                    np.nan,
                 )
             )
         row = {"Player": player, "League": league, "Date": date, "Market": market, "Offers": offers}
@@ -314,7 +323,7 @@ def main(progress):
     history = history.loc[
         (datetime.datetime.today().date() - datetime.timedelta(days=365)) <= gameDates
     ]
-    history.to_pickle(filepath)
+    write_history(history)
 
     logger.info("Success!")
 

--- a/tests/golden/fixtures/confer_help.txt
+++ b/tests/golden/fixtures/confer_help.txt
@@ -3,4 +3,8 @@ Usage: confer [OPTIONS]
   Fetch current odds and player props into the archive.
 
 Options:
-  --help  Show this message and exit.
+  --close-lines  Targeted close-line scrape only. Reads
+                 data/upcoming_events.json and hits per-event endpoints for
+                 games starting within the closing window. Exits without
+                 touching archive or API when no events are due.
+  --help         Show this message and exit.

--- a/tests/golden/test_clv_explode.py
+++ b/tests/golden/test_clv_explode.py
@@ -1,0 +1,111 @@
+"""Snapshot test for ``analysis.explode_offers`` with the 9-tuple Offers shape.
+
+Verifies that the closing trio (Close Books P, Market CLV, Model CLV)
+surfaces as columns alongside the open Model P / Books P / Bet etc.
+Also confirms backward compatibility: legacy 6-tuple offers explode with
+NaN closing fields rather than crashing.
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pandas as pd
+
+from sportstradamus.analysis import explode_offers
+
+
+def _build_fixture():
+    return pd.DataFrame(
+        [
+            {
+                "Player": "Player A",
+                "League": "NBA",
+                "Team": "BOS",
+                "Date": "2026-05-04",
+                "Market": "points",
+                "Actual": 22,
+                "Offers": [
+                    # Resolved 9-tuple with full CLV trio
+                    (
+                        18.5,
+                        1.0,
+                        "Underdog",
+                        "Over",
+                        0.60,
+                        0.55,
+                        0.62,
+                        0.07,
+                        0.02,
+                    ),
+                ],
+            },
+            {
+                "Player": "Player B",
+                "League": "NBA",
+                "Team": "MIA",
+                "Date": "2026-05-04",
+                "Market": "rebounds",
+                "Actual": 8,
+                "Offers": [
+                    # Legacy 6-tuple — must pad to NaN closing trio.
+                    (5.5, 1.0, "Sleeper", "Over", 0.58, 0.52),
+                ],
+            },
+        ]
+    )
+
+
+def test_explode_offers_surfaces_clv_columns():
+    df = explode_offers(_build_fixture())
+
+    expected_cols = {
+        "Line",
+        "Boost",
+        "Platform",
+        "Bet",
+        "Model P",
+        "Books P",
+        "Close Books P",
+        "Market CLV",
+        "Model CLV",
+        "Result",
+    }
+    assert expected_cols.issubset(df.columns)
+
+
+def test_explode_offers_preserves_resolved_clv():
+    df = explode_offers(_build_fixture())
+    row = df.loc[df["Player"] == "Player A"].iloc[0]
+    assert row["Close Books P"] == 0.62
+    assert row["Market CLV"] == 0.07
+    assert row["Model CLV"] == 0.02
+    assert row["Result"] == "Over"
+
+
+def test_explode_offers_pads_legacy_six_tuple_with_nan():
+    df = explode_offers(_build_fixture())
+    row = df.loc[df["Player"] == "Player B"].iloc[0]
+    assert math.isnan(row["Close Books P"])
+    assert math.isnan(row["Market CLV"])
+    assert math.isnan(row["Model CLV"])
+    assert row["Bet"] == "Over"
+    assert row["Model P"] == 0.58
+
+
+def test_explode_offers_handles_empty_offers_list():
+    df = pd.DataFrame(
+        [
+            {
+                "Player": "Empty",
+                "League": "NBA",
+                "Date": "2026-05-04",
+                "Market": "points",
+                "Actual": np.nan,
+                "Offers": [],
+            }
+        ]
+    )
+    out = explode_offers(df)
+    assert out.empty

--- a/tests/test_clv.py
+++ b/tests/test_clv.py
@@ -1,0 +1,125 @@
+"""Unit tests for the CLV fill / summary helpers in ``sportstradamus.clv``."""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from sportstradamus import clv
+
+
+class _StubArchive:
+    """Minimal stub that mirrors ``Archive.get_ev``'s lookup contract."""
+
+    def __init__(self, table):
+        self._table = table
+
+    def get_ev(self, league, market, date, player):
+        return self._table.get((league, market, date, player), float("nan"))
+
+
+def test_signed_clv_over_uses_positive_sign():
+    assert clv._signed_clv(0.50, 0.55, "Over") == pytest.approx(0.05)
+
+
+def test_signed_clv_under_flips_sign():
+    assert clv._signed_clv(0.50, 0.55, "Under") == pytest.approx(-0.05)
+
+
+def test_signed_clv_higher_is_over_synonym():
+    assert clv._signed_clv(0.40, 0.45, "Higher") == pytest.approx(0.05)
+
+
+def test_signed_clv_returns_nan_when_open_is_nan():
+    assert math.isnan(clv._signed_clv(float("nan"), 0.55, "Over"))
+
+
+def test_signed_clv_returns_nan_when_close_is_nan():
+    assert math.isnan(clv._signed_clv(0.55, float("nan"), "Under"))
+
+
+def _build_history():
+    """One Over leg with archive coverage, one Under leg without."""
+    return pd.DataFrame(
+        [
+            {
+                "Player": "Player A",
+                "League": "NBA",
+                "Date": "2026-05-04",
+                "Market": "points",
+                "Offers": [
+                    (10.5, 1.0, "Underdog", "Over", 0.60, 0.55, np.nan, np.nan, np.nan),
+                ],
+            },
+            {
+                "Player": "Player B",
+                "League": "NBA",
+                "Date": "2026-05-04",
+                "Market": "points",
+                "Offers": [
+                    (12.5, 1.0, "Underdog", "Under", 0.48, 0.50, np.nan, np.nan, np.nan),
+                ],
+            },
+        ]
+    )
+
+
+def test_fill_from_archive_writes_close_and_clv_for_resolved_leg():
+    archive = _StubArchive({("NBA", "points", "2026-05-04", "Player A"): 0.62})
+    df = clv.fill_from_archive(_build_history(), archive)
+
+    offer = df.loc[0, "Offers"][0]
+    assert offer[6] == pytest.approx(0.62)
+    # Market CLV = +1 * (0.62 - 0.55) = 0.07
+    assert offer[7] == pytest.approx(0.07)
+    # Model CLV = +1 * (0.62 - 0.60) = 0.02
+    assert offer[8] == pytest.approx(0.02)
+
+
+def test_fill_from_archive_leaves_unresolved_leg_nan():
+    archive = _StubArchive({("NBA", "points", "2026-05-04", "Player A"): 0.62})
+    df = clv.fill_from_archive(_build_history(), archive)
+
+    offer = df.loc[1, "Offers"][0]
+    assert math.isnan(offer[6])
+    assert math.isnan(offer[7])
+    assert math.isnan(offer[8])
+
+
+def test_fill_from_archive_pads_legacy_six_tuple():
+    archive = _StubArchive({("NBA", "points", "2026-05-04", "Player A"): 0.60})
+    legacy = pd.DataFrame(
+        [
+            {
+                "Player": "Player A",
+                "League": "NBA",
+                "Date": "2026-05-04",
+                "Market": "points",
+                "Offers": [(10.5, 1.0, "Underdog", "Over", 0.55, 0.50)],
+            }
+        ]
+    )
+    out = clv.fill_from_archive(legacy, archive)
+    offer = out.loc[0, "Offers"][0]
+    assert len(offer) == 9
+    assert offer[6] == pytest.approx(0.60)
+
+
+def test_summarize_drops_unresolved_legs():
+    archive = _StubArchive({("NBA", "points", "2026-05-04", "Player A"): 0.62})
+    df = clv.fill_from_archive(_build_history(), archive)
+
+    summary = clv.summarize(df)
+    assert summary["n"] == 1
+    assert summary["market_clv_mean"] == pytest.approx(0.07)
+    assert summary["model_clv_mean"] == pytest.approx(0.02)
+    assert summary["frac_beat_close"] == pytest.approx(1.0)
+
+
+def test_summarize_returns_zero_n_when_no_legs():
+    summary = clv.summarize(pd.DataFrame({"Offers": [[]], "League": ["NBA"], "Market": ["points"]}))
+    assert summary["n"] == 0
+    assert math.isnan(summary["market_clv_mean"])


### PR DESCRIPTION
## Summary

Captures Closing Line Value per offer without burning the user's
4-broad-`confer`-runs/day Odds API budget. Three pieces:

- **`Offers` tuple grows 6 → 9 fields** — adds `Close Books P`, `Market CLV`, `Model CLV`. Legacy 6-tuples are zero-padded with NaN on read so existing `history` rows keep working transparently.
- **`confer --close-lines`** is a new flag on the existing CLI. It reads `data/upcoming_events.json` (a tiny ledger refreshed by every broad `confer` run) and only fires per-event Odds API calls for games starting within `[+5min, +25min]`. Empty windows return before touching the archive or the network — safe to cron every 5 minutes during American-sports hours. Intended crontab is in the module docstring.
- **`reflect` calls `clv.fill_from_archive`** after `resolve_history`, reads each offer's close from `Archive.get_ev` (the last prematch sample before kickoff stays in archive because in-progress games drop out of prematch endpoints), and logs mean Market/Model CLV plus a per-`(League, Market, Platform)` segment table.

Also migrates `history` / `parlay_hist` reads & writes to parquet via a new `helpers/io.py` (parquet primary, `.dat` fallback) to stay aligned with the parquet conversion on `feature/dashboard`.

Supersedes #15 — same commits, branch renamed and retargeted at `devel`.

## Math

Per leg, in no-vig probability units:

```
sign       = +1 if Bet in {"Over",  "Higher"} else -1
Market CLV = sign * (Close Books P - Open Books P)
Model CLV  = sign * (Close Books P - Open Model P)
```

## What's deferred

- Backfilling `Commence` into legacy rows from each league's `Stats.gamelog` so old predictions can be retroactively segmented by lead-time. The core CLV path doesn't need it because `Archive.get_ev` already returns the close at `reflect` time.
- Bootstrap CIs around mean CLV, drift alerts, model-SHA segmentation, dashboard time-series view.

## Test plan

- [ ] `poetry run pytest tests/test_clv.py` — unit tests for `_signed_clv` (sign flips, NaN propagation), `fill_from_archive` (writes the trio, leaves unresolved legs NaN, pads legacy 6-tuples), and `summarize` (drops unresolved legs).
- [ ] `poetry run pytest tests/golden/` — golden tests including the new `test_clv_explode.py` and the regenerated `confer_help.txt` snapshot.
- [ ] `poetry run ruff check src/sportstradamus/` (touched files clean; pre-existing scripts/ errors unchanged from `devel`).
- [ ] Sanity-check `poetry run confer --close-lines` once on an empty ledger and confirm it returns instantly without API calls.
- [ ] After a few days of close-line samples accumulate, eyeball `reflect`'s mean CLV by league.

https://claude.ai/code/session_01Herx7mJ9K9vSFY266Y15s3

---
_Generated by [Claude Code](https://claude.ai/code/session_01Herx7mJ9K9vSFY266Y15s3)_