### PR TITLE
Phase 3 Step 6: pickem-build orchestrator (Power/Flex/Rivals)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ meditate = "sportstradamus.training.cli:meditate"
 dashboard = "sportstradamus.dashboard:run"
 reflect = "sportstradamus.nightly:run"
 kelly = "sportstradamus.strategies.kelly:main"
+pickem-build = "sportstradamus.strategies.underdog_pickem:main"
 
 [tool.poetry.group.strategy]
 optional = true

--- a/src/sportstradamus/strategies/__init__.py
+++ b/src/sportstradamus/strategies/__init__.py
@@ -1,7 +1,7 @@
 """Bet-sizing and contest-construction strategies.
 
-Phase 3 §3.1 introduces fractional-Kelly sizing here; subsequent phases will
-add the Underdog ``pickem-build`` orchestrator alongside it.
+Phase 3 §3.1 introduces fractional-Kelly sizing here; §3.3 + §3.5 Rivals add
+the :mod:`underdog_pickem` orchestrator that drives ``pickem-build``.
 """
 
 from sportstradamus.strategies.kelly import (
@@ -15,6 +15,11 @@ from sportstradamus.strategies.kelly import (
     joint_kelly_portfolio,
     resolve_shrinkage,
 )
+from sportstradamus.strategies.underdog_pickem import (
+    PickemConfig,
+    RecommendedEntry,
+    construct_entries,
+)
 
 __all__ = [
     "DEFAULT_KELLY_FRACTION",
@@ -23,6 +28,9 @@ __all__ = [
     "MAX_FRACTION_OF_BANKROLL",
     "SHRINKAGE_FLOOR",
     "KellyCandidate",
+    "PickemConfig",
+    "RecommendedEntry",
+    "construct_entries",
     "fractional_kelly_stake",
     "joint_kelly_portfolio",
     "resolve_shrinkage",

--- a/src/sportstradamus/strategies/_pickem_emit.py
+++ b/src/sportstradamus/strategies/_pickem_emit.py
@@ -25,8 +25,7 @@ def rank_and_dedupe(
     """Sort by EV-per-dollar, drop near-duplicate entries by leg overlap."""
     ranked = sorted(
         entries,
-        key=lambda e: (e.ev * e.joint_prob)
-        / float(max(e.recommended_stake, Decimal("0.01"))),
+        key=lambda e: (e.ev * e.joint_prob) / float(max(e.recommended_stake, Decimal("0.01"))),
         reverse=True,
     )
     kept: list[RecommendedEntry] = []

--- a/src/sportstradamus/strategies/_pickem_emit.py
+++ b/src/sportstradamus/strategies/_pickem_emit.py
@@ -1,0 +1,99 @@
+"""Internal helpers for ``strategies/underdog_pickem.py``.
+
+Keeps the orchestrator under the CLAUDE.md 300-line ceiling by hosting the
+rank/dedupe pass and the YAML emit. No public API; all symbols private to
+the strategies subpackage.
+"""
+
+from __future__ import annotations
+
+import datetime
+from decimal import Decimal
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from sportstradamus.strategies.underdog_pickem import (
+        PickemConfig,
+        RecommendedEntry,
+    )
+
+
+def rank_and_dedupe(
+    entries: list[RecommendedEntry], config: PickemConfig
+) -> list[RecommendedEntry]:
+    """Sort by EV-per-dollar, drop near-duplicate entries by leg overlap."""
+    ranked = sorted(
+        entries,
+        key=lambda e: (e.ev * e.joint_prob)
+        / float(max(e.recommended_stake, Decimal("0.01"))),
+        reverse=True,
+    )
+    kept: list[RecommendedEntry] = []
+    for e in ranked:
+        legs_set = set(e.legs)
+        if any(len(legs_set & set(k.legs)) > config.max_overlap for k in kept):
+            continue
+        kept.append(e)
+        if len(kept) >= config.top_k:
+            break
+    return kept
+
+
+def emit_yaml(
+    entries: list[RecommendedEntry],
+    date: datetime.date,
+    bankroll: Decimal,
+    config: PickemConfig,
+    out_path: Path,
+) -> Path:
+    """Serialize ``entries`` to ``out_path`` and return the path."""
+    yaml = _lazy_import("yaml")
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "generated_at": datetime.datetime.now().isoformat(),
+        "date": date.isoformat(),
+        "bankroll": str(bankroll),
+        "config": {
+            "min_model_edge": config.min_model_edge,
+            "min_sharp_edge": config.min_sharp_edge,
+            "disagreement_threshold": config.disagreement_threshold,
+            "min_ev": config.min_ev,
+            "entry_sizes": list(config.entry_sizes),
+            "contest_variants": list(config.contest_variants),
+            "top_k": config.top_k,
+            "max_overlap": config.max_overlap,
+            "kelly_fraction": config.kelly_fraction,
+            "max_stake_pct_bankroll": config.max_stake_pct_bankroll,
+        },
+        "entries": [
+            {
+                "id": e.id,
+                "contest_variant": e.contest_variant,
+                "entry_size": e.entry_size,
+                "legs": list(e.legs),
+                "joint_prob": float(e.joint_prob),
+                "payout_multiplier": float(e.payout_multiplier),
+                "ev": float(e.ev),
+                "recommended_stake": str(e.recommended_stake),
+                "shrinkage": float(e.shrinkage),
+                "shrinkage_source": e.shrinkage_source,
+                "extras": e.extras,
+            }
+            for e in entries
+        ],
+    }
+    with open(out_path, "w") as fh:
+        yaml.safe_dump(payload, fh, sort_keys=False)
+    return out_path
+
+
+def _lazy_import(name: str) -> Any:
+    try:
+        return __import__(name)
+    except ImportError as exc:
+        raise ImportError(
+            f"`{name}` is required for pickem-build. Install with "
+            f"`poetry install --with strategy`."
+        ) from exc

--- a/src/sportstradamus/strategies/underdog_pickem.py
+++ b/src/sportstradamus/strategies/underdog_pickem.py
@@ -1,11 +1,9 @@
-"""Underdog Pick'em entry-construction orchestrator (Phase 3 §3.3 + §3.5 Rivals).
+"""Underdog Pick'em orchestrator (Phase 3 §3.3 + §3.5 Rivals).
 
-Pure orchestrator: re-scores Underdog offers via
-:func:`prediction.scoring.process_offers`, re-runs
-:func:`prediction.correlation.find_correlation` per contest variant, then
-applies the Pick'em-specific filters, Kelly sizing, ranking, and YAML emit.
-Rank/dedupe and YAML emit live in :mod:`strategies._pickem_emit` to keep
-this module under the CLAUDE.md 300-line ceiling.
+Pure orchestrator over ``prediction.scoring.process_offers`` and
+``prediction.correlation.find_correlation`` (one search per contest
+variant). Rank/dedupe and YAML emit live in :mod:`._pickem_emit` to keep
+this file under the CLAUDE.md 300-line ceiling.
 """
 
 from __future__ import annotations
@@ -103,9 +101,7 @@ def _filter_parlays(
     return df.reset_index(drop=True)
 
 
-def _validate_rivals_coverage(
-    parlay_df: pd.DataFrame, offers: pd.DataFrame
-) -> pd.DataFrame:
+def _validate_rivals_coverage(parlay_df: pd.DataFrame, offers: pd.DataFrame) -> pd.DataFrame:
     """Drop Rivals candidates where one matchup side is missing from offers."""
     if parlay_df.empty or offers.empty:
         return parlay_df
@@ -119,8 +115,7 @@ def _validate_rivals_coverage(
                 continue
             sides = [s.strip() for s in str(desc).split("vs.")[:2]]
             covered = sum(
-                1 for side in sides
-                if any(side and side.split()[0] in p for p in players)
+                1 for side in sides if any(side and side.split()[0] in p for p in players)
             )
             if covered < 2:
                 _logger.warning("rivals candidate dropped: one-sided (%s)", desc)
@@ -276,16 +271,21 @@ def _build_cli() -> Any:
     @click.command()
     @click.option("--date", default="today", help="Slate date (YYYY-MM-DD or 'today').")
     @click.option("--bankroll", type=str, required=True, help="Bankroll in dollars.")
-    @click.option("--out", "out_path", type=click.Path(dir_okay=False), default=None,
-                  help="Override output YAML path.")
+    @click.option(
+        "--out",
+        "out_path",
+        type=click.Path(dir_okay=False),
+        default=None,
+        help="Override output YAML path.",
+    )
     def pickem_build(date: str, bankroll: str, out_path: str | None) -> None:
         """Build today's Underdog Pick'em entries and emit recommendations YAML."""
-        slate_date = (
-            datetime.date.today() if date == "today" else datetime.date.fromisoformat(date)
-        )
+        slate_date = datetime.date.today() if date == "today" else datetime.date.fromisoformat(date)
         config = PickemConfig()
         entries = construct_entries(slate_date, Decimal(bankroll), config)
-        target = Path(out_path) if out_path else _RECOMMENDATIONS_DIR / f"{slate_date.isoformat()}.yaml"
+        target = (
+            Path(out_path) if out_path else _RECOMMENDATIONS_DIR / f"{slate_date.isoformat()}.yaml"
+        )
         path = emit_yaml(entries, slate_date, Decimal(bankroll), config, target)
         click.echo(f"wrote {len(entries)} entries -> {path}")
 

--- a/src/sportstradamus/strategies/underdog_pickem.py
+++ b/src/sportstradamus/strategies/underdog_pickem.py
@@ -1,0 +1,300 @@
+"""Underdog Pick'em entry-construction orchestrator (Phase 3 §3.3 + §3.5 Rivals).
+
+Pure orchestrator: re-scores Underdog offers via
+:func:`prediction.scoring.process_offers`, re-runs
+:func:`prediction.correlation.find_correlation` per contest variant, then
+applies the Pick'em-specific filters, Kelly sizing, ranking, and YAML emit.
+Rank/dedupe and YAML emit live in :mod:`strategies._pickem_emit` to keep
+this module under the CLAUDE.md 300-line ceiling.
+"""
+
+from __future__ import annotations
+
+import datetime
+import hashlib
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+from decimal import Decimal
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+
+from sportstradamus.helpers.logging import get_logger
+from sportstradamus.strategies._pickem_emit import emit_yaml, rank_and_dedupe
+from sportstradamus.strategies.kelly import (
+    DEFAULT_KELLY_FRACTION,
+    MAX_FRACTION_OF_BANKROLL,
+    fractional_kelly_stake,
+    resolve_shrinkage,
+)
+
+_logger = get_logger("pickem-build")
+
+# Roadmap §3.5: Rivals payout structure caps the variant at 2-3 leg entries
+# regardless of what the user sets in ``PickemConfig.entry_sizes``.
+_RIVALS_LEG_SIZES: tuple[int, ...] = (2, 3)
+
+_RECOMMENDATIONS_DIR = Path("data") / "recommendations"
+
+
+@dataclass(frozen=True)
+class PickemConfig:
+    """Tunable thresholds for :func:`construct_entries` (§6.a)."""
+
+    min_model_edge: float = 0.020
+    min_sharp_edge: float = 0.015
+    disagreement_threshold: float = 0.04
+    min_correlation: float = 0.10
+    min_ev: float = 0.05
+    entry_sizes: tuple[int, ...] = (3, 5)
+    contest_variants: tuple[str, ...] = ("power", "flex", "rivals")
+    top_k: int = 20
+    max_overlap: int = 2
+    kelly_fraction: float = DEFAULT_KELLY_FRACTION
+    max_stake_pct_bankroll: float = MAX_FRACTION_OF_BANKROLL
+
+
+@dataclass(frozen=True)
+class RecommendedEntry:
+    """One ranked entry emitted to the recommendations YAML."""
+
+    id: str
+    contest_variant: str
+    entry_size: int
+    legs: tuple[str, ...]
+    joint_prob: float
+    payout_multiplier: float
+    ev: float
+    recommended_stake: Decimal
+    shrinkage_source: str = "training"
+    shrinkage: float = 1.0
+    extras: dict[str, Any] = field(default_factory=dict)
+
+
+def _filter_legs(offers: pd.DataFrame, config: PickemConfig) -> pd.DataFrame:
+    """Apply leg-level filters: model & sharp coverage + edge + disagreement."""
+    if offers.empty:
+        return offers
+    required = {"Model P", "Books P"}
+    if not required.issubset(offers.columns):
+        msg = f"_filter_legs needs columns {required}; got {set(offers.columns)}"
+        raise ValueError(msg)
+
+    df = offers.dropna(subset=["Model P", "Books P"]).copy()
+    keep = (
+        ((df["Model P"] - 0.5) >= config.min_model_edge)
+        & ((df["Books P"] - 0.5) >= config.min_sharp_edge)
+        & ((df["Model P"] - df["Books P"]).abs() <= config.disagreement_threshold)
+    )
+    return df.loc[keep].copy()
+
+
+def _filter_parlays(
+    parlay_df: pd.DataFrame, variant: str, entry_sizes: Iterable[int], config: PickemConfig
+) -> pd.DataFrame:
+    """Apply post-search size + EV filters; Rivals is forced to 2/3 legs."""
+    if parlay_df.empty:
+        return parlay_df
+    sizes = set(_RIVALS_LEG_SIZES if variant == "rivals" else entry_sizes)
+    df = parlay_df.copy()
+    df = df[df["Bet Size"].isin(sizes)]
+    df = df[(df["Model EV"] - 1.0) >= config.min_ev]
+    return df.reset_index(drop=True)
+
+
+def _validate_rivals_coverage(
+    parlay_df: pd.DataFrame, offers: pd.DataFrame
+) -> pd.DataFrame:
+    """Drop Rivals candidates where one matchup side is missing from offers."""
+    if parlay_df.empty or offers.empty:
+        return parlay_df
+    players = offers["Player"].astype(str).tolist() if "Player" in offers.columns else []
+    keep_rows = []
+    for _, row in parlay_df.iterrows():
+        legs = [row.get(f"Leg {i}", "") for i in range(1, int(row["Bet Size"]) + 1)]
+        ok = True
+        for desc in legs:
+            if "vs." not in str(desc):
+                continue
+            sides = [s.strip() for s in str(desc).split("vs.")[:2]]
+            covered = sum(
+                1 for side in sides
+                if any(side and side.split()[0] in p for p in players)
+            )
+            if covered < 2:
+                _logger.warning("rivals candidate dropped: one-sided (%s)", desc)
+                ok = False
+                break
+        if ok:
+            keep_rows.append(row)
+    return pd.DataFrame(keep_rows).reset_index(drop=True) if keep_rows else parlay_df.iloc[0:0]
+
+
+def _row_to_entry(
+    row: pd.Series,
+    variant: str,
+    bankroll: Decimal,
+    config: PickemConfig,
+    shrinkage_info: tuple[float, str],
+) -> RecommendedEntry:
+    payout = float(row["Boost"])
+    model_ev = float(row["Model EV"])
+    joint_prob = model_ev / payout if payout > 0 else 0.0
+    ev = model_ev - 1.0
+    bet_size = int(row["Bet Size"])
+    legs = tuple(str(row.get(f"Leg {i}", "")) for i in range(1, bet_size + 1))
+    shrinkage, source = shrinkage_info
+
+    stake = fractional_kelly_stake(
+        bankroll=bankroll,
+        win_prob=joint_prob,
+        payout_multiplier=Decimal(repr(payout)),
+        fraction=config.kelly_fraction,
+        model_shrinkage=shrinkage,
+        max_fraction_of_bankroll=config.max_stake_pct_bankroll,
+    )
+
+    digest = hashlib.sha1("|".join(legs).encode()).hexdigest()[:12]
+    return RecommendedEntry(
+        id=digest,
+        contest_variant=variant,
+        entry_size=bet_size,
+        legs=legs,
+        joint_prob=joint_prob,
+        payout_multiplier=payout,
+        ev=ev,
+        recommended_stake=stake,
+        shrinkage=shrinkage,
+        shrinkage_source=source,
+        extras={"league": str(row.get("League", "")), "game": str(row.get("Game", ""))},
+    )
+
+
+def _resolve_market_shrinkage(league: str, market: str) -> tuple[float, str]:
+    """Resolve a Kelly shrinkage value plus a tag identifying its source."""
+    try:
+        from sportstradamus import clv as _clv
+        from sportstradamus.training.report import get_market_calibration
+    except ImportError:
+        return 1.0, "fallback"
+
+    try:
+        live_bss, live_n = _clv.get_segment_calibration(league, market)
+    except Exception:
+        live_bss, live_n = float("nan"), 0
+    try:
+        train_metrics = get_market_calibration(league, market)
+    except Exception:
+        train_metrics = {"brier_skill_score": float("nan")}
+    train_bss = train_metrics.get("brier_skill_score", float("nan"))
+
+    shrinkage = resolve_shrinkage(training_bss=train_bss, live_bss=live_bss, live_n=live_n)
+    has_train = not _isna(train_bss)
+    has_live = not _isna(live_bss) and live_n > 0
+    if not has_train and not has_live:
+        return shrinkage, "fallback"
+    if has_train and has_live:
+        return shrinkage, "blended"
+    return shrinkage, "training" if has_train else "clv_segment"
+
+
+def _isna(x: Any) -> bool:
+    try:
+        return bool(pd.isna(x))
+    except (TypeError, ValueError):
+        return x is None
+
+
+def construct_entries(
+    date: datetime.date,
+    bankroll: Decimal,
+    config: PickemConfig | None = None,
+    *,
+    parlay_dfs: dict[str, pd.DataFrame] | None = None,
+    offers_df: pd.DataFrame | None = None,
+) -> list[RecommendedEntry]:
+    """Build ranked, sized Underdog Pick'em entries for ``date``.
+
+    ``parlay_dfs`` / ``offers_df`` injection short-circuits the live scraper
+    so tests and offline reruns do not hit the network.
+    """
+    config = config or PickemConfig()
+    if parlay_dfs is None:
+        parlay_dfs, offers_df = _live_load(config)
+    offers_df = pd.DataFrame() if offers_df is None else offers_df
+    filtered_offers = _filter_legs(offers_df, config) if not offers_df.empty else offers_df
+
+    entries: list[RecommendedEntry] = []
+    for variant in config.contest_variants:
+        parlays = parlay_dfs.get(variant, pd.DataFrame())
+        if parlays.empty:
+            continue
+        parlays = _filter_parlays(parlays, variant, config.entry_sizes, config)
+        if variant == "rivals":
+            parlays = _validate_rivals_coverage(parlays, filtered_offers)
+        for _, row in parlays.iterrows():
+            league = str(row.get("League", ""))
+            market = ""
+            if not filtered_offers.empty and "Market" in filtered_offers.columns:
+                market = str(filtered_offers["Market"].iloc[0])
+            shrinkage_info = _resolve_market_shrinkage(league, market)
+            entries.append(_row_to_entry(row, variant, bankroll, config, shrinkage_info))
+
+    return rank_and_dedupe(entries, config)
+
+
+def _live_load(config: PickemConfig) -> tuple[dict[str, pd.DataFrame], pd.DataFrame]:
+    """Re-run the prophecize loader and search per variant. Heavy."""
+    from sportstradamus.books import get_ud
+    from sportstradamus.prediction.correlation import find_correlation
+    from sportstradamus.prediction.scoring import process_offers
+    from sportstradamus.stats import StatsNBA, StatsNFL, StatsWNBA
+
+    stats: dict[str, Any] = {}
+    today = datetime.date.today()
+    for cls, key in ((StatsNBA, "NBA"), (StatsNFL, "NFL"), (StatsWNBA, "WNBA")):
+        s = cls()
+        s.load()
+        if today > (s.season_start - datetime.timedelta(days=7)):
+            s.update()
+            stats[key] = s
+    offers_df, _ = process_offers(
+        get_ud(), "Underdog", stats, contest_variant=config.contest_variants[0]
+    )
+    scored = offers_df.to_dict("records") if not offers_df.empty else []
+    parlay_dfs = {
+        v: find_correlation(scored, stats, "Underdog", contest_variant=v)[1]
+        for v in config.contest_variants
+    }
+    return parlay_dfs, offers_df
+
+
+def _build_cli() -> Any:
+    import click
+
+    @click.command()
+    @click.option("--date", default="today", help="Slate date (YYYY-MM-DD or 'today').")
+    @click.option("--bankroll", type=str, required=True, help="Bankroll in dollars.")
+    @click.option("--out", "out_path", type=click.Path(dir_okay=False), default=None,
+                  help="Override output YAML path.")
+    def pickem_build(date: str, bankroll: str, out_path: str | None) -> None:
+        """Build today's Underdog Pick'em entries and emit recommendations YAML."""
+        slate_date = (
+            datetime.date.today() if date == "today" else datetime.date.fromisoformat(date)
+        )
+        config = PickemConfig()
+        entries = construct_entries(slate_date, Decimal(bankroll), config)
+        target = Path(out_path) if out_path else _RECOMMENDATIONS_DIR / f"{slate_date.isoformat()}.yaml"
+        path = emit_yaml(entries, slate_date, Decimal(bankroll), config, target)
+        click.echo(f"wrote {len(entries)} entries -> {path}")
+
+    return pickem_build
+
+
+def main() -> None:
+    _build_cli()()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/golden/test_underdog_pickem.py
+++ b/tests/golden/test_underdog_pickem.py
@@ -1,0 +1,235 @@
+"""Tests for Phase 3 Step 6: Underdog Pick'em orchestrator."""
+
+from __future__ import annotations
+
+import datetime
+from decimal import Decimal
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from sportstradamus.strategies._pickem_emit import emit_yaml
+from sportstradamus.strategies.underdog_pickem import (
+    PickemConfig,
+    _filter_legs,
+    _filter_parlays,
+    _validate_rivals_coverage,
+    construct_entries,
+)
+
+
+def _offers(rows):
+    cols = ["Player", "Team", "Market", "Bet", "Model P", "Books P"]
+    return pd.DataFrame(rows, columns=cols)
+
+
+def _parlay(legs, *, bet_size=None, model_ev=2.5, payout=3.0, league="WNBA", game="A/B"):
+    bet_size = bet_size or len(legs)
+    row = {
+        "Game": game,
+        "Date": "2026-05-08",
+        "League": league,
+        "Platform": "Underdog",
+        "Model EV": model_ev,
+        "Books EV": model_ev * 0.95,
+        "Boost": payout,
+        "Rec Bet": 1.0,
+        "Bet Size": bet_size,
+    }
+    for i, leg in enumerate(legs, 1):
+        row[f"Leg {i}"] = leg
+    for i in range(len(legs) + 1, 7):
+        row[f"Leg {i}"] = ""
+    return row
+
+
+# --- leg filter ---------------------------------------------------------------
+
+
+def test_filter_legs_drops_below_model_edge():
+    cfg = PickemConfig(min_model_edge=0.05)
+    df = _offers(
+        [
+            ("Caitlin Clark", "IND", "PTS", "Over", 0.56, 0.55),
+            ("A'ja Wilson", "LV", "PTS", "Over", 0.52, 0.51),
+        ]
+    )
+    out = _filter_legs(df, cfg)
+    assert list(out["Player"]) == ["Caitlin Clark"]
+
+
+def test_filter_legs_drops_below_sharp_edge():
+    cfg = PickemConfig(min_model_edge=0.0, min_sharp_edge=0.10)
+    df = _offers([("X", "T", "M", "Over", 0.60, 0.55)])
+    assert _filter_legs(df, cfg).empty
+
+
+def test_filter_legs_disagreement():
+    cfg = PickemConfig(min_model_edge=0.0, min_sharp_edge=0.0, disagreement_threshold=0.02)
+    df = _offers(
+        [
+            ("Agree", "T", "M", "Over", 0.60, 0.59),
+            ("Diverge", "T", "M", "Over", 0.70, 0.55),
+        ]
+    )
+    out = _filter_legs(df, cfg)
+    assert list(out["Player"]) == ["Agree"]
+
+
+# --- parlay-level filter ------------------------------------------------------
+
+
+def test_filter_parlays_size_and_ev():
+    cfg = PickemConfig(min_ev=0.10, entry_sizes=(3,))
+    df = pd.DataFrame(
+        [
+            _parlay(["L1", "L2", "L3"], model_ev=1.50),
+            _parlay(["L1", "L2"], model_ev=2.0, bet_size=2),  # wrong size
+            _parlay(["L1", "L2", "L3"], model_ev=1.05),  # below min_ev
+        ]
+    )
+    out = _filter_parlays(df, "power", cfg.entry_sizes, cfg)
+    assert len(out) == 1
+    assert out["Bet Size"].iloc[0] == 3
+
+
+def test_filter_parlays_rivals_overrides_entry_sizes():
+    cfg = PickemConfig(min_ev=0.0, entry_sizes=(5, 6))
+    df = pd.DataFrame(
+        [
+            _parlay(["A vs. B"], bet_size=2, model_ev=1.5),
+            _parlay(["A vs. B", "C vs. D", "E vs. F", "G vs. H", "I vs. J"], model_ev=2.0),
+        ]
+    )
+    out = _filter_parlays(df, "rivals", cfg.entry_sizes, cfg)
+    assert list(out["Bet Size"]) == [2]
+
+
+# --- rivals coverage ---------------------------------------------------------
+
+
+def test_rivals_one_sided_dropped(caplog):
+    import logging
+    target = logging.getLogger("sportstradamus.cli.pickem-build")
+    target.addHandler(caplog.handler)
+    target.setLevel(logging.WARNING)
+    try:
+        offers = _offers([("Caitlin Clark", "IND", "PTS", "Over", 0.55, 0.54)])
+        df = pd.DataFrame(
+            [_parlay(["Caitlin Clark vs. Sabrina Ionescu"], bet_size=2, model_ev=1.5)]
+        )
+        out = _validate_rivals_coverage(df, offers)
+    finally:
+        target.removeHandler(caplog.handler)
+    assert out.empty
+    assert any("rivals candidate dropped" in r.getMessage() for r in caplog.records)
+
+
+def test_rivals_both_sides_kept():
+    offers = _offers(
+        [
+            ("Caitlin Clark", "IND", "PTS", "Over", 0.55, 0.54),
+            ("Sabrina Ionescu", "NY", "PTS", "Under", 0.55, 0.54),
+        ]
+    )
+    df = pd.DataFrame(
+        [_parlay(["Caitlin Clark vs. Sabrina Ionescu"], bet_size=2, model_ev=1.5)]
+    )
+    out = _validate_rivals_coverage(df, offers)
+    assert len(out) == 1
+
+
+# --- end-to-end with injection -----------------------------------------------
+
+
+@pytest.fixture
+def fake_market_calibration(monkeypatch):
+    monkeypatch.setattr(
+        "sportstradamus.strategies.underdog_pickem._resolve_market_shrinkage",
+        lambda league, market: (0.5, "training"),
+    )
+
+
+def test_construct_entries_all_three_variants(fake_market_calibration):
+    cfg = PickemConfig(
+        min_model_edge=0.0,
+        min_sharp_edge=0.0,
+        disagreement_threshold=1.0,
+        min_ev=0.0,
+        entry_sizes=(3,),
+        contest_variants=("power", "flex", "rivals"),
+        top_k=10,
+        max_overlap=2,
+    )
+    offers = _offers(
+        [
+            ("Clark", "IND", "PTS", "Over", 0.55, 0.54),
+            ("Wilson", "LV", "PTS", "Over", 0.55, 0.54),
+            ("Ionescu", "NY", "PTS", "Over", 0.55, 0.54),
+            ("Stewart", "NY", "PTS", "Over", 0.55, 0.54),
+        ]
+    )
+    parlay_dfs = {
+        "power": pd.DataFrame([_parlay(["P1", "P2", "P3"], model_ev=1.4)]),
+        "flex": pd.DataFrame([_parlay(["F1", "F2", "F3"], model_ev=1.3)]),
+        "rivals": pd.DataFrame(
+            [_parlay(["Clark vs. Ionescu"], bet_size=2, model_ev=1.5)]
+        ),
+    }
+    out = construct_entries(
+        datetime.date(2026, 5, 8), Decimal("500"), cfg,
+        parlay_dfs=parlay_dfs, offers_df=offers,
+    )
+    variants = {e.contest_variant for e in out}
+    assert variants == {"power", "flex", "rivals"}
+
+
+def test_construct_entries_yaml_roundtrip(tmp_path: Path, fake_market_calibration):
+    cfg = PickemConfig(
+        min_model_edge=0.0,
+        min_sharp_edge=0.0,
+        disagreement_threshold=1.0,
+        min_ev=0.0,
+        entry_sizes=(3,),
+        contest_variants=("power",),
+    )
+    offers = _offers([("Clark", "IND", "PTS", "Over", 0.6, 0.58)])
+    parlay_dfs = {"power": pd.DataFrame([_parlay(["L1", "L2", "L3"], model_ev=1.5)])}
+    entries = construct_entries(
+        datetime.date(2026, 5, 8), Decimal("500"), cfg,
+        parlay_dfs=parlay_dfs, offers_df=offers,
+    )
+    assert len(entries) == 1
+
+    yaml = pytest.importorskip("yaml")
+    out_path = tmp_path / "rec.yaml"
+    emit_yaml(entries, datetime.date(2026, 5, 8), Decimal("500"), cfg, out_path)
+    payload = yaml.safe_load(out_path.read_text())
+    assert payload["date"] == "2026-05-08"
+    assert payload["bankroll"] == "500"
+    assert payload["entries"][0]["contest_variant"] == "power"
+    assert payload["entries"][0]["entry_size"] == 3
+    assert payload["entries"][0]["legs"] == ["L1", "L2", "L3"]
+    assert "joint_prob" in payload["entries"][0]
+    assert "payout_multiplier" in payload["entries"][0]
+
+
+def test_dedupe_max_overlap(fake_market_calibration):
+    cfg = PickemConfig(
+        min_model_edge=0.0, min_sharp_edge=0.0, disagreement_threshold=1.0,
+        min_ev=0.0, entry_sizes=(3,), contest_variants=("power",),
+        top_k=10, max_overlap=2,
+    )
+    parlay_dfs = {
+        "power": pd.DataFrame(
+            [
+                _parlay(["L1", "L2", "L3"], model_ev=1.5),
+                _parlay(["L1", "L2", "L3"], model_ev=1.5),  # exact dup
+            ]
+        )
+    }
+    out = construct_entries(
+        datetime.date(2026, 5, 8), Decimal("500"), cfg, parlay_dfs=parlay_dfs,
+    )
+    assert len(out) == 1

--- a/tests/golden/test_underdog_pickem.py
+++ b/tests/golden/test_underdog_pickem.py
@@ -111,6 +111,7 @@ def test_filter_parlays_rivals_overrides_entry_sizes():
 
 def test_rivals_one_sided_dropped(caplog):
     import logging
+
     target = logging.getLogger("sportstradamus.cli.pickem-build")
     target.addHandler(caplog.handler)
     target.setLevel(logging.WARNING)
@@ -133,9 +134,7 @@ def test_rivals_both_sides_kept():
             ("Sabrina Ionescu", "NY", "PTS", "Under", 0.55, 0.54),
         ]
     )
-    df = pd.DataFrame(
-        [_parlay(["Caitlin Clark vs. Sabrina Ionescu"], bet_size=2, model_ev=1.5)]
-    )
+    df = pd.DataFrame([_parlay(["Caitlin Clark vs. Sabrina Ionescu"], bet_size=2, model_ev=1.5)])
     out = _validate_rivals_coverage(df, offers)
     assert len(out) == 1
 
@@ -173,13 +172,14 @@ def test_construct_entries_all_three_variants(fake_market_calibration):
     parlay_dfs = {
         "power": pd.DataFrame([_parlay(["P1", "P2", "P3"], model_ev=1.4)]),
         "flex": pd.DataFrame([_parlay(["F1", "F2", "F3"], model_ev=1.3)]),
-        "rivals": pd.DataFrame(
-            [_parlay(["Clark vs. Ionescu"], bet_size=2, model_ev=1.5)]
-        ),
+        "rivals": pd.DataFrame([_parlay(["Clark vs. Ionescu"], bet_size=2, model_ev=1.5)]),
     }
     out = construct_entries(
-        datetime.date(2026, 5, 8), Decimal("500"), cfg,
-        parlay_dfs=parlay_dfs, offers_df=offers,
+        datetime.date(2026, 5, 8),
+        Decimal("500"),
+        cfg,
+        parlay_dfs=parlay_dfs,
+        offers_df=offers,
     )
     variants = {e.contest_variant for e in out}
     assert variants == {"power", "flex", "rivals"}
@@ -197,8 +197,11 @@ def test_construct_entries_yaml_roundtrip(tmp_path: Path, fake_market_calibratio
     offers = _offers([("Clark", "IND", "PTS", "Over", 0.6, 0.58)])
     parlay_dfs = {"power": pd.DataFrame([_parlay(["L1", "L2", "L3"], model_ev=1.5)])}
     entries = construct_entries(
-        datetime.date(2026, 5, 8), Decimal("500"), cfg,
-        parlay_dfs=parlay_dfs, offers_df=offers,
+        datetime.date(2026, 5, 8),
+        Decimal("500"),
+        cfg,
+        parlay_dfs=parlay_dfs,
+        offers_df=offers,
     )
     assert len(entries) == 1
 
@@ -217,9 +220,14 @@ def test_construct_entries_yaml_roundtrip(tmp_path: Path, fake_market_calibratio
 
 def test_dedupe_max_overlap(fake_market_calibration):
     cfg = PickemConfig(
-        min_model_edge=0.0, min_sharp_edge=0.0, disagreement_threshold=1.0,
-        min_ev=0.0, entry_sizes=(3,), contest_variants=("power",),
-        top_k=10, max_overlap=2,
+        min_model_edge=0.0,
+        min_sharp_edge=0.0,
+        disagreement_threshold=1.0,
+        min_ev=0.0,
+        entry_sizes=(3,),
+        contest_variants=("power",),
+        top_k=10,
+        max_overlap=2,
     )
     parlay_dfs = {
         "power": pd.DataFrame(
@@ -230,6 +238,9 @@ def test_dedupe_max_overlap(fake_market_calibration):
         )
     }
     out = construct_entries(
-        datetime.date(2026, 5, 8), Decimal("500"), cfg, parlay_dfs=parlay_dfs,
+        datetime.date(2026, 5, 8),
+        Decimal("500"),
+        cfg,
+        parlay_dfs=parlay_dfs,
     )
     assert len(out) == 1


### PR DESCRIPTION
## Summary

Implements Phase 3 §6 (session 12) per `docs/PHASE_3_IMPLEMENTATION.md`: an Underdog-native `pickem-build` orchestrator covering Power, Flex, and Rivals contest variants.

- **`strategies/underdog_pickem.py`** — `construct_entries` end-to-end orchestrator with `PickemConfig` / `RecommendedEntry`. Reuses `find_correlation` + `beam_search_parlays` for each variant; no math lives in this module.
- **Filters** — leg-level coverage + edge thresholds + Model-vs-Books disagreement gate; parlay-level size + `min_ev` gate; Rivals forced to 2/3-leg sizes and matchup coverage validated against scored offers (one-sided coverage drops with a WARNING).
- **Sizing** — `fractional_kelly_stake` per candidate, with a per-market shrinkage resolver that tags the source as `training` / `clv_segment` / `blended` / `fallback`.
- **YAML emit + ranking** — split into `strategies/_pickem_emit.py` to keep the orchestrator under the CLAUDE.md 300-line ceiling. Output schema matches §6.c.
- **CLI** — `pickem-build` registered in `pyproject.toml`; `--date today --bankroll 500 [--out path]`.
- **Tests** — `tests/golden/test_underdog_pickem.py` covers leg filters, parlay filters, Rivals 2/3-leg constraint, one-sided-coverage WARNING, all-three-variant emission, dedupe, and a YAML round-trip via `yaml.safe_load`.

Targeted at `feature/decision-engine` per the session brief.

## Test plan

- [x] `poetry run pytest tests/golden/` — 81 passed, 6 skipped (all preexisting skips)
- [x] `poetry run ruff check src/sportstradamus/strategies/ tests/golden/test_underdog_pickem.py` — clean
- [x] `from sportstradamus.strategies import construct_entries, PickemConfig, RecommendedEntry` resolves
- [x] CLI builds (`_build_cli().params` lists `date`, `bankroll`, `out`)
- [ ] Manual `poetry run pickem-build --date today --bankroll 500` against a live slate (out of scope for this CI environment)

https://claude.ai/code/session_01BCoEV7wMCjBB9VwhCG7TqV

---
_Generated by [Claude Code](https://claude.ai/code/session_01BCoEV7wMCjBB9VwhCG7TqV)_