### PR TITLE
Session 6: Prediction package exports & ruff fixes

### DIFF
--- a/src/sportstradamus/prediction/persist.py
+++ b/src/sportstradamus/prediction/persist.py
@@ -81,8 +81,8 @@ def write_current_offers(
             "leagues": sorted(set(leagues)),
             "platforms": sorted(set(platforms)),
             "contest_variant": contest_variant,
-            "offer_rows": int(len(offers_out)),
-            "parlay_rows": int(len(parlays_out)),
+            "offer_rows": len(offers_out),
+            "parlay_rows": len(parlays_out),
         },
         CURRENT_META_PATH,
     )


### PR DESCRIPTION
## Summary

Session 6 (Phase 3 Step 3) — Re-exports and import fixes for the prediction package split.

- **prediction/__init__.py**: Already correctly re-exports `beam_search_parlays` from `prediction.parlay`
- **prediction/correlation.py**: Already correctly re-exports all parlay functions for backwards compatibility
- **prediction/scoring.py**: No changes needed; correctly imports from correlation
- **Minor fix**: Remove unnecessary `int()` casts in `persist.py` (ruff RUF046)

## Test plan

- [x] All imports resolve correctly (canonical + package-level + backwards-compat)
- [x] No ruff violations
- [x] Parlay split complete from session 5; session 6 verification and ruff cleanup

https://claude.ai/code/session_01NfXRvKJZtF9t1km1cd285k

---
_Generated by [Claude Code](https://claude.ai/code/session_01NfXRvKJZtF9t1km1cd285k)_