### PR TITLE
training/report: raw-metric parquet schema + book-baseline row + Kelly getter (Phase 3 §4.c-g, session 8)

### DIFF
--- a/src/sportstradamus/training/report.py
+++ b/src/sportstradamus/training/report.py
@@ -1,4 +1,10 @@
-"""Training report generation: reads saved model pickles and writes training_report.txt."""
+"""Training report generation: reads saved model pickles and writes training_report.txt.
+
+Per Phase 3 §4.c/§4.e/§4.f/§4.g, ``model_stats.parquet`` carries the migrated
+raw-metric set plus a pinned ``row_kind="book_baseline"`` row so downstream
+consumers (Kelly, dashboard) compare against "what taking the book's odds gets
+you" rather than against a scaled Brier.
+"""
 
 import importlib.resources as pkg_resources
 import json
@@ -8,6 +14,7 @@ import numpy as np
 import pandas as pd
 
 from sportstradamus import data
+from sportstradamus.helpers import get_logger
 from sportstradamus.helpers.io import MODEL_STATS_PATH, _atomic_write_parquet
 from sportstradamus.training.config import (
     load_distribution_config,
@@ -16,18 +23,36 @@ from sportstradamus.training.config import (
     save_zi_config,
 )
 
+logger = get_logger(__name__)
+
 # Stats matrix row labels — depend on number of rows present in model["stats"].
 _STATS_ROW_LABELS_3 = ("raw", "corrected", "calibrated")
 _STATS_ROW_LABELS_2 = ("no_filter", "filter")
-# Column rename: source key in model["stats"] -> snake_case for parquet.
+# Per-row classification stats source key (model["stats"]) → snake_case parquet column.
+# Renames per Phase 3 §4.b — a clean break: old names disappear on next meditate.
 _STATS_COL_MAP = {
     "Accuracy": "accuracy",
-    "Over Prec": "over_prec",
-    "Under Prec": "under_prec",
-    "Over%": "over_pct",
-    "Sharpness": "sharpness",
+    "Over Prec": "precision_over",
+    "Under Prec": "precision_under",
+    "Over%": "predicted_over_rate",
+    "Sharpness": "prediction_std",
     "NLL": "nll",
 }
+# Validation-set raw metrics computed in pipeline.py:_compute_metrics, mirrored
+# verbatim into both the model's calibrated row and the book_baseline row.
+_RAW_METRIC_KEYS = (
+    "brier_score",
+    "log_loss",
+    "roc_auc",
+    "expected_calibration_error",
+    "accuracy",
+    "precision_over",
+    "precision_under",
+    "predicted_over_rate",
+    "empirical_over_rate",
+    "prediction_std",
+    "nll",
+)
 
 
 def report() -> None:
@@ -73,8 +98,33 @@ def report() -> None:
 
             f.write(f" {league} {market} ".center(62, "="))
             f.write("\n")
-            f.write(f" Distribution Model: {dist}\n")
-            f.write(f" Historical Zero Rate: {h_gate:.4f}\n")
+            f.write(f" Distribution: {dist} | Historical Zero Rate: {h_gate:.4f}\n")
+
+            metrics_block = model.get("metrics") or {}
+            book = metrics_block.get("book_baseline")
+            mm = metrics_block.get("model")
+            if mm is not None:
+                if book is not None:
+                    f.write(
+                        f" BOOK BASELINE  brier={book['brier_score']:.3f}"
+                        f" logloss={book['log_loss']:.3f}"
+                        f" auc={book['roc_auc']:.3f}"
+                        f" ece={book['expected_calibration_error']:.3f}\n"
+                    )
+                else:
+                    f.write(" BOOK BASELINE  unavailable\n")
+                f.write(
+                    f" MODEL          brier={mm['brier_score']:.3f}"
+                    f" logloss={mm['log_loss']:.3f}"
+                    f" auc={mm['roc_auc']:.3f}"
+                    f" ece={mm['expected_calibration_error']:.3f}\n"
+                )
+                bss = metrics_block.get("brier_skill_score", float("nan"))
+                ks = metrics_block.get("kelly_shrinkage", float("nan"))
+                bss_str = f"{bss:+.3f}" if np.isfinite(bss) else "nan"
+                ks_str = f"{ks:.3f}" if np.isfinite(ks) else "nan"
+                f.write(f" SKILL          brier_skill_score={bss_str}  kelly_shrinkage={ks_str}\n")
+
             n_rows = len(next(iter(model["stats"].values())))
             if n_rows == 3:
                 idx = ["Raw Model", "Corrected", "Calibrated"]
@@ -91,10 +141,7 @@ def report() -> None:
                 shape_ratio = (
                     mod_shape / max(emp_shape, 0.01) if not np.isnan(emp_shape) else float("nan")
                 )
-                f.write(
-                    f" DIAG model_weight={d.get('model_weight', float('nan')):.3f}"
-                    f" DIAG model_calib={d.get('model_calib', float('nan')):.3f}\n"
-                )
+                f.write(f" DIAG model_weight={d.get('model_weight', float('nan')):.3f}\n")
                 f.write(
                     f" DIAG start_{sl}={d.get('start_shape', 0.0):.3f}"
                     f" model_{sl}={mod_shape:.3f}"
@@ -186,11 +233,53 @@ def report() -> None:
     write_model_stats(league_models, stat_cv, stat_std)
 
 
+def _diag_row(model: dict, league: str, market: str, stat_cv: dict, stat_std: dict) -> dict:
+    """Diagnostic + hyperparameter columns repeated on every parquet row for the market."""
+    diag = model.get("diagnostics", {}) or {}
+    params = model.get("params", {}) or {}
+    emp_shape = diag.get("empirical_shape", float("nan"))
+    mod_shape = diag.get("model_shape", float("nan"))
+    shape_ratio = mod_shape / max(emp_shape, 0.01) if not np.isnan(emp_shape) else float("nan")
+    return {
+        "model_weight": diag.get("model_weight", float("nan")),
+        "start_shape": diag.get("start_shape", float("nan")),
+        "model_shape": mod_shape,
+        "empirical_shape": emp_shape,
+        "shape_ratio": shape_ratio,
+        "model_ev": diag.get("model_ev", float("nan")),
+        "mean_line": diag.get("mean_line", float("nan")),
+        "result_mean": diag.get("result_mean", float("nan")),
+        "mean_ev_diff": diag.get("ev_minus_line", float("nan")),
+        "median_ev_diff": diag.get("median_ev_diff", float("nan")),
+        "frac_ev_gt_line": diag.get("frac_ev_gt_line", float("nan")),
+        "over_pct_ev_gt": diag.get("over_pct_ev_gt", float("nan")),
+        "over_pct_ev_lt": diag.get("over_pct_ev_lt", float("nan")),
+        "cf_over_pct": diag.get("cf_over_pct", float("nan")),
+        "dispersion_cal": diag.get("dispersion_cal", float("nan")),
+        "marginal_shape": diag.get("marginal_shape", float("nan")),
+        "shape_ceiling": diag.get("shape_ceiling", float("nan")),
+        "hp_rounds": params.get("opt_rounds", float("nan")),
+        "hp_leaves": params.get("num_leaves", float("nan")),
+        "hp_lr": params.get("learning_rate", float("nan")),
+        "hp_min_child": params.get("min_child_samples", float("nan")),
+        "hp_l1": params.get("lambda_l1", float("nan")),
+        "hp_l2": params.get("lambda_l2", float("nan")),
+        "cv": float(stat_cv.get(league, {}).get(market, float("nan"))),
+        "std": float(stat_std.get(league, {}).get(market, float("nan"))),
+        "historical_zero_rate": model.get("hist_gate", float("nan")),
+    }
+
+
 def write_model_stats(league_models: dict, stat_cv: dict, stat_std: dict) -> None:
     """Persist a structured per-market metrics table for the dashboard.
 
-    One row per (league, market, metric_row). Diagnostics and hyperparameters
-    are repeated per metric_row so each row is self-contained for filtering.
+    Per Phase 3 §4.c: each (league, market) emits one ``row_kind="book_baseline"``
+    row carrying the metrics produced if the model *were* the bookmaker, plus
+    one ``row_kind="model"`` row per ``metric_row`` (raw / corrected / calibrated).
+    The new raw metrics from ``model["metrics"]["model"]`` (Brier, log-loss,
+    ROC-AUC, ECE, etc.) are attached to the calibrated model row only — they
+    describe the calibrated output. ``brier_skill_score`` and ``kelly_shrinkage``
+    are mirrored on the calibrated row so the Kelly getter can read one row.
     """
     rows = []
     for league, markets in league_models.items():
@@ -204,58 +293,94 @@ def write_model_stats(league_models: dict, stat_cv: dict, stat_std: dict) -> Non
                 if n_rows == 2
                 else tuple(f"row_{i}" for i in range(n_rows))
             )
-            diag = model.get("diagnostics", {}) or {}
-            params = model.get("params", {}) or {}
-            emp_shape = diag.get("empirical_shape", float("nan"))
-            mod_shape = diag.get("model_shape", float("nan"))
-            shape_ratio = (
-                mod_shape / max(emp_shape, 0.01) if not np.isnan(emp_shape) else float("nan")
-            )
+            metrics_block = model.get("metrics") or {}
+            model_metrics = metrics_block.get("model") or {}
+            book_metrics = metrics_block.get("book_baseline")
+            bss = metrics_block.get("brier_skill_score", float("nan"))
+            ks = metrics_block.get("kelly_shrinkage", float("nan"))
+            diag_cols = _diag_row(model, league, market, stat_cv, stat_std)
 
+            # --- Book baseline row (one per market) ---
+            book_row = {
+                "league": league,
+                "market": market,
+                "distribution": model.get("distribution"),
+                "row_kind": "book_baseline",
+                "metric_row": None,
+            }
+            book_row.update({k: float("nan") for k in _RAW_METRIC_KEYS})
+            if book_metrics is not None:
+                for k in _RAW_METRIC_KEYS:
+                    if k in book_metrics:
+                        book_row[k] = float(book_metrics[k])
+            book_row["brier_skill_score"] = 0.0 if book_metrics is not None else float("nan")
+            book_row["kelly_shrinkage"] = 0.0 if book_metrics is not None else float("nan")
+            book_row.update(diag_cols)
+            rows.append(book_row)
+
+            # --- Model rows (one per metric_row) ---
             for i, label in enumerate(labels):
                 row = {
                     "league": league,
                     "market": market,
                     "distribution": model.get("distribution"),
+                    "row_kind": "model",
                     "metric_row": label,
                 }
+                # Per-row classification stats from model["stats"] (renamed).
                 for src, dst in _STATS_COL_MAP.items():
                     vals = stats_block.get(src)
                     row[dst] = (
                         float(vals[i]) if vals is not None and i < len(vals) else float("nan")
                     )
-                row.update(
-                    {
-                        "model_weight": diag.get("model_weight", float("nan")),
-                        "model_calib": diag.get("model_calib", float("nan")),
-                        "start_shape": diag.get("start_shape", float("nan")),
-                        "model_shape": mod_shape,
-                        "empirical_shape": emp_shape,
-                        "shape_ratio": shape_ratio,
-                        "model_ev": diag.get("model_ev", float("nan")),
-                        "mean_line": diag.get("mean_line", float("nan")),
-                        "result_mean": diag.get("result_mean", float("nan")),
-                        "mean_ev_diff": diag.get("ev_minus_line", float("nan")),
-                        "median_ev_diff": diag.get("median_ev_diff", float("nan")),
-                        "frac_ev_gt_line": diag.get("frac_ev_gt_line", float("nan")),
-                        "over_pct_ev_gt": diag.get("over_pct_ev_gt", float("nan")),
-                        "over_pct_ev_lt": diag.get("over_pct_ev_lt", float("nan")),
-                        "cf_over_pct": diag.get("cf_over_pct", float("nan")),
-                        "dispersion_cal": diag.get("dispersion_cal", float("nan")),
-                        "marginal_shape": diag.get("marginal_shape", float("nan")),
-                        "shape_ceiling": diag.get("shape_ceiling", float("nan")),
-                        "hp_rounds": params.get("opt_rounds", float("nan")),
-                        "hp_leaves": params.get("num_leaves", float("nan")),
-                        "hp_lr": params.get("learning_rate", float("nan")),
-                        "hp_min_child": params.get("min_child_samples", float("nan")),
-                        "hp_l1": params.get("lambda_l1", float("nan")),
-                        "hp_l2": params.get("lambda_l2", float("nan")),
-                        "cv": float(stat_cv.get(league, {}).get(market, float("nan"))),
-                        "std": float(stat_std.get(league, {}).get(market, float("nan"))),
-                        "historical_zero_rate": model.get("hist_gate", float("nan")),
-                    }
-                )
+                # Validation-set raw metrics + skill/shrinkage live on the
+                # calibrated row (where the calibrated probs were scored).
+                is_calibrated = label == "calibrated"
+                for k in _RAW_METRIC_KEYS:
+                    if is_calibrated and k in model_metrics:
+                        # Don't clobber the per-row stats already filled above
+                        # (accuracy/precision_over/etc.); prefer the validation-set
+                        # value from compute_metrics for the calibrated row.
+                        row[k] = float(model_metrics[k])
+                    else:
+                        row.setdefault(k, float("nan"))
+                row["brier_skill_score"] = float(bss) if is_calibrated else float("nan")
+                row["kelly_shrinkage"] = float(ks) if is_calibrated else float("nan")
+                row.update(diag_cols)
                 rows.append(row)
 
     df = pd.DataFrame(rows)
     _atomic_write_parquet(df, MODEL_STATS_PATH)
+
+
+def get_market_calibration(league: str, market: str) -> dict[str, float]:
+    """Return ``{kelly_shrinkage, brier_skill_score, model_weight}`` for one market.
+
+    Reads ``model_stats.parquet``. Returns NaNs when the row is missing so the
+    Kelly resolution chain can fall through to its next source. Kelly imports
+    this getter — never reaches into the parquet directly.
+    """
+    nan_result = {
+        "kelly_shrinkage": float("nan"),
+        "brier_skill_score": float("nan"),
+        "model_weight": float("nan"),
+    }
+    if not MODEL_STATS_PATH.is_file():
+        return nan_result
+    df = pd.read_parquet(MODEL_STATS_PATH)
+    if df.empty:
+        return nan_result
+    mask = (df["league"] == league) & (df["market"] == market) & (df["row_kind"] == "model")
+    if "metric_row" in df.columns:
+        cal = mask & (df["metric_row"] == "calibrated")
+        sub = df[cal] if cal.any() else df[mask]
+    else:
+        sub = df[mask]
+    if sub.empty:
+        return nan_result
+    row = sub.iloc[0]
+    return {
+        "kelly_shrinkage": float(row.get("kelly_shrinkage", float("nan"))),
+        "brier_skill_score": float(row.get("brier_skill_score", float("nan"))),
+        "model_weight": float(row.get("model_weight", float("nan"))),
+    }

--- a/tests/golden/test_training_metrics.py
+++ b/tests/golden/test_training_metrics.py
@@ -1,0 +1,178 @@
+"""Golden tests for training/report.py write_model_stats + get_market_calibration.
+
+Covers Phase 3 §4.c/§4.f/§4.g: the migrated raw-metric schema, the pinned
+``row_kind="book_baseline"`` row, and the thin getter Kelly consumes.
+"""
+
+from __future__ import annotations
+
+import math
+import sys
+from unittest import mock
+
+import pandas as pd
+import pytest
+
+from sportstradamus.training.report import (
+    _RAW_METRIC_KEYS,
+    get_market_calibration,
+    write_model_stats,
+)
+
+report_module = sys.modules["sportstradamus.training.report"]
+
+
+def _model_metrics(brier: float = 0.20) -> dict:
+    return {
+        "brier_score": brier,
+        "log_loss": 0.65,
+        "roc_auc": 0.62,
+        "expected_calibration_error": 0.02,
+        "accuracy": 0.58,
+        "precision_over": 0.60,
+        "precision_under": 0.55,
+        "predicted_over_rate": 0.51,
+        "empirical_over_rate": 0.49,
+        "prediction_std": 0.08,
+        "nll": 0.65,
+    }
+
+
+def _make_model(*, with_book: bool = True, brier: float = 0.197) -> dict:
+    book = _model_metrics(brier=0.218) if with_book else None
+    bss = 1 - (brier / max(book["brier_score"], 1e-9)) if book is not None else float("nan")
+    ks = max(0.0, min(1.0, bss)) if math.isfinite(bss) else float("nan")
+    return {
+        "distribution": "Gamma",
+        "cv": 0.5,
+        "std": 1.0,
+        "hist_gate": 0.01,
+        "stats": {
+            "Accuracy": [0.50, 0.55, 0.58],
+            "Over Prec": [0.50, 0.55, 0.60],
+            "Under Prec": [0.50, 0.55, 0.55],
+            "Over%": [0.49, 0.50, 0.51],
+            "Sharpness": [0.04, 0.06, 0.08],
+            "NLL": [0.70, 0.67, 0.65],
+        },
+        "metrics": {
+            "model": _model_metrics(brier=brier),
+            "book_baseline": book,
+            "brier_skill_score": float(bss),
+            "kelly_shrinkage": float(ks),
+        },
+        "diagnostics": {
+            "model_weight": 0.30,
+            "shape_label": "alpha",
+            "start_shape": 1.0,
+            "model_shape": 1.1,
+            "empirical_shape": 1.0,
+            "ev_minus_line": 0.05,
+            "median_ev_diff": 0.04,
+            "frac_ev_gt_line": 0.55,
+            "over_pct_ev_gt": 0.60,
+            "over_pct_ev_lt": 0.40,
+            "cf_over_pct": 0.50,
+            "dispersion_cal": 1.0,
+            "marginal_shape": 1.0,
+            "shape_ceiling": 2.0,
+            "model_ev": 220.0,
+            "mean_line": 215.0,
+            "result_mean": 218.0,
+        },
+        "params": {
+            "opt_rounds": 100,
+            "num_leaves": 31,
+            "learning_rate": 0.05,
+            "min_child_samples": 20,
+            "lambda_l1": 0.1,
+            "lambda_l2": 0.1,
+        },
+    }
+
+
+@pytest.fixture
+def patched_path(tmp_path):
+    target = tmp_path / "model_stats.parquet"
+    with mock.patch.object(report_module, "MODEL_STATS_PATH", target):
+        yield target
+
+
+def test_write_emits_book_baseline_and_model_rows(patched_path):
+    league_models = {"NFL": {"player_pass_yds": _make_model()}}
+    write_model_stats(
+        league_models, {"NFL": {"player_pass_yds": 0.5}}, {"NFL": {"player_pass_yds": 1.0}}
+    )
+
+    df = pd.read_parquet(patched_path)
+    assert set(df["row_kind"]) == {"book_baseline", "model"}
+    book = df[df["row_kind"] == "book_baseline"]
+    assert len(book) == 1
+    assert book.iloc[0]["brier_score"] == pytest.approx(0.218)
+    # Skill score on the baseline row is pinned at 0 — the book matches itself.
+    assert book.iloc[0]["brier_skill_score"] == 0.0
+    assert book.iloc[0]["kelly_shrinkage"] == 0.0
+
+    model_rows = df[df["row_kind"] == "model"]
+    assert set(model_rows["metric_row"]) == {"raw", "corrected", "calibrated"}
+    cal = model_rows[model_rows["metric_row"] == "calibrated"].iloc[0]
+    # Calibrated row carries the validation raw metrics and the skill score.
+    assert cal["brier_score"] == pytest.approx(0.197)
+    assert cal["brier_skill_score"] == pytest.approx(1 - 0.197 / 0.218)
+    assert cal["kelly_shrinkage"] == pytest.approx(1 - 0.197 / 0.218)
+    # Raw/corrected rows do not carry the validation raw metrics.
+    raw = model_rows[model_rows["metric_row"] == "raw"].iloc[0]
+    assert math.isnan(raw["brier_score"])
+    assert math.isnan(raw["brier_skill_score"])
+
+
+def test_useless_model_skill_score_zero(patched_path):
+    # Same Brier as book → BSS = 0, kelly_shrinkage = 0.
+    league_models = {"NFL": {"m": _make_model(brier=0.218)}}
+    write_model_stats(league_models, {}, {})
+    df = pd.read_parquet(patched_path)
+    cal = df[(df["row_kind"] == "model") & (df["metric_row"] == "calibrated")].iloc[0]
+    assert cal["brier_skill_score"] == pytest.approx(0.0, abs=1e-9)
+    assert cal["kelly_shrinkage"] == pytest.approx(0.0, abs=1e-9)
+
+
+def test_missing_book_baseline_skill_is_nan(patched_path):
+    league_models = {"NFL": {"m": _make_model(with_book=False)}}
+    write_model_stats(league_models, {}, {})
+    df = pd.read_parquet(patched_path)
+    book = df[df["row_kind"] == "book_baseline"].iloc[0]
+    # No book metrics → all raw metric columns NaN.
+    for k in _RAW_METRIC_KEYS:
+        assert math.isnan(book[k])
+    assert math.isnan(book["brier_skill_score"])
+    assert math.isnan(book["kelly_shrinkage"])
+    cal = df[(df["row_kind"] == "model") & (df["metric_row"] == "calibrated")].iloc[0]
+    assert math.isnan(cal["brier_skill_score"])
+    assert math.isnan(cal["kelly_shrinkage"])
+
+
+def test_get_market_calibration_returns_calibrated_row(patched_path):
+    league_models = {"NFL": {"player_pass_yds": _make_model()}}
+    write_model_stats(league_models, {}, {})
+    out = get_market_calibration("NFL", "player_pass_yds")
+    assert out["kelly_shrinkage"] == pytest.approx(1 - 0.197 / 0.218)
+    assert out["brier_skill_score"] == pytest.approx(1 - 0.197 / 0.218)
+    assert out["model_weight"] == pytest.approx(0.30)
+
+
+def test_get_market_calibration_missing_returns_nans(patched_path):
+    league_models = {"NFL": {"player_pass_yds": _make_model()}}
+    write_model_stats(league_models, {}, {})
+    out = get_market_calibration("NBA", "missing_market")
+    assert math.isnan(out["kelly_shrinkage"])
+    assert math.isnan(out["brier_skill_score"])
+    assert math.isnan(out["model_weight"])
+
+
+def test_get_market_calibration_no_parquet(tmp_path):
+    target = tmp_path / "does_not_exist.parquet"
+    with mock.patch.object(report_module, "MODEL_STATS_PATH", target):
+        out = get_market_calibration("NFL", "x")
+    assert math.isnan(out["kelly_shrinkage"])
+    assert math.isnan(out["brier_skill_score"])
+    assert math.isnan(out["model_weight"])


### PR DESCRIPTION
## Summary

Session 8 of Phase 3 — `training/report.py` only, per the one-module-per-session rule. Picks up the `metrics` block that session 7 (#36) added to the in-memory model dict and surfaces it through the parquet, the human-readable report, and a thin getter the Kelly module will consume.

- **`write_model_stats`** now emits one `row_kind="book_baseline"` row per market plus one `row_kind="model"` row per `metric_row` (raw / corrected / calibrated). Validation-set raw metrics (`brier_score`, `log_loss`, `roc_auc`, `expected_calibration_error`, `empirical_over_rate`, …) and the derived `brier_skill_score` / `kelly_shrinkage` attach to the calibrated model row — they describe the calibrated output. The baseline row pins `brier_skill_score` / `kelly_shrinkage` at `0` (the book matches itself); when book metrics are unavailable, the raw-metric columns are NaN, per §4.c.
- **Renames** per §4.b: `Over Prec → precision_over`, `Under Prec → precision_under`, `Over% → predicted_over_rate`, `Sharpness → prediction_std`. `accuracy` / `nll` keep their names. `model_calib` is removed; dashboard page 7 lands in session 9.
- **`training_report.txt`** gains the `BOOK BASELINE` / `MODEL` / `SKILL` header block so remote-box review without Streamlit stays self-contained (§4.e).
- **`get_market_calibration(league, market)`** returns `{kelly_shrinkage, brier_skill_score, model_weight}` for the calibrated row, NaNs on miss — the Kelly resolution-chain shape from §5.d (§4.f).

## Test plan

- [x] `poetry run ruff check src/sportstradamus/`
- [x] `poetry run ruff format --check src/sportstradamus/training/report.py tests/golden/test_training_metrics.py`
- [x] `poetry run pytest tests/golden/` — 54 passed, 3 skipped
- [x] New `tests/golden/test_training_metrics.py` (6 tests) covers row layout, useless-model BSS=0, missing-book NaN path, and the getter's hit / miss / no-parquet branches.

Phase 3 plan: `docs/PHASE_3_IMPLEMENTATION.md` — Step 4.c, 4.e, 4.f, 4.g (session 8 row in §8 table, scoped under PR `3-train`).


---
_Generated by [Claude Code](https://claude.ai/code/session_01G9aXS1K4c18kp2awybjj5v)_