### PR TITLE
Add cron wrapper script for pipeline jobs

### DIFF
--- a/scripts/run_job.sh
+++ b/scripts/run_job.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# Wrapper for cron-driven Sportstradamus pipelines.
+#
+# Usage:
+#   run_job.sh <job> [extra args passed through to the underlying command]
+#
+# Jobs:
+#   prophecize         poetry run prophecize
+#   confer             poetry run confer
+#   close-lines        poetry run confer --close-lines
+#   meditate           poetry run meditate
+#   reflect            poetry run reflect
+#
+# Environment (optional):
+#   HEALTHCHECK_URL_<JOB>   per-job healthchecks.io URL (e.g. HEALTHCHECK_URL_PROPHECIZE)
+#   HEALTHCHECK_URL         fallback URL used if the per-job one is unset
+#   SPORTSTRADAMUS_DIR      project root (default: parent of this script)
+#   LOG_DIR                 log directory (default: $SPORTSTRADAMUS_DIR/logs)
+#
+# Exit codes: propagates the wrapped command's exit code.
+
+set -u
+set -o pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+PROJECT_DIR="${SPORTSTRADAMUS_DIR:-$(dirname -- "$SCRIPT_DIR")}"
+LOG_DIR="${LOG_DIR:-$PROJECT_DIR/logs}"
+LOCK_DIR="${LOCK_DIR:-/tmp}"
+
+if [[ $# -lt 1 ]]; then
+    echo "usage: $(basename "$0") <prophecize|confer|close-lines|meditate|reflect> [args...]" >&2
+    exit 64
+fi
+
+JOB="$1"
+shift
+
+case "$JOB" in
+    prophecize)   CMD=(poetry run prophecize) ;;
+    confer)       CMD=(poetry run confer) ;;
+    close-lines)  CMD=(poetry run confer --close-lines) ;;
+    meditate)     CMD=(poetry run meditate) ;;
+    reflect)      CMD=(poetry run reflect) ;;
+    *)
+        echo "unknown job: $JOB" >&2
+        exit 64
+        ;;
+esac
+CMD+=("$@")
+
+mkdir -p "$LOG_DIR"
+LOG_FILE="$LOG_DIR/${JOB}.log"
+LOCK_FILE="$LOCK_DIR/sportstradamus-${JOB}.lock"
+
+# Resolve the healthcheck URL: per-job override wins, fall back to the shared one.
+job_upper="$(echo "$JOB" | tr '[:lower:]-' '[:upper:]_')"
+hc_var="HEALTHCHECK_URL_${job_upper}"
+HC_URL="${!hc_var:-${HEALTHCHECK_URL:-}}"
+
+ping_hc() {
+    local suffix="$1"  # "" for success, "/fail" for failure, "/start" for start
+    [[ -z "$HC_URL" ]] && return 0
+    curl -fsS --max-time 10 --retry 3 -o /dev/null "${HC_URL}${suffix}" || true
+}
+
+log() {
+    printf '[%s] %s\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" "$*" >>"$LOG_FILE"
+}
+
+run() {
+    log "START job=$JOB cmd=${CMD[*]}"
+    ping_hc "/start"
+
+    local start_ts end_ts duration status
+    start_ts=$(date +%s)
+    set +e
+    "${CMD[@]}" >>"$LOG_FILE" 2>&1
+    status=$?
+    set -e
+    end_ts=$(date +%s)
+    duration=$((end_ts - start_ts))
+
+    if [[ $status -eq 0 ]]; then
+        log "OK job=$JOB duration=${duration}s"
+        ping_hc ""
+    else
+        log "FAIL job=$JOB duration=${duration}s exit=$status"
+        # Send last 50 lines of the log as the failure body so the alert is useful.
+        if [[ -n "$HC_URL" ]]; then
+            tail -n 50 "$LOG_FILE" | curl -fsS --max-time 10 --retry 3 \
+                --data-binary @- -o /dev/null "${HC_URL}/fail" || true
+        fi
+    fi
+    return $status
+}
+
+cd "$PROJECT_DIR"
+
+# flock -n: bail immediately if a previous run of this same job is still going.
+exec 9>"$LOCK_FILE"
+if ! flock -n 9; then
+    log "SKIP job=$JOB reason=already_running"
+    exit 0
+fi
+
+run


### PR DESCRIPTION
## Summary
- Adds `scripts/run_job.sh` as a single entry point for cron with a `<job>` flag (`prophecize`, `confer`, `close-lines`, `meditate`, `reflect`).
- Timestamped logs in `logs/<job>.log`, `flock`-based overlap prevention, and healthchecks.io start/success/fail pings so cron failures are visible without an orchestrator.
- Concluded a full Prefect/Dagster setup isn't justified yet given the current five-job linear schedule.

## Crontab migration
Replace your existing entries with absolute paths to the wrapper:

```cron
HEALTHCHECK_URL_PROPHECIZE=https://hc-ping.com/<uuid>
HEALTHCHECK_URL_CONFER=https://hc-ping.com/<uuid>
HEALTHCHECK_URL_CLOSE_LINES=https://hc-ping.com/<uuid>
HEALTHCHECK_URL_MEDITATE=https://hc-ping.com/<uuid>
HEALTHCHECK_URL_REFLECT=https://hc-ping.com/<uuid>

50 8-20 * * *           /home/user/Sportstradamus/scripts/run_job.sh prophecize
30 8,12 * * *           /home/user/Sportstradamus/scripts/run_job.sh confer
0 1 * * 5               /home/user/Sportstradamus/scripts/run_job.sh meditate
0 23 * * *              /home/user/Sportstradamus/scripts/run_job.sh reflect
*/5 11-23,0-1 * * *     /home/user/Sportstradamus/scripts/run_job.sh close-lines
```

`HEALTHCHECK_URL` (without suffix) works as a shared fallback if you'd rather use one check.

## Test plan
- [ ] Confirm `run_job.sh prophecize` runs the pipeline end-to-end and writes `logs/prophecize.log`.
- [ ] Trigger an intentional failure (e.g. bad flag) and verify `/fail` ping fires with last 50 log lines.
- [ ] Start a long-running job and confirm a second invocation exits via `SKIP ... already_running` instead of double-running.
- [ ] Verify cron uses absolute paths and the new env vars are picked up.

https://claude.ai/code/session_01TaUtEWH8QD4F8owCpCuPcf

---
_Generated by [Claude Code](https://claude.ai/code/session_01TaUtEWH8QD4F8owCpCuPcf)_