### PR TITLE
Phase 3 session 3: explicit clv.persist_segments hook in nightly

### DIFF
--- a/src/sportstradamus/clv.py
+++ b/src/sportstradamus/clv.py
@@ -166,9 +166,11 @@ def summarize(history: pd.DataFrame) -> dict:
     df["_beat"] = (df["Market CLV"] > 0).astype(float)
     grouped = (
         df.groupby(["League", "Market", "Platform"], dropna=False)
-        .agg(n=("Market CLV", "count"),
-             market_clv=("Market CLV", "mean"),
-             frac_beat_close=("_beat", "mean"))
+        .agg(
+            n=("Market CLV", "count"),
+            market_clv=("Market CLV", "mean"),
+            frac_beat_close=("_beat", "mean"),
+        )
         .reset_index()
     )
     segments = grouped.loc[grouped["n"] >= CLV_SEGMENT_MIN_N].sort_values(

--- a/src/sportstradamus/clv.py
+++ b/src/sportstradamus/clv.py
@@ -175,23 +175,25 @@ def summarize(history: pd.DataFrame) -> dict:
         "market_clv", ascending=False
     )
 
-    _persist_segments(grouped)
-
     return {
         "n": len(df),
         "market_clv_mean": market_mean,
         "model_clv_mean": model_mean,
         "frac_beat_close": frac_beat,
         "segments": segments,
+        "all_segments": grouped,
     }
 
 
-def _persist_segments(grouped: pd.DataFrame) -> None:
+def persist_segments(grouped: pd.DataFrame) -> None:
     """Write the full per-segment frame to ``data/clv_segments.parquet``.
 
     All segments are persisted (not just the reportable ones) so the Kelly
     shrinkage getter can reason about sample size for low-n segments too.
+    Called explicitly from ``reflect`` after :func:`summarize`.
     """
+    if grouped is None or grouped.empty:
+        return
     path = _segments_parquet_path()
     path.parent.mkdir(parents=True, exist_ok=True)
     grouped.to_parquet(path, index=False)

--- a/src/sportstradamus/nightly.py
+++ b/src/sportstradamus/nightly.py
@@ -122,6 +122,7 @@ def run(league, skip_update, history_only, log_level):
     write_history(history)
 
     clv_summary = clv.summarize(history)
+    clv.persist_segments(clv_summary.get("all_segments"))
     if clv_summary["n"]:
         logger.info(
             "CLV legs: %d  Market CLV mean: %+.3f  Model CLV mean: %+.3f  beat-close: %.1f%%",

--- a/tests/golden/test_clv_close_sanity.py
+++ b/tests/golden/test_clv_close_sanity.py
@@ -119,9 +119,7 @@ def test_persist_segments_writes_parquet(_isolated_segments_parquet):
     assert {"League", "Market", "Platform", "n", "market_clv", "frac_beat_close"} <= set(
         seg_df.columns
     )
-    row = seg_df.loc[
-        (seg_df["League"] == "NBA") & (seg_df["Market"] == "points")
-    ].iloc[0]
+    row = seg_df.loc[(seg_df["League"] == "NBA") & (seg_df["Market"] == "points")].iloc[0]
     assert int(row["n"]) == 25
     assert row["frac_beat_close"] == pytest.approx(1.0)
 

--- a/tests/golden/test_clv_close_sanity.py
+++ b/tests/golden/test_clv_close_sanity.py
@@ -91,7 +91,7 @@ def test_check_close_sample_freshness_handles_empty_frame():
     assert out.empty
 
 
-def test_summarize_persists_segment_parquet(_isolated_segments_parquet):
+def test_persist_segments_writes_parquet(_isolated_segments_parquet):
     rows = []
     # 25 over-rate-1 legs in NBA/points (segment beats close every time).
     for _ in range(25):
@@ -109,6 +109,10 @@ def test_summarize_persists_segment_parquet(_isolated_segments_parquet):
     df = pd.DataFrame(rows)
     summary = clv.summarize(df)
     assert summary["n"] == 25
+    # summarize does not auto-persist; reflect calls persist_segments
+    # explicitly with the full per-segment frame.
+    assert not _isolated_segments_parquet.exists()
+    clv.persist_segments(summary["all_segments"])
     assert _isolated_segments_parquet.exists()
 
     seg_df = pd.read_parquet(_isolated_segments_parquet)


### PR DESCRIPTION
## Summary

Phase 3 Step 1.b / session 3 from `docs/PHASE_3_IMPLEMENTATION.md`.

- Move the `clv_segments.parquet` side-effect out of `clv.summarize` and into `reflect`'s call site (`nightly.py`).
- `clv.summarize` now returns the full per-segment frame under `all_segments` alongside the reporting-only `segments`.
- `clv.persist_segments` is public; the old `_persist_segments` is removed.
- `nightly.py` calls `clv.persist_segments(clv_summary["all_segments"])` immediately after `summarize`.
- Test renamed and reworked: `test_persist_segments_writes_parquet` calls `persist_segments` explicitly and asserts that `summarize` no longer auto-persists.

Behavior on disk is unchanged — same parquet, same contents — but the side-effect is now visible at the orchestration layer instead of buried inside the aggregator.

## Test plan

- [x] `poetry run ruff check src/sportstradamus/clv.py src/sportstradamus/nightly.py tests/golden/test_clv_close_sanity.py`
- [x] `pytest tests/golden/test_clv_close_sanity.py` (10/10 pass)

https://claude.ai/code/session_01Uszw3F65J7NoA19ujuvDws

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uszw3F65J7NoA19ujuvDws)_