### PR TITLE
Add structured JSON logging to CLI entry points

### DIFF
--- a/src/sportstradamus/helpers/__init__.py
+++ b/src/sportstradamus/helpers/__init__.py
@@ -54,6 +54,7 @@ from sportstradamus.helpers.distributions import (
     prob_to_odds,
     set_model_start_values,
 )
+from sportstradamus.helpers.logging import JsonFormatter, get_logger
 from sportstradamus.helpers.scraping import Scrape
 from sportstradamus.helpers.text import (
     get_mlb_pitchers,
@@ -65,6 +66,7 @@ from sportstradamus.helpers.text import (
 
 __all__ = [
     "Archive",
+    "JsonFormatter",
     "Scrape",
     "abbreviations",
     "banned",
@@ -76,6 +78,7 @@ __all__ = [
     "fit_distro",
     "fused_loc",
     "get_ev",
+    "get_logger",
     "get_mlb_pitchers",
     "get_odds",
     "get_push_prob",

--- a/src/sportstradamus/helpers/logging.py
+++ b/src/sportstradamus/helpers/logging.py
@@ -1,0 +1,127 @@
+"""Structured JSON logging for CLI entry points.
+
+Each CLI calls :func:`get_logger` once at startup. The returned
+:class:`logging.Logger` writes one JSON record per line to
+``logs/{YYYY-MM-DD}/{cli_name}.jsonl`` (rotating at 50 MB) and mirrors
+``WARNING``/``ERROR`` records to ``stderr`` in plain text.
+
+Stdlib ``logging`` only — no third-party logging libraries.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sys
+from datetime import datetime
+from logging.handlers import RotatingFileHandler
+from pathlib import Path
+
+# Rotation cap for the JSONL file handler. 50 MB matches the spec; the
+# default 1 backup is enough for daily rotation since the date stamp in
+# the path already partitions logs by day.
+_MAX_BYTES = 50 * 1024 * 1024
+_BACKUP_COUNT = 5
+
+# Fields that ``logging.LogRecord`` always carries. Anything not in this
+# set is treated as a caller-supplied ``extra=`` and serialized into the
+# JSON record.
+_RESERVED_RECORD_FIELDS = frozenset(
+    {
+        "args",
+        "asctime",
+        "created",
+        "exc_info",
+        "exc_text",
+        "filename",
+        "funcName",
+        "levelname",
+        "levelno",
+        "lineno",
+        "message",
+        "module",
+        "msecs",
+        "msg",
+        "name",
+        "pathname",
+        "process",
+        "processName",
+        "relativeCreated",
+        "stack_info",
+        "taskName",
+        "thread",
+        "threadName",
+    }
+)
+
+
+class JsonFormatter(logging.Formatter):
+    """Format records as one JSON object per line.
+
+    Emits the fixed fields ``ts``, ``level``, ``module``, ``message`` and
+    folds any caller-supplied ``extra={...}`` keys into the same record.
+    """
+
+    def format(self, record: logging.LogRecord) -> str:
+        """Serialize ``record`` as a JSON line."""
+        payload: dict[str, object] = {
+            "ts": datetime.fromtimestamp(record.created).isoformat(timespec="microseconds"),
+            "level": record.levelname,
+            "module": record.module,
+            "message": record.getMessage(),
+        }
+        for key, value in record.__dict__.items():
+            if key in _RESERVED_RECORD_FIELDS or key.startswith("_"):
+                continue
+            payload[key] = value
+        if record.exc_info:
+            payload["exc_info"] = self.formatException(record.exc_info)
+        return json.dumps(payload, default=str)
+
+
+def _log_dir() -> Path:
+    """Return ``logs/{YYYY-MM-DD}/`` rooted at the current working directory."""
+    return Path("logs") / datetime.now().strftime("%Y-%m-%d")
+
+
+def get_logger(name: str) -> logging.Logger:
+    """Return a configured logger for the given CLI name.
+
+    The logger writes JSON lines to ``logs/{YYYY-MM-DD}/{name}.jsonl`` with
+    rotation at 50 MB, and additionally writes ``WARNING``/``ERROR`` records
+    in plain text to ``stderr``. Repeated calls with the same ``name``
+    return the same logger without stacking handlers.
+
+    Args:
+        name: CLI identifier used as both the logger name and the log
+            file basename (e.g. ``"confer"``, ``"meditate"``).
+
+    Returns:
+        A ``logging.Logger`` ready for use.
+    """
+    logger = logging.getLogger(f"sportstradamus.cli.{name}")
+    if getattr(logger, "_sportstradamus_configured", False):
+        return logger
+
+    log_dir = _log_dir()
+    log_dir.mkdir(parents=True, exist_ok=True)
+
+    file_handler = RotatingFileHandler(
+        log_dir / f"{name}.jsonl",
+        maxBytes=_MAX_BYTES,
+        backupCount=_BACKUP_COUNT,
+        encoding="utf-8",
+    )
+    file_handler.setLevel(logging.DEBUG)
+    file_handler.setFormatter(JsonFormatter())
+
+    stderr_handler = logging.StreamHandler(stream=sys.stderr)
+    stderr_handler.setLevel(logging.WARNING)
+    stderr_handler.setFormatter(logging.Formatter("%(levelname)s %(name)s: %(message)s"))
+
+    logger.addHandler(file_handler)
+    logger.addHandler(stderr_handler)
+    logger.setLevel(logging.INFO)
+    logger.propagate = False
+    logger._sportstradamus_configured = True  # type: ignore[attr-defined]
+    return logger

--- a/src/sportstradamus/moneylines.py
+++ b/src/sportstradamus/moneylines.py
@@ -41,6 +41,7 @@ from sportstradamus.helpers import (
     Archive,
     abbreviations,
     get_ev,
+    get_logger,
     no_vig_odds,
     remove_accents,
     stat_cv,
@@ -99,8 +100,17 @@ def _get_with_retry(url, params=None):
         "Exits without touching archive or API when no events are due."
     ),
 )
-def confer(close_lines: bool):
+@click.option(
+    "--log-level",
+    type=click.Choice(["DEBUG", "INFO", "WARNING", "ERROR"]),
+    default="INFO",
+    help="Verbosity for the structured JSONL log.",
+)
+def confer(close_lines: bool, log_level: str):
     """Fetch current odds and player props into the archive."""
+    cli_log = get_logger("confer")
+    cli_log.setLevel(log_level)
+    cli_log.info("confer invoked", extra={"close_lines": close_lines})
     filepath = pkg_resources.files(creds) / "keys.json"
     with open(filepath) as infile:
         keys = json.load(infile)

--- a/src/sportstradamus/nightly.py
+++ b/src/sportstradamus/nightly.py
@@ -13,7 +13,6 @@ Schedule with cron after games finish, e.g.:
 
 import importlib.resources as pkg_resources
 import json
-import logging
 from datetime import datetime
 
 import click
@@ -22,7 +21,7 @@ from tqdm import tqdm
 
 from sportstradamus import clv, data
 from sportstradamus.analysis import check_bet, resolve_history
-from sportstradamus.helpers import Archive
+from sportstradamus.helpers import Archive, get_logger
 from sportstradamus.helpers.io import (
     read_history,
     read_parlay_hist,
@@ -31,8 +30,7 @@ from sportstradamus.helpers.io import (
 )
 from sportstradamus.stats import StatsMLB, StatsNBA, StatsNFL, StatsNHL, StatsWNBA
 
-logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
-logger = logging.getLogger(__name__)
+logger = get_logger("reflect")
 
 LEAGUE_CLASSES = {
     "NBA": StatsNBA,
@@ -54,8 +52,19 @@ LEAGUE_CLASSES = {
 @click.option(
     "--history-only", is_flag=True, default=False, help="Skip parlay resolution (much faster)."
 )
-def run(league, skip_update, history_only):
+@click.option(
+    "--log-level",
+    type=click.Choice(["DEBUG", "INFO", "WARNING", "ERROR"]),
+    default="INFO",
+    help="Verbosity for the structured JSONL log.",
+)
+def run(league, skip_update, history_only, log_level):
     """Nightly resolution: update stats, fill Actual/Legs/Misses, save."""
+    logger.setLevel(log_level)
+    logger.info(
+        "reflect invoked",
+        extra={"league": league, "skip_update": skip_update, "history_only": history_only},
+    )
     # ------------------------------------------------------------------
     # 1. Load league Stats objects (optionally with update)
     # ------------------------------------------------------------------

--- a/src/sportstradamus/prediction/cli.py
+++ b/src/sportstradamus/prediction/cli.py
@@ -30,7 +30,7 @@ from tqdm import tqdm
 
 from sportstradamus import creds
 from sportstradamus.books import get_sleeper, get_ud
-from sportstradamus.helpers import Archive, stat_map
+from sportstradamus.helpers import Archive, get_logger, stat_map
 from sportstradamus.helpers.io import (
     read_history,
     read_parlay_hist,
@@ -110,9 +110,21 @@ def _authorize_sheets():
         "matches the legacy ranking line."
     ),
 )
+@click.option(
+    "--log-level",
+    type=click.Choice(["DEBUG", "INFO", "WARNING", "ERROR"]),
+    default="INFO",
+    help="Verbosity for the structured JSONL log.",
+)
 @line_profiler.profile
-def main(progress, legacy_correlation, contest_variant):
+def main(progress, legacy_correlation, contest_variant, log_level):
     """Run the full prediction pipeline and write results to Google Sheets."""
+    cli_log = get_logger("prophecize")
+    cli_log.setLevel(log_level)
+    cli_log.info(
+        "prophecize invoked",
+        extra={"contest_variant": contest_variant, "legacy_correlation": legacy_correlation},
+    )
     tqdm.__init__ = partialmethod(tqdm.__init__, disable=(not progress))
 
     gc = _authorize_sheets()

--- a/src/sportstradamus/training/cli.py
+++ b/src/sportstradamus/training/cli.py
@@ -9,7 +9,7 @@ import click
 import numpy as np
 
 from sportstradamus import data
-from sportstradamus.helpers import Archive, book_weights, feature_filter
+from sportstradamus.helpers import Archive, book_weights, feature_filter, get_logger
 from sportstradamus.stats import StatsNBA, StatsNFL, StatsWNBA
 from sportstradamus.training.calibration import fit_book_weights
 from sportstradamus.training.correlate import correlate
@@ -51,8 +51,25 @@ np.seterr(divide="ignore", invalid="ignore")
     default=False,
     help="Rebuild only the per-league correlation matrices and exit; skip the per-market training loop",
 )
-def meditate(force, league, rebuild_filter, reset_markets, rebuild_correlations):
+@click.option(
+    "--log-level",
+    type=click.Choice(["DEBUG", "INFO", "WARNING", "ERROR"]),
+    default="INFO",
+    help="Verbosity for the structured JSONL log.",
+)
+def meditate(force, league, rebuild_filter, reset_markets, rebuild_correlations, log_level):
     """Train or retrain LightGBMLSS models for each configured market."""
+    log = get_logger("meditate")
+    log.setLevel(log_level)
+    log.info(
+        "meditate invoked",
+        extra={
+            "force": force,
+            "league": league,
+            "rebuild_filter": rebuild_filter,
+            "rebuild_correlations": rebuild_correlations,
+        },
+    )
     np.random.seed(69)
 
     if reset_markets.strip():
@@ -68,7 +85,7 @@ def meditate(force, league, rebuild_filter, reset_markets, rebuild_correlations)
             ff.setdefault(lg, {}).setdefault("Filtered", {})
             if mk in ff[lg]["Filtered"]:
                 del ff[lg]["Filtered"][mk]
-                print(f"Reset filter for {lg}:{mk}")
+                log.info("Reset filter", extra={"league": lg, "market": mk})
         with open(ff_path, "w") as fh:
             json.dump(ff, fh, indent=4)
         # Reload module-level feature_filter so this run sees the change

--- a/tests/golden/fixtures/confer_help.txt
+++ b/tests/golden/fixtures/confer_help.txt
@@ -3,8 +3,11 @@ Usage: confer [OPTIONS]
   Fetch current odds and player props into the archive.
 
 Options:
-  --close-lines  Targeted close-line scrape only. Reads
-                 data/upcoming_events.json and hits per-event endpoints for
-                 games starting within the closing window. Exits without
-                 touching archive or API when no events are due.
-  --help         Show this message and exit.
+  --close-lines                   Targeted close-line scrape only. Reads
+                                  data/upcoming_events.json and hits per-event
+                                  endpoints for games starting within the
+                                  closing window. Exits without touching archive
+                                  or API when no events are due.
+  --log-level [DEBUG|INFO|WARNING|ERROR]
+                                  Verbosity for the structured JSONL log.
+  --help                          Show this message and exit.

--- a/tests/golden/fixtures/meditate_help.txt
+++ b/tests/golden/fixtures/meditate_help.txt
@@ -19,4 +19,6 @@ Options:
                                   Rebuild only the per-league correlation
                                   matrices and exit; skip the per-market
                                   training loop
+  --log-level [DEBUG|INFO|WARNING|ERROR]
+                                  Verbosity for the structured JSONL log.
   --help                          Show this message and exit.

--- a/tests/golden/fixtures/prophecize_help.txt
+++ b/tests/golden/fixtures/prophecize_help.txt
@@ -15,4 +15,6 @@ Options:
                                   Default 'power' matches the displayed Boost
                                   column historically; 'insurance' matches the
                                   legacy ranking line.
+  --log-level [DEBUG|INFO|WARNING|ERROR]
+                                  Verbosity for the structured JSONL log.
   --help                          Show this message and exit.

--- a/tests/golden/fixtures/reflect_help.txt
+++ b/tests/golden/fixtures/reflect_help.txt
@@ -3,7 +3,10 @@ Usage: run [OPTIONS]
   Nightly resolution: update stats, fill Actual/Legs/Misses, save.
 
 Options:
-  --league TEXT   Resolve only this league (default: all).
-  --skip-update   Skip stats.update() API calls — use cached gamelogs only.
-  --history-only  Skip parlay resolution (much faster).
-  --help          Show this message and exit.
+  --league TEXT                   Resolve only this league (default: all).
+  --skip-update                   Skip stats.update() API calls — use cached
+                                  gamelogs only.
+  --history-only                  Skip parlay resolution (much faster).
+  --log-level [DEBUG|INFO|WARNING|ERROR]
+                                  Verbosity for the structured JSONL log.
+  --help                          Show this message and exit.


### PR DESCRIPTION
## Summary

- New `helpers/logging.get_logger(name)` returns a stdlib logger that writes JSON lines to `logs/{YYYY-MM-DD}/{cli_name}.jsonl` (rotating at 50 MB) and mirrors WARNING/ERROR records to stderr.
- Re-exported `get_logger` and `JsonFormatter` from `sportstradamus.helpers`.
- Added `--log-level` (`DEBUG|INFO|WARNING|ERROR`, default `INFO`) to `confer`, `meditate`, `prophecize`, and `reflect`. Each CLI emits a startup record so the JSONL file is populated on every run.
- Migrated the lone `print()` call in `training/cli.py` (`reset-markets` reset notice) to a structured logger call.
- Regenerated the four affected `--help` golden snapshots.

`freeze-close` was listed in the task but does not exist in the codebase yet — only referenced in `docs/sportstradamus_roadmap_v2.md`. Wiring deferred until that CLI lands.

## Test plan

- [x] `ruff check` clean on all modified files (and `ruff format --check` passes)
- [x] `confer --help` matches the regenerated golden snapshot byte-for-byte
- [x] Running `confer --close-lines` produces `logs/2026-05-07/confer.jsonl` containing the startup record
- [ ] Full `pytest tests/golden/` suite passes in CI (this sandbox lacks `lightgbmlss` + several config fixtures, so the suite couldn't be run locally)

https://claude.ai/code/session_01TysUFn7YmshL2iPopWn5V1

---
_Generated by [Claude Code](https://claude.ai/code/session_01TysUFn7YmshL2iPopWn5V1)_