### PR TITLE
Overhaul dashboard predictions/parlays views and pool Underdog payouts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ pyarrow = "^21.0.0"
 scrapeops-python-requests = "^0.4.7"
 streamlit = ">=1.38"
 plotly = ">=5.18"
+streamlit-aggrid = "^1.2.1.post2"
 
 [tool.poetry.scripts]
 prophecize = "sportstradamus.prediction.cli:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ nflreadpy = "^0.1.2"
 polars = "^1.33.1"
 pyarrow = "^21.0.0"
 scrapeops-python-requests = "^0.4.7"
-streamlit = ">=1.30"
+streamlit = ">=1.38"
 plotly = ">=5.18"
 
 [tool.poetry.scripts]

--- a/src/sportstradamus/dashboard_data.py
+++ b/src/sportstradamus/dashboard_data.py
@@ -45,6 +45,26 @@ PRED_BANNER_COLOR = "#1f4e79"  # deep teal
 STATS_BANNER_COLOR = "#2d6a4f"  # forest green
 
 
+def format_ts(ts: str) -> str:
+    """Convert a raw timestamp string to a friendly local-time label.
+
+    Handles UTC ISO strings (with Z suffix), naive local strings, and fallback values.
+    Returns a human-readable format like "May 15 at 10:42 PM".
+    """
+    if not ts or ts in ("no run on record", "no meditate run on record"):
+        return ts
+    ts_norm = ts.replace("Z", "+00:00")
+    try:
+        dt = datetime.fromisoformat(ts_norm)
+    except ValueError:
+        try:
+            dt = datetime.strptime(ts_norm, "%Y-%m-%d %H:%M")
+        except ValueError:
+            return ts
+    local_dt = dt.astimezone()
+    return local_dt.strftime("%b %-d at %-I:%M %p")
+
+
 @st.cache_data(ttl=3600, show_spinner="Loading prediction history...")
 def load_history():
     """Load prediction history (parquet → legacy pickle fallback).

--- a/src/sportstradamus/dashboard_data.py
+++ b/src/sportstradamus/dashboard_data.py
@@ -20,6 +20,7 @@ from sportstradamus.analysis import (
     resolve_history,
 )
 from sportstradamus.helpers.io import (
+    CURRENT_HISTORY_PATH,
     CURRENT_META_PATH,
     CURRENT_OFFERS_PATH,
     CURRENT_PARLAYS_PATH,
@@ -113,6 +114,12 @@ def load_current_offers() -> pd.DataFrame:
 def load_current_parlays() -> pd.DataFrame:
     """Today's parlay candidates, written by `prophecize`."""
     return read_parquet_safe(CURRENT_PARLAYS_PATH)
+
+
+@st.cache_data(ttl=3600, show_spinner="Loading player history...")
+def load_current_history() -> pd.DataFrame:
+    """Per-game player stat history for today's offers, written by `prophecize`."""
+    return read_parquet_safe(CURRENT_HISTORY_PATH)
 
 
 @st.cache_data(ttl=3600)

--- a/src/sportstradamus/helpers/archive.py
+++ b/src/sportstradamus/helpers/archive.py
@@ -212,9 +212,7 @@ class Archive:
         for table in ("odds", "lines"):
             cols = self._table_columns(table)
             if "observed_at" not in cols:
-                self._connection.execute(
-                    f"ALTER TABLE {table} ADD COLUMN observed_at TIMESTAMP"
-                )
+                self._connection.execute(f"ALTER TABLE {table} ADD COLUMN observed_at TIMESTAMP")
                 if "sample_ts" in cols:
                     self._connection.execute(
                         f"UPDATE {table} SET observed_at = sample_ts "
@@ -294,9 +292,7 @@ class Archive:
             return np.nan
         return self._weighted_book_ev(league, market, rows)
 
-    def get_team_market(
-        self, league, market, date, team, *, at: datetime.datetime | None = None
-    ):
+    def get_team_market(self, league, market, date, team, *, at: datetime.datetime | None = None):
         """Weighted-average team-market EV (non-player, non-moneyline)."""
         rows = self._book_rows(league, market, date, team, at=at)
         if not rows:

--- a/src/sportstradamus/helpers/io.py
+++ b/src/sportstradamus/helpers/io.py
@@ -35,6 +35,7 @@ PARLAY_HIST_PATH = pkg_resources.files(data) / "parlay_hist.parquet"
 CURRENT_OFFERS_PATH = pkg_resources.files(data) / "current_offers.parquet"
 CURRENT_PARLAYS_PATH = pkg_resources.files(data) / "current_parlays.parquet"
 CURRENT_META_PATH = pkg_resources.files(data) / "current_meta.json"
+CURRENT_HISTORY_PATH = pkg_resources.files(data) / "current_history.parquet"
 MODEL_STATS_PATH = pkg_resources.files(data) / "model_stats.parquet"
 
 # Legacy pickle paths kept as read-only fallback until the parquet migration

--- a/src/sportstradamus/pages/1_🎯_Predictions_Today.py
+++ b/src/sportstradamus/pages/1_🎯_Predictions_Today.py
@@ -22,6 +22,39 @@ BOOST_HOT_CEILING = 2.5
 
 HIGHLIGHT_BG = "#1f4e79"
 
+# Columns shown in the main grid. The remaining scored columns are clutter on
+# the main screen and live in the per-row detail popup instead.
+MAIN_COLS = [
+    "League",
+    "Date",
+    "Team",
+    "Opponent",
+    "Player",
+    "Market",
+    "Bet",
+    "Line",
+    "Boost",
+    "Model P",
+    "Model",
+    "Books",
+    "Platform",
+]
+
+# Clutter columns surfaced only in the per-row detail popup.
+DETAIL_COLS = [
+    "Model EV",
+    "Model STD",
+    "Push P",
+    "Avg 5",
+    "Avg H2H",
+    "Moneyline",
+    "O/U",
+    "DVPOA",
+]
+
+# Numeric columns the user can range-filter on the main screen.
+RANGE_COLS = ["Model P", "Model", "Books"]
+
 st.set_page_config(page_title="Predictions — Today", layout="wide")
 st.title("Today's Predictions")
 
@@ -36,6 +69,13 @@ if offers.empty:
         "generate `current_offers.parquet`."
     )
     st.stop()
+
+# Defensive: a row with no boost, no model edge, and no book edge is a scoring
+# artifact (the snapshot writer drops these, but older parquets may predate it).
+signal_cols = [c for c in ["Boost", "Model", "Books"] if c in offers.columns]
+if signal_cols:
+    signal = offers[signal_cols].fillna(0)
+    offers = offers.loc[(signal != 0).any(axis=1)]
 
 # --- In-page filters (predictions section keeps its own controls) ---
 col1, col2, col3 = st.columns(3)
@@ -61,6 +101,28 @@ if selected_markets:
 if player_query:
     filtered = filtered.loc[filtered["Player"].str.contains(player_query, case=False, na=False)]
 
+# --- Numeric range filters for the hit-probability and EV columns ---
+range_cols = [c for c in RANGE_COLS if c in filtered.columns]
+if range_cols:
+    st.caption("Numeric range filters")
+    rcols = st.columns(len(range_cols))
+    for slot, col in zip(rcols, range_cols, strict=False):
+        series = pd.to_numeric(filtered[col], errors="coerce").dropna()
+        if series.empty:
+            continue
+        lo = float(series.min())
+        hi = float(series.max())
+        if lo == hi:
+            continue
+        sel = slot.slider(col, lo, hi, (lo, hi), step=(hi - lo) / 100 or 0.01)
+        vals = pd.to_numeric(filtered[col], errors="coerce")
+        filtered = filtered.loc[vals.between(sel[0], sel[1]) | vals.isna()]
+
+# Default ordering: descending by the Model column.
+if "Model" in filtered.columns:
+    filtered = filtered.sort_values("Model", ascending=False)
+
+filtered = filtered.reset_index(drop=True)
 st.caption(f"Showing **{len(filtered):,}** of {len(offers):,} offers")
 
 
@@ -77,23 +139,65 @@ def _highlight_hot(row: pd.Series) -> list[str]:
     return [style] * len(row)
 
 
-styled = filtered.style.apply(_highlight_hot, axis=1).format(
-    {
-        "Model EV": "{:.3f}",
-        "Model": "{:.3f}",
-        "Books": "{:.3f}",
-        "Push P": "{:.3f}",
-        "Line": "{:.2f}",
-        "Boost": "{:.2f}",
-        "Avg 5": "{:.2f}",
-        "Avg H2H": "{:.2f}",
-        "Moneyline": "{:.0f}",
-        "O/U": "{:.1f}",
-        "DVPOA": "{:.3f}",
-    }
+@st.dialog("Offer detail", width="large")
+def _show_detail(row: pd.Series) -> None:
+    st.subheader(f"{row.get('Player', '?')} — {row.get('Market', '?')}")
+    st.write(
+        f"**{row.get('Bet', '?')} {row.get('Line', '?')}** · "
+        f"{row.get('Team', '?')} vs {row.get('Opponent', '?')} · "
+        f"{row.get('League', '?')} · {row.get('Platform', '?')}"
+    )
+
+    detail = [c for c in DETAIL_COLS if c in row.index]
+    if detail:
+        cols = st.columns(4)
+        for i, c in enumerate(detail):
+            val = row[c]
+            cols[i % 4].metric(c, f"{val:.3f}" if isinstance(val, (int, float)) else str(val))
+
+    team_corr = row.get("Team Correlation")
+    opp_corr = row.get("Opp Correlation")
+    st.markdown("**Recommended correlated bets**")
+    if isinstance(team_corr, str) and team_corr.strip():
+        st.markdown(f"_Same team:_ {team_corr}")
+    if isinstance(opp_corr, str) and opp_corr.strip():
+        st.markdown(f"_Opponent:_ {opp_corr}")
+    if not (isinstance(team_corr, str) and team_corr.strip()) and not (
+        isinstance(opp_corr, str) and opp_corr.strip()
+    ):
+        st.caption("No correlated legs cleared the display thresholds for this offer.")
+
+
+display_cols = [c for c in MAIN_COLS if c in filtered.columns]
+styled = (
+    filtered[display_cols]
+    .style.apply(_highlight_hot, axis=1)
+    .format(
+        {
+            "Model P": "{:.3f}",
+            "Model": "{:.3f}",
+            "Books": "{:.3f}",
+            "Line": "{:.2f}",
+            "Boost": "{:.2f}",
+        }
+    )
 )
 
-st.dataframe(styled, use_container_width=True, height=720)
+event = st.dataframe(
+    styled,
+    use_container_width=True,
+    height=720,
+    hide_index=True,
+    on_select="rerun",
+    selection_mode="single-row",
+    key="offers_table",
+)
+
+selected_rows = event.selection.rows if event and event.selection else []
+if selected_rows:
+    _show_detail(filtered.iloc[selected_rows[0]])
+else:
+    st.caption("Select a row to see Model EV, Model std, push/odds context, and correlated bets.")
 
 with st.expander("Snapshot info"):
     st.json(meta)

--- a/src/sportstradamus/pages/1_🎯_Predictions_Today.py
+++ b/src/sportstradamus/pages/1_🎯_Predictions_Today.py
@@ -9,6 +9,7 @@ import pandas as pd
 import streamlit as st
 
 from sportstradamus.dashboard_data import (
+    format_ts,
     load_current_meta,
     load_current_offers,
     render_banner,
@@ -59,7 +60,7 @@ st.set_page_config(page_title="Predictions — Today", layout="wide")
 st.title("Today's Predictions")
 
 meta = load_current_meta()
-generated = meta.get("generated_at", "no run on record")
+generated = format_ts(meta.get("generated_at", "no run on record"))
 render_banner("predictions", f"generated {generated}")
 
 offers = load_current_offers()

--- a/src/sportstradamus/pages/1_🎯_Predictions_Today.py
+++ b/src/sportstradamus/pages/1_🎯_Predictions_Today.py
@@ -153,7 +153,7 @@ def _show_detail(row: pd.Series) -> None:
         cols = st.columns(4)
         for i, c in enumerate(detail):
             val = row[c]
-            cols[i % 4].metric(c, f"{val:.3f}" if isinstance(val, (int, float)) else str(val))
+            cols[i % 4].metric(c, f"{val:.3f}" if isinstance(val, int | float) else str(val))
 
     team_corr = row.get("Team Correlation")
     opp_corr = row.get("Opp Correlation")

--- a/src/sportstradamus/pages/1_🎯_Predictions_Today.py
+++ b/src/sportstradamus/pages/1_🎯_Predictions_Today.py
@@ -5,26 +5,44 @@ import sys
 
 sys.path.insert(0, str(pathlib.Path(__file__).parent.parent.parent))
 
+import altair as alt
+import numpy as np
 import pandas as pd
 import streamlit as st
+from st_aggrid import AgGrid, GridOptionsBuilder, GridUpdateMode
 
 from sportstradamus.dashboard_data import (
-    format_ts,
+    load_current_history,
     load_current_meta,
     load_current_offers,
     render_banner,
 )
+from sportstradamus.helpers.distributions import get_odds
 
-# Hot-row highlight: model edge above the boost cost (Model > 1.02), strong
-# bookmaker agreement (Books > 0.95), and a moderate boost (≤ 2.5).
+st.set_page_config(page_title="Predictions — Today", layout="wide")
+st.title("Today's Predictions")
+
+meta = load_current_meta()
+generated = meta.get("generated_at", "no run on record")
+render_banner("predictions", f"generated {generated}")
+
+offers = load_current_offers()
+if offers.empty:
+    st.info(
+        "No current predictions found. Run `poetry run prophecize` to "
+        "generate `current_offers.parquet`."
+    )
+    st.stop()
+
+history = load_current_history()
+
+# Hot-row highlight thresholds
 EV_HOT_THRESHOLD = 1.02
 BOOKS_HOT_THRESHOLD = 0.95
 BOOST_HOT_CEILING = 2.5
-
 HIGHLIGHT_BG = "#1f4e79"
 
-# Columns shown in the main grid. The remaining scored columns are clutter on
-# the main screen and live in the per-row detail popup instead.
+# Main table columns
 MAIN_COLS = [
     "League",
     "Date",
@@ -41,44 +59,16 @@ MAIN_COLS = [
     "Platform",
 ]
 
-# Clutter columns surfaced only in the per-row detail popup.
-DETAIL_COLS = [
-    "Model EV",
-    "Model STD",
-    "Push P",
-    "Avg 5",
-    "Avg H2H",
-    "Moneyline",
-    "O/U",
-    "DVPOA",
-]
-
-# Numeric columns the user can range-filter on the main screen.
+# Numeric columns for range filtering
 RANGE_COLS = ["Model P", "Model", "Books"]
 
-st.set_page_config(page_title="Predictions — Today", layout="wide")
-st.title("Today's Predictions")
-
-meta = load_current_meta()
-generated = format_ts(meta.get("generated_at", "no run on record"))
-render_banner("predictions", f"generated {generated}")
-
-offers = load_current_offers()
-if offers.empty:
-    st.info(
-        "No current predictions found. Run `poetry run prophecize` to "
-        "generate `current_offers.parquet`."
-    )
-    st.stop()
-
-# Defensive: a row with no boost, no model edge, and no book edge is a scoring
-# artifact (the snapshot writer drops these, but older parquets may predate it).
+# Defensive: drop rows with no signal (all zero edge/boost)
 signal_cols = [c for c in ["Boost", "Model", "Books"] if c in offers.columns]
 if signal_cols:
     signal = offers[signal_cols].fillna(0)
     offers = offers.loc[(signal != 0).any(axis=1)]
 
-# --- In-page filters (predictions section keeps its own controls) ---
+# --- In-page filters ---
 col1, col2, col3 = st.columns(3)
 with col1:
     leagues = sorted(offers["League"].dropna().unique())
@@ -102,7 +92,7 @@ if selected_markets:
 if player_query:
     filtered = filtered.loc[filtered["Player"].str.contains(player_query, case=False, na=False)]
 
-# --- Numeric range filters for the hit-probability and EV columns ---
+# Numeric range filters
 range_cols = [c for c in RANGE_COLS if c in filtered.columns]
 if range_cols:
     st.caption("Numeric range filters")
@@ -119,29 +109,124 @@ if range_cols:
         vals = pd.to_numeric(filtered[col], errors="coerce")
         filtered = filtered.loc[vals.between(sel[0], sel[1]) | vals.isna()]
 
-# Default ordering: descending by the Model column.
+# Default ordering: descending by Model
 if "Model" in filtered.columns:
     filtered = filtered.sort_values("Model", ascending=False)
 
 filtered = filtered.reset_index(drop=True)
 st.caption(f"Showing **{len(filtered):,}** of {len(offers):,} offers")
 
+# --- Session state for detail popup navigation ---
+if "detail_stack" not in st.session_state:
+    st.session_state.detail_stack = []
 
-def _highlight_hot(row: pd.Series) -> list[str]:
-    is_hot = (
-        pd.notna(row.get("Model"))
-        and pd.notna(row.get("Books"))
-        and pd.notna(row.get("Boost"))
-        and row["Model"] > EV_HOT_THRESHOLD
-        and row["Books"] > BOOKS_HOT_THRESHOLD
-        and row["Boost"] <= BOOST_HOT_CEILING
+
+# --- Helper functions for charts ---
+
+
+def _history_chart(df: pd.DataFrame, line: float, title: str) -> alt.Chart:
+    """Render bar chart of game history with dotted line at betting threshold."""
+    df = df.copy()
+    df["color"] = np.where(df["StatValue"] >= line, "Over", "Under")
+    bars = (
+        alt.Chart(df)
+        .mark_bar()
+        .encode(
+            x=alt.X("GameDate:T", title="Date", axis=alt.Axis(labelAngle=-45)),
+            y=alt.Y("StatValue:Q", title=""),
+            color=alt.Color(
+                "color:N",
+                scale=alt.Scale(domain=["Over", "Under"], range=["#4CAF50", "#F44336"]),
+                legend=None,
+            ),
+            tooltip=["GameDate:T", "Opponent:N", "StatValue:Q"],
+        )
+        .properties(title=title)
     )
-    style = f"background-color:{HIGHLIGHT_BG};color:white" if is_hot else ""
-    return [style] * len(row)
+    rule = (
+        alt.Chart(pd.DataFrame({"Line": [line]}))
+        .mark_rule(strokeDash=[6, 3], color="#FFFFFF", strokeWidth=1.5)
+        .encode(y="Line:Q")
+    )
+    return bars + rule
+
+
+def _to_american(p: float) -> str:
+    """Convert probability to American odds format."""
+    if not isinstance(p, float) or np.isnan(p) or p <= 0 or p >= 1:
+        return "N/A"
+    if p >= 0.5:
+        return f"-{round(p / (1 - p) * 100)}"
+    return f"+{round((1 - p) / p * 100)}"
+
+
+def _parse_corr(s: str, max_n: int = 3) -> list[tuple[str, float]]:
+    """Parse comma-separated correlation string into (desc, multiplier) tuples."""
+    if not isinstance(s, str) or not s.strip():
+        return []
+    out = []
+    for item in s.split(",")[:max_n]:
+        item = item.strip()
+        if "(" in item and item.endswith(")"):
+            desc, raw = item.rsplit("(", 1)
+            try:
+                mult = float(raw.rstrip("x)"))
+            except ValueError:
+                mult = 1.0
+            out.append((desc.strip(), mult))
+        else:
+            out.append((item, 1.0))
+    return out
+
+
+def _strength_badge(mult: float) -> str:
+    """Return emoji badge for correlation strength."""
+    if mult >= 1.25:
+        return "🔴 Strong"
+    if mult >= 1.1:
+        return "🟡 Moderate"
+    return "⚪ Mild"
+
+
+def _find_corr_row_idx(desc: str, filtered: pd.DataFrame) -> int | None:
+    """Find row index in filtered DataFrame matching a correlation description."""
+    for direction in ("Over", "Under"):
+        if direction in desc:
+            player_name = desc.split(direction)[0].strip()
+            matches = filtered[filtered["Player"].str.lower() == player_name.lower()]
+            if not matches.empty:
+                return matches.index[0]
+    return None
+
+
+def _render_corr_cards(
+    items: list[tuple[str, float]], group_label: str, filtered: pd.DataFrame, tab_key_prefix: str
+) -> None:
+    """Render correlated bet cards as clickable buttons."""
+    if not items:
+        return
+    st.markdown(f"**{group_label}**")
+    for i, (desc, mult) in enumerate(items):
+        col1, col2 = st.columns([4, 1])
+        col1.markdown(f"**{desc}**")
+        col2.markdown(_strength_badge(mult) + f" {mult:.2f}×")
+        if st.button("View →", key=f"{tab_key_prefix}_{i}"):
+            idx = _find_corr_row_idx(desc, filtered)
+            if idx is not None:
+                st.session_state.detail_stack.append(idx)
+                st.rerun()
 
 
 @st.dialog("Offer detail", width="large")
-def _show_detail(row: pd.Series) -> None:
+def _show_detail(row: pd.Series, history: pd.DataFrame, filtered: pd.DataFrame) -> None:
+    """Render detailed view of a single offer with charts and correlations."""
+    # Back button for navigation stack
+    if len(st.session_state.detail_stack) > 1:
+        if st.button("← Back"):
+            st.session_state.detail_stack.pop()
+            st.rerun()
+
+    # Header
     st.subheader(f"{row.get('Player', '?')} — {row.get('Market', '?')}")
     st.write(
         f"**{row.get('Bet', '?')} {row.get('Line', '?')}** · "
@@ -149,56 +234,159 @@ def _show_detail(row: pd.Series) -> None:
         f"{row.get('League', '?')} · {row.get('Platform', '?')}"
     )
 
-    detail = [c for c in DETAIL_COLS if c in row.index]
-    if detail:
-        cols = st.columns(4)
-        for i, c in enumerate(detail):
-            val = row[c]
-            cols[i % 4].metric(c, f"{val:.3f}" if isinstance(val, int | float) else str(val))
+    # Context metrics: Moneyline (as American odds), O/U (raw total), DVPOA (as %)
+    col1, col2, col3 = st.columns(3)
+    with col1:
+        ml = row.get("Moneyline")
+        ml_str = _to_american(ml) if pd.notna(ml) else "N/A"
+        st.metric("Moneyline", ml_str)
+    with col2:
+        ou = row.get("O/U")
+        ou_str = f"{ou:.1f}" if pd.notna(ou) and isinstance(ou, int | float) else "N/A"
+        st.metric("O/U Total", ou_str)
+    with col3:
+        dvpoa = row.get("DVPOA")
+        dvpoa_str = (
+            f"{dvpoa * 100:+.1f}%" if pd.notna(dvpoa) and isinstance(dvpoa, int | float) else "N/A"
+        )
+        st.metric("DVPOA", dvpoa_str)
 
-    team_corr = row.get("Team Correlation")
-    opp_corr = row.get("Opp Correlation")
-    st.markdown("**Recommended correlated bets**")
-    if isinstance(team_corr, str) and team_corr.strip():
-        st.markdown(f"_Same team:_ {team_corr}")
-    if isinstance(opp_corr, str) and opp_corr.strip():
-        st.markdown(f"_Opponent:_ {opp_corr}")
-    if not (isinstance(team_corr, str) and team_corr.strip()) and not (
-        isinstance(opp_corr, str) and opp_corr.strip()
-    ):
-        st.caption("No correlated legs cleared the display thresholds for this offer.")
+    # Three tabs: History, Model Distribution, Correlated Bets
+    tab1, tab2, tab3 = st.tabs(["📈 History", "〜 Model", "🔗 Correlated"])
+
+    with tab1:
+        stat_key = row.get("Stat", row.get("Market"))
+        line = row.get("Line")
+        player_hist = history.loc[
+            (history["Player"] == row["Player"])
+            & (history["League"] == row["League"])
+            & (history["Market"] == stat_key)
+        ].sort_values("GameDate")
+
+        if not player_hist.empty:
+            recent = player_hist.tail(15)
+            st.altair_chart(_history_chart(recent, line, "Last 15 games"), use_container_width=True)
+
+            h2h = player_hist.loc[player_hist["Opponent"] == row["Opponent"]]
+            if not h2h.empty:
+                st.altair_chart(
+                    _history_chart(h2h, line, f"vs {row['Opponent']}"), use_container_width=True
+                )
+            else:
+                st.caption(f"No H2H games vs {row['Opponent']} in current season window.")
+        else:
+            st.caption("No history available.")
+
+    with tab2:
+        dist = row.get("Dist")
+        ev = row.get("Model EV")
+        cv = row.get("CV")
+        line = row.get("Line")
+
+        if pd.notna(dist) and pd.notna(ev) and pd.notna(cv):
+            std = row.get("Model STD") or ev * 0.3
+            lo = max(0.0, ev - 4 * std)
+            hi = ev + 4 * std
+            step = 0.5 if dist in ("Gamma", "ZAGamma", "SkewNormal") else 1.0
+            xs = np.arange(lo, hi + step, step)
+
+            kw = {
+                k: row.get(k)
+                for k in ("Model R", "Model Alpha", "Model Sigma", "Model Skew", "Gate")
+            }
+            kw = {k: v for k, v in kw.items() if pd.notna(v) or (not isinstance(v, float))}
+
+            try:
+                cdf_vals = [get_odds(x, ev, dist, cv, **kw) for x in xs]
+                pmf_vals = np.diff([0.0, *cdf_vals])
+                xs_mid = xs[: len(pmf_vals)]
+
+                df_pdf = pd.DataFrame(
+                    {
+                        "x": xs_mid,
+                        "P": pmf_vals,
+                        "Side": ["Over" if x >= line else "Under" for x in xs_mid],
+                    }
+                )
+
+                chart = (
+                    alt.Chart(df_pdf)
+                    .mark_bar(size=max(4, 400 // max(len(xs_mid), 1)))
+                    .encode(
+                        x=alt.X("x:Q", title=row["Market"]),
+                        y=alt.Y("P:Q", title="Probability"),
+                        color=alt.Color(
+                            "Side:N",
+                            scale=alt.Scale(domain=["Over", "Under"], range=["#2196F3", "#FF7043"]),
+                            legend=alt.Legend(orient="top"),
+                        ),
+                        tooltip=["x:Q", "P:Q", "Side:N"],
+                    )
+                )
+                rule = (
+                    alt.Chart(pd.DataFrame({"Line": [line]}))
+                    .mark_rule(strokeDash=[6, 3], color="#FFFFFF", strokeWidth=1.5)
+                    .encode(x="Line:Q")
+                )
+                st.altair_chart(chart + rule, use_container_width=True)
+            except Exception as e:
+                st.error(f"Error computing distribution: {e}")
+        else:
+            st.caption("Distribution parameters unavailable — re-run `prophecize` to refresh.")
+
+    with tab3:
+        same_items = _parse_corr(row.get("Team Correlation"))
+        opp_items = _parse_corr(row.get("Opp Correlation"))
+
+        _render_corr_cards(same_items, f"Same team — {row['Team']}", filtered, "corr_same")
+        _render_corr_cards(opp_items, f"Opponent — {row['Opponent']}", filtered, "corr_opp")
+
+        if not same_items and not opp_items:
+            st.caption("No correlated legs cleared the display thresholds for this offer.")
 
 
+# --- AgGrid table ---
 display_cols = [c for c in MAIN_COLS if c in filtered.columns]
-styled = (
-    filtered[display_cols]
-    .style.apply(_highlight_hot, axis=1)
-    .format(
-        {
-            "Model P": "{:.3f}",
-            "Model": "{:.3f}",
-            "Books": "{:.3f}",
-            "Line": "{:.2f}",
-            "Boost": "{:.2f}",
-        }
-    )
+
+gb = GridOptionsBuilder.from_dataframe(filtered[display_cols])
+gb.configure_selection(selection_mode="single", use_checkbox=False)
+gb.configure_grid_options(rowStyle={"cursor": "pointer"})
+
+# Hot-row styling on Model column
+gb.configure_column(
+    "Model",
+    cellStyle={
+        "function": (
+            f"params.data.Model > {EV_HOT_THRESHOLD} && "
+            f"params.data.Books > {BOOKS_HOT_THRESHOLD} && "
+            f"params.data.Boost <= {BOOST_HOT_CEILING} "
+            f"? {{'backgroundColor': '{HIGHLIGHT_BG}', 'color': 'white'}} : {{}}"
+        )
+    },
 )
 
-event = st.dataframe(
-    styled,
-    use_container_width=True,
+go = gb.build()
+ag = AgGrid(
+    filtered[display_cols],
+    gridOptions=go,
+    update_mode=GridUpdateMode.SELECTION_CHANGED,
+    fit_columns_on_grid_load=True,
     height=720,
-    hide_index=True,
-    on_select="rerun",
-    selection_mode="single-row",
-    key="offers_table",
+    use_container_width=True,
 )
 
-selected_rows = event.selection.rows if event and event.selection else []
-if selected_rows:
-    _show_detail(filtered.iloc[selected_rows[0]])
+selected = ag.selected_rows
+if selected:
+    player = selected[0]["Player"]
+    idx = filtered.loc[filtered["Player"] == player].index[0]
+    if not st.session_state.detail_stack or st.session_state.detail_stack[-1] != idx:
+        st.session_state.detail_stack = [idx]
+
+if st.session_state.detail_stack:
+    row_idx = st.session_state.detail_stack[-1]
+    _show_detail(filtered.loc[row_idx], history, filtered)
 else:
-    st.caption("Select a row to see Model EV, Model std, push/odds context, and correlated bets.")
+    st.caption("Click a row to see charts and correlated bets.")
 
 with st.expander("Snapshot info"):
     st.json(meta)

--- a/src/sportstradamus/pages/2_🎯_Predictions_Parlays.py
+++ b/src/sportstradamus/pages/2_🎯_Predictions_Parlays.py
@@ -9,6 +9,7 @@ import pandas as pd
 import streamlit as st
 
 from sportstradamus.dashboard_data import (
+    format_ts,
     load_current_meta,
     load_current_parlays,
     render_banner,
@@ -28,7 +29,7 @@ st.set_page_config(page_title="Predictions — Parlays", layout="wide")
 st.title("Today's Parlay Candidates")
 
 meta = load_current_meta()
-generated = meta.get("generated_at", "no run on record")
+generated = format_ts(meta.get("generated_at", "no run on record"))
 render_banner(
     "predictions",
     f"generated {generated} · pooled payouts (power 2-3 legs, flex 4+ legs)",

--- a/src/sportstradamus/pages/2_🎯_Predictions_Parlays.py
+++ b/src/sportstradamus/pages/2_🎯_Predictions_Parlays.py
@@ -13,19 +13,26 @@ from sportstradamus.dashboard_data import (
     load_current_parlays,
     render_banner,
 )
-from sportstradamus.helpers import underdog_payouts
 
 LEG_COLS = [f"Leg {i}" for i in range(1, 7)]
 TOP_PARLAY_DEFAULT = 50
-CONTEST_VARIANTS = ["power", "flex", "insurance", "rivals"]
+
+# User-facing parlay sort options → (column, ascending).
+SORT_OPTIONS = {
+    "Model EV": ("Model EV", False),
+    "Recommended bet size": ("Rec Bet", False),
+    "Fun metric": ("Fun", False),
+}
 
 st.set_page_config(page_title="Predictions — Parlays", layout="wide")
 st.title("Today's Parlay Candidates")
 
 meta = load_current_meta()
 generated = meta.get("generated_at", "no run on record")
-scored_variant = meta.get("contest_variant", "power")
-render_banner("predictions", f"generated {generated} · scored as `{scored_variant}`")
+render_banner(
+    "predictions",
+    f"generated {generated} · pooled payouts (power 2-3 legs, flex 4+ legs)",
+)
 
 parlays = load_current_parlays()
 if parlays.empty:
@@ -35,6 +42,9 @@ if parlays.empty:
     )
     st.stop()
 
+if "Family" not in parlays.columns:
+    parlays["Family"] = 1
+
 col1, col2, col3, col4 = st.columns(4)
 with col1:
     leagues = sorted(parlays["League"].dropna().unique())
@@ -43,22 +53,10 @@ with col2:
     platforms = sorted(parlays["Platform"].dropna().unique()) if "Platform" in parlays else []
     selected_platforms = st.multiselect("Platform", platforms, default=platforms)
 with col3:
-    # Filters parlays to bet sizes the chosen variant actually pays out.
-    # EV columns reflect the run's scored variant (see banner).
-    default_idx = (
-        CONTEST_VARIANTS.index(scored_variant) if scored_variant in CONTEST_VARIANTS else 0
-    )
-    contest_variant = st.selectbox("Contest variant", CONTEST_VARIANTS, index=default_idx)
+    sort_label = st.selectbox("Sort parlays by", list(SORT_OPTIONS), index=0)
 with col4:
     top_n = st.number_input(
         "Show top N parlays", min_value=10, max_value=500, value=TOP_PARLAY_DEFAULT, step=10
-    )
-
-if contest_variant != scored_variant:
-    st.warning(
-        f"Showing only bet sizes payable under **{contest_variant}**. EV columns "
-        f"still reflect the **{scored_variant}** payout schedule the run was scored "
-        "under — re-run `prophecize --contest-variant " + contest_variant + "` to re-score."
     )
 
 view = parlays
@@ -66,45 +64,67 @@ if selected_leagues:
     view = view.loc[view["League"].isin(selected_leagues)]
 if selected_platforms and "Platform" in view:
     view = view.loc[view["Platform"].isin(selected_platforms)]
-if "Bet Size" in view.columns:
-    allowed_sizes = {int(k) for k in underdog_payouts.get(contest_variant, {})}
-    if allowed_sizes:
-        view = view.loc[view["Bet Size"].isin(allowed_sizes)]
 
-view = view.sort_values("Model EV", ascending=False).head(int(top_n))
+sort_col, ascending = SORT_OPTIONS[sort_label]
+if sort_col in view.columns:
+    view = view.sort_values(sort_col, ascending=ascending)
+view = view.head(int(top_n))
 st.caption(f"Showing **{len(view):,}** of {len(parlays):,} parlays")
+
+
+def _render_parlay(row: pd.Series) -> None:
+    with st.container(border=True):
+        indep_p = row.get("Indep P")
+        show_indep = pd.notna(indep_p)
+        meta_cols = st.columns(6 if show_indep else 5)
+        meta_cols[0].metric("Model EV", f"{row['Model EV']:.2f}")
+        meta_cols[1].metric("Books EV", f"{row.get('Books EV', float('nan')):.2f}")
+        meta_cols[2].metric("Boost", f"{row.get('Boost', float('nan')):.2f}x")
+        meta_cols[3].metric("Bet Size", row.get("Bet Size", "—"))
+        meta_cols[4].metric("Fun", f"{row.get('Fun', float('nan')):.2f}")
+        if show_indep:
+            # Indep P is the no-correlation joint; comparing it to the joint P
+            # reveals how much correlation lifted (or sank) the row.
+            joint_p = row.get("P", float("nan"))
+            delta = (joint_p - indep_p) if pd.notna(joint_p) else None
+            meta_cols[5].metric(
+                "Joint vs Indep",
+                f"{joint_p:.3f}" if pd.notna(joint_p) else "—",
+                f"{delta:+.3f}" if delta is not None else None,
+                help="Correlation-aware joint P vs independence-assumption Indep P.",
+            )
+        legs = [row.get(c) for c in LEG_COLS if isinstance(row.get(c), str) and row.get(c)]
+        for leg in legs:
+            st.text(f"  • {leg}")
+        if pd.notna(row.get("Rec Bet")):
+            st.caption(f"Recommended bet: {row['Rec Bet']:.2f} units")
+
 
 for game, group in view.groupby("Game", sort=False):
     top_ev = group["Model EV"].max()
     with st.expander(f"{game} — {len(group)} parlays, top EV {top_ev:.2f}"):
-        for _, row in group.iterrows():
-            with st.container(border=True):
-                # Six tiles when Indep P is available, five otherwise — keeps
-                # the layout balanced for older runs that pre-date correlation.
-                indep_p = row.get("Indep P")
-                show_indep = pd.notna(indep_p)
-                meta_cols = st.columns(6 if show_indep else 5)
-                meta_cols[0].metric("Model EV", f"{row['Model EV']:.2f}")
-                meta_cols[1].metric("Books EV", f"{row.get('Books EV', float('nan')):.2f}")
-                meta_cols[2].metric("Boost", f"{row.get('Boost', float('nan')):.2f}x")
-                meta_cols[3].metric("Bet Size", row.get("Bet Size", "—"))
-                meta_cols[4].metric("Fun", f"{row.get('Fun', float('nan')):.2f}")
-                if show_indep:
-                    # Indep P is the no-correlation joint; comparing it to the
-                    # joint P reveals how much correlation lifted (or sank) the row.
-                    joint_p = row.get("P", float("nan"))
-                    delta = (joint_p - indep_p) if pd.notna(joint_p) else None
-                    meta_cols[5].metric(
-                        "Joint vs Indep",
-                        f"{joint_p:.3f}" if pd.notna(joint_p) else "—",
-                        f"{delta:+.3f}" if delta is not None else None,
-                        help="Correlation-aware joint P vs independence-assumption Indep P.",
-                    )
-                legs = [row.get(c) for c in LEG_COLS if isinstance(row.get(c), str) and row.get(c)]
-                for leg in legs:
-                    st.text(f"  • {leg}")
-                if pd.notna(row.get("Rec Bet")):
-                    st.caption(f"Recommended bet: {row['Rec Bet']:.2f} units")
+        families = sorted(group["Family"].dropna().unique())
+        if len(families) > 1:
+            fam_choice = st.selectbox(
+                "Family (independence cluster)",
+                ["All"] + [f"Family {int(f)}" for f in families],
+                key=f"family_{game}",
+                help=(
+                    "The backend clusters this game's parlays into up to three "
+                    "families by how independent they are from each other."
+                ),
+            )
+        else:
+            fam_choice = "All"
+
+        for fam in families:
+            if fam_choice != "All" and fam_choice != f"Family {int(fam)}":
+                continue
+            fam_group = group.loc[group["Family"] == fam]
+            if len(families) > 1:
+                st.markdown(f"**Family {int(fam)}** — {len(fam_group)} parlays")
+            for _, row in fam_group.iterrows():
+                _render_parlay(row)
 
 with st.expander("Snapshot info"):
     st.json(meta)

--- a/src/sportstradamus/pages/3_📊_Stats_Overview.py
+++ b/src/sportstradamus/pages/3_📊_Stats_Overview.py
@@ -13,6 +13,7 @@ from sklearn.metrics import brier_score_loss
 
 from sportstradamus import clv
 from sportstradamus.dashboard_data import (
+    format_ts,
     get_filtered_history,
     load_history,
     load_parlays,
@@ -34,7 +35,7 @@ if history.empty:
 
 meta = load_resolve_meta()
 if meta.get("last_run"):
-    st.caption(f"Data last resolved: {meta['last_run']}")
+    st.caption(f"Data last resolved: {format_ts(meta['last_run'])}")
 else:
     st.warning(
         "Nightly resolution has not run yet. Run `poetry run reflect` to resolve prediction outcomes."

--- a/src/sportstradamus/pages/4_📊_Stats_Diagnostics.py
+++ b/src/sportstradamus/pages/4_📊_Stats_Diagnostics.py
@@ -24,6 +24,7 @@ from sportstradamus.analysis import (
     murphy_decomposition,
 )
 from sportstradamus.dashboard_data import (
+    format_ts,
     get_filtered_history,
     get_prediction_history,
     load_history,
@@ -52,7 +53,7 @@ if history.empty:
 
 meta = load_resolve_meta()
 if meta.get("last_run"):
-    st.caption(f"Data last resolved: {meta['last_run']}")
+    st.caption(f"Data last resolved: {format_ts(meta['last_run'])}")
 
 # --- Sidebar filters (time window first, then league/platform) ---
 st.sidebar.header("Filters")

--- a/src/sportstradamus/pages/5_📊_Stats_Correlations.py
+++ b/src/sportstradamus/pages/5_📊_Stats_Correlations.py
@@ -13,6 +13,7 @@ import plotly.graph_objects as go
 import streamlit as st
 
 from sportstradamus.dashboard_data import (
+    format_ts,
     load_history,
     load_parlays,
     load_resolve_meta,
@@ -42,7 +43,7 @@ if parlays.empty:
 
 meta = load_resolve_meta()
 if meta.get("last_run"):
-    st.caption(f"Data last resolved: {meta['last_run']}")
+    st.caption(f"Data last resolved: {format_ts(meta['last_run'])}")
 
 # --- Sidebar: time window first, then league/platform ---
 st.sidebar.header("Filters")

--- a/src/sportstradamus/pages/6_📊_Stats_Profit_Sim.py
+++ b/src/sportstradamus/pages/6_📊_Stats_Profit_Sim.py
@@ -13,6 +13,7 @@ import plotly.graph_objects as go
 import streamlit as st
 
 from sportstradamus.dashboard_data import (
+    format_ts,
     get_filtered_history,
     load_history,
     load_resolve_meta,
@@ -30,7 +31,7 @@ if history.empty:
 
 meta = load_resolve_meta()
 if meta.get("last_run"):
-    st.caption(f"Data last resolved: {meta['last_run']}")
+    st.caption(f"Data last resolved: {format_ts(meta['last_run'])}")
 
 # --- Explode offers and filter to resolved, non-push ---
 df = get_filtered_history(history)

--- a/src/sportstradamus/pages/7_📊_Stats_Model_Training.py
+++ b/src/sportstradamus/pages/7_📊_Stats_Model_Training.py
@@ -17,7 +17,7 @@ sys.path.insert(0, str(pathlib.Path(__file__).parent.parent.parent))
 import pandas as pd
 import streamlit as st
 
-from sportstradamus.dashboard_data import load_model_stats, render_banner
+from sportstradamus.dashboard_data import format_ts, load_model_stats, render_banner
 from sportstradamus.helpers.io import MODEL_STATS_PATH
 
 # The "calibrated" row carries the post-correction performance the model
@@ -196,7 +196,7 @@ st.set_page_config(page_title="Stats — Model Training", layout="wide")
 st.title("Model Training Diagnostics")
 
 mtime = (
-    dt.datetime.fromtimestamp(MODEL_STATS_PATH.stat().st_mtime).isoformat(timespec="seconds")
+    format_ts(dt.datetime.fromtimestamp(MODEL_STATS_PATH.stat().st_mtime).isoformat(timespec="seconds"))
     if MODEL_STATS_PATH.is_file()
     else "no meditate run on record"
 )

--- a/src/sportstradamus/pages/7_📊_Stats_Model_Training.py
+++ b/src/sportstradamus/pages/7_📊_Stats_Model_Training.py
@@ -196,7 +196,9 @@ st.set_page_config(page_title="Stats — Model Training", layout="wide")
 st.title("Model Training Diagnostics")
 
 mtime = (
-    format_ts(dt.datetime.fromtimestamp(MODEL_STATS_PATH.stat().st_mtime).isoformat(timespec="seconds"))
+    format_ts(
+        dt.datetime.fromtimestamp(MODEL_STATS_PATH.stat().st_mtime).isoformat(timespec="seconds")
+    )
     if MODEL_STATS_PATH.is_file()
     else "no meditate run on record"
 )

--- a/src/sportstradamus/prediction/cli.py
+++ b/src/sportstradamus/prediction/cli.py
@@ -122,6 +122,7 @@ def main(progress, legacy_correlation, contest_variant, log_level):
             legacy=legacy_correlation,
         )
         parlay_df = pd.concat([parlay_df, ud5])
+        ud_offers["Stat"] = ud_offers["Market"]  # preserve gamelog key before remap
         ud_offers["Market"] = ud_offers["Market"].map(stat_map["Underdog"])
         ud_offers.loc[ud_offers["Bet"] == "Over", "Boost"] = (
             1.78 * ud_offers.loc[ud_offers["Bet"] == "Over", "Boost"]
@@ -145,6 +146,7 @@ def main(progress, legacy_correlation, contest_variant, log_level):
             legacy=legacy_correlation,
         )
         parlay_df = pd.concat([parlay_df, sl5])
+        sl_offers["Stat"] = sl_offers["Market"]  # preserve gamelog key before remap
         sl_offers["Market"] = sl_offers["Market"].map(stat_map["Sleeper"])
         sl_offers.loc[sl_offers["Bet"] == "Under", "Boost"] = (
             1.78 * 1.78 / sl_offers.loc[sl_offers["Bet"] == "Under", "Boost"]
@@ -162,12 +164,20 @@ def main(progress, legacy_correlation, contest_variant, log_level):
         parlay_df.reset_index(drop=True, inplace=True)
         parlay_df[["Legs", "Misses", "Profit"]] = np.nan
 
+    # Overwrite O/U percentage with raw game total from Archive
+    if not snapshot_offers.empty and "O/U" in snapshot_offers.columns:
+        snapshot_offers["O/U"] = snapshot_offers.apply(
+            lambda r: archive.get_total(r["League"], r["Date"], r["Team"]) or r["O/U"],
+            axis=1,
+        )
+
     write_current_offers(
         snapshot_offers,
         parlay_df,
         sports,
         platforms_run,
         contest_variant=contest_variant,
+        stats_dict=stats,
     )
 
     # --- Append to rolling parlay history ---

--- a/src/sportstradamus/prediction/cli.py
+++ b/src/sportstradamus/prediction/cli.py
@@ -58,12 +58,12 @@ _HISTORY_RETENTION_DAYS = 365
 )
 @click.option(
     "--contest-variant",
-    type=click.Choice(["power", "flex", "insurance", "rivals"]),
-    default="power",
+    type=click.Choice(["pooled", "power", "flex", "insurance", "rivals"]),
+    default="pooled",
     help=(
-        "Underdog contest variant for parlay scoring. Default 'power' "
-        "matches the displayed Boost column historically; 'insurance' "
-        "matches the legacy ranking line."
+        "Underdog payout pool for parlay scoring. Default 'pooled' "
+        "combines power (2-3 legs) and flex (4+ legs) into one pool; "
+        "single-variant names are kept for the pickem-build path."
     ),
 )
 @click.option(

--- a/src/sportstradamus/prediction/correlation.py
+++ b/src/sportstradamus/prediction/correlation.py
@@ -167,7 +167,7 @@ def find_correlation(
     stats,
     platform,
     *,
-    contest_variant: Literal["power", "flex", "insurance", "rivals"] = "power",
+    contest_variant: Literal["pooled", "power", "flex", "insurance", "rivals"] = "pooled",
     legacy: bool = False,
 ):
     """Annotate offers with correlation info and build parlay candidates.
@@ -180,11 +180,10 @@ def find_correlation(
         offers: List of scored offer dicts from :func:`process_offers`.
         stats: ``{league: Stats}`` dict for active leagues.
         platform: DFS platform name (e.g. ``"Underdog"``).
-        contest_variant: Underdog contest variant ("power", "flex",
-            "insurance", "rivals"). Ignored for non-Underdog platforms.
-            Default "power" matches the displayed Boost column historically;
-            ranking changes vs. legacy because legacy ranked at the insurance
-            line — use ``legacy=True`` for bit-for-bit historical behavior.
+        contest_variant: Underdog payout pool. Default ``"pooled"`` combines
+            ``power`` (sizes 2-3) and ``flex`` (sizes 4+) into one pool;
+            the single-variant names are accepted for the ``pickem-build``
+            path. Ignored for non-Underdog platforms.
         legacy: When True, reproduce the pre-2026.05 pipeline verbatim — no
             PSD repair, no push-aware EV, mixed insurance/power Boost
             overwrite at line 498. Removed next release.

--- a/src/sportstradamus/prediction/model_prob.py
+++ b/src/sportstradamus/prediction/model_prob.py
@@ -207,23 +207,29 @@ def model_prob(offers, league, market, platform, stat_data, playerStats):
         # Book-side probability
         if dist == "SkewNormal":
             offer_df["Books"] = offer_df.apply(
-                lambda x: 1
-                - get_odds(
-                    x["Line"],
-                    x["Books EV"],
-                    dist,
-                    cv=cv,
-                    step=step,
-                    sigma=x["Books EV"] * cv,
-                    skew_alpha=0,
-                    gate=hist_gate or None,
+                lambda x: (
+                    1
+                    - get_odds(
+                        x["Line"],
+                        x["Books EV"],
+                        dist,
+                        cv=cv,
+                        step=step,
+                        sigma=x["Books EV"] * cv,
+                        skew_alpha=0,
+                        gate=hist_gate or None,
+                    )
                 ),
                 axis=1,
             )
         else:
             offer_df["Books"] = offer_df.apply(
-                lambda x: 1
-                - get_odds(x["Line"], x["Books EV"], dist, cv, step=step, gate=hist_gate or None),
+                lambda x: (
+                    1
+                    - get_odds(
+                        x["Line"], x["Books EV"], dist, cv, step=step, gate=hist_gate or None
+                    )
+                ),
                 axis=1,
             )
 
@@ -405,9 +411,11 @@ def model_prob(offers, league, market, platform, stat_data, playerStats):
             0
         ).infer_objects(copy=False) * (1.78 if platform == "Underdog" else 1)
         offer_df["Boost"] = offer_df.apply(
-            lambda x: (x["Boost_Over"] if x["Bet"] == "Over" else x["Boost_Under"])
-            if not np.isnan(x["Boost_Over"])
-            else x["Boost"],
+            lambda x: (
+                (x["Boost_Over"] if x["Bet"] == "Over" else x["Boost_Under"])
+                if not np.isnan(x["Boost_Over"])
+                else x["Boost"]
+            ),
             axis=1,
         )
 
@@ -448,6 +456,28 @@ def model_prob(offers, league, market, platform, stat_data, playerStats):
         else:
             offer_df["Model Param"] = offer_df["Model Alpha"]
 
+        # Display-only standard deviation of the blended model distribution.
+        # Approximations on the overall mean are sufficient for the dashboard
+        # detail popup; they do not feed any scoring path.
+        _m = offer_df["Model EV"].to_numpy(dtype=float)
+        if dist in ("NegBin", "ZINB") and "Model R" in offer_df.columns:
+            _r = offer_df["Model R"].to_numpy(dtype=float)
+            offer_df["Model STD"] = np.sqrt(np.clip(_m + _m**2 / np.clip(_r, 1e-6, None), 0, None))
+        elif dist == "SkewNormal" and "Model Sigma" in offer_df.columns:
+            _sg = offer_df["Model Sigma"].to_numpy(dtype=float)
+            _sk = (
+                offer_df["Model Skew"].to_numpy(dtype=float)
+                if "Model Skew" in offer_df.columns
+                else np.zeros_like(_sg)
+            )
+            _delta = _sk / np.sqrt(1 + _sk**2)
+            offer_df["Model STD"] = _sg * np.sqrt(np.clip(1 - 2 * _delta**2 / np.pi, 0, None))
+        elif "Model Alpha" in offer_df.columns:
+            _a = offer_df["Model Alpha"].to_numpy(dtype=float)
+            offer_df["Model STD"] = _m / np.sqrt(np.clip(_a, 1e-6, None))
+        else:
+            offer_df["Model STD"] = np.nan
+
         offer_df["Dist"] = dist
         offer_df["CV"] = cv
         offer_df["Gate"] = offer_df.get("Model Gate", np.nan)
@@ -476,6 +506,7 @@ def model_prob(offers, league, market, platform, stat_data, playerStats):
                 "Player position",
                 "Model EV",
                 "Model Param",
+                "Model STD",
                 "Model P",
                 "Push P",
                 "Books EV",

--- a/src/sportstradamus/prediction/parlay.py
+++ b/src/sportstradamus/prediction/parlay.py
@@ -55,10 +55,38 @@ _PUSH_MC_SAMPLES: int = 50_000
 # Kelly sizing denominator: 5% bankroll per unit. Legacy.
 _KELLY_BANKROLL_FRACTION: float = 0.05
 
+# Pooled-variant split: slips of this size or smaller pay on the all-or-nothing
+# ``power`` schedule; larger slips pay on the partial-hit ``flex`` schedule.
+_POWER_MAX_SIZE: int = 3
+
+
+def _pooled_underdog_curve() -> dict[int, list[float]]:
+    """Build the single combined Underdog payout pool keyed by bet size.
+
+    Underdog entries are not separate interchangeable contests: a 2- or
+    3-leg slip pays out on the all-or-nothing ``power`` schedule, while a
+    4+-leg slip pays out on the partial-hit ``flex`` schedule. ``rivals``
+    legs carry no special schedule — they sit in the same pool as any
+    other leg. The legacy ``insurance`` table is an old alias of ``flex``
+    and is intentionally not consulted here.
+    """
+    power = underdog_payouts["power"]
+    flex = underdog_payouts["flex"]
+    curve: dict[int, list[float]] = {}
+    for sz_str, mult in power.items():
+        sz = int(sz_str)
+        if sz <= _POWER_MAX_SIZE:
+            curve[sz] = [float(mult), 0.0]
+    for sz_str, row in flex.items():
+        sz = int(sz_str)
+        if sz > _POWER_MAX_SIZE:
+            curve[sz] = [float(v) for v in row]
+    return curve
+
 
 def _payout_curve_for(
     platform: str,
-    contest_variant: Literal["power", "flex", "insurance", "rivals"],
+    contest_variant: Literal["pooled", "power", "flex", "insurance", "rivals"],
     legacy: bool,
 ) -> tuple[list[float], dict[int, list[float]]]:
     """Build the (per-size search list, per-(size,misses) payout table) for a platform.
@@ -67,9 +95,11 @@ def _payout_curve_for(
     indexed ``[bet_size - 2]``). The second drives push-aware EV and the
     display ``Boost`` column (full payout curve indexed by miss count).
 
-    Underdog pulls from ``data/underdog_payouts.json`` per the chosen
-    ``contest_variant``. Other platforms (PrizePicks, Sleeper, ParlayPlay,
-    Chalkboard) keep the legacy single-payout table.
+    Underdog pulls from ``data/underdog_payouts.json``. The default
+    ``"pooled"`` variant builds one combined pool (``power`` for sizes 2-3,
+    ``flex`` for sizes 4+); the legacy single-variant names are still
+    accepted for the ``pickem-build`` path. Other platforms (PrizePicks,
+    Sleeper, ParlayPlay, Chalkboard) keep the legacy single-payout table.
     """
     # Deferred import: legacy shims live in ``correlation.py`` per
     # CONTRIBUTING.md §Package Map; importing at module scope would create a
@@ -97,6 +127,14 @@ def _payout_curve_for(
         lst = legacy_tables[platform]
         full = {i + 2: [lst[i], 0.0] for i in range(len(lst))}
         return lst, full
+
+    if contest_variant == "pooled":
+        full_curve = _pooled_underdog_curve()
+        max_size = max(full_curve.keys())
+        for sz in range(2, max_size + 1):
+            full_curve.setdefault(sz, [0.0])
+        search = [full_curve[sz][0] for sz in range(2, max_size + 1)]
+        return search, full_curve
 
     variant_table = underdog_payouts[contest_variant]
     if contest_variant in ("flex", "insurance"):
@@ -227,7 +265,7 @@ def beam_search_parlays(
     team,
     opp,
     *,
-    contest_variant: Literal["power", "flex", "insurance", "rivals"] = "power",
+    contest_variant: Literal["pooled", "power", "flex", "insurance", "rivals"] = "pooled",
     legacy: bool = False,
 ):
     """Enumerate top parlay combinations via beam search.

--- a/src/sportstradamus/prediction/persist.py
+++ b/src/sportstradamus/prediction/persist.py
@@ -23,9 +23,10 @@ from sportstradamus.helpers.io import (
 
 # Display columns kept in current_offers.parquet. Internal model-tuning cols
 # (`Model Param`, `Dist`, `CV`, `Gate`, `Temperature`, `Disp Cal`, `Step`,
-# `Model P`, `Books P`, `K`, `Player position`) are dropped — the dashboard
-# is a renderer, not a re-scorer. `Push P` is kept so the parlay page can
-# show per-leg push probability for integer-line discrete markets.
+# `Books P`, `K`, `Player position`) are dropped — the dashboard is a
+# renderer, not a re-scorer. `Model P` (hit probability), `Model STD`, and
+# the correlation strings are kept so the dashboard can show them in the
+# main table and the per-row detail popup.
 _OFFER_KEEP_COLS = [
     "League",
     "Date",
@@ -37,16 +38,24 @@ _OFFER_KEEP_COLS = [
     "Bet",
     "Line",
     "Boost",
-    "Model EV",
+    "Model P",
     "Model",
     "Books",
+    "Model EV",
+    "Model STD",
     "Push P",
     "Avg 5",
     "Avg H2H",
     "Moneyline",
     "O/U",
     "DVPOA",
+    "Team Correlation",
+    "Opp Correlation",
 ]
+
+# A row with no boost, no model edge, and no book edge carries no signal —
+# it is a scoring artifact and is dropped before the snapshot is written.
+_OFFER_SIGNAL_COLS = ["Boost", "Model", "Books"]
 
 # Internal correlation cols dropped from current_parlays.parquet — these are
 # scoring artifacts not useful for human review. `Indep P` is kept (independence
@@ -59,7 +68,7 @@ def write_current_offers(
     parlays: pd.DataFrame,
     leagues: Iterable[str],
     platforms: Iterable[str],
-    contest_variant: str = "power",
+    contest_variant: str = "pooled",
 ) -> None:
     """Write the current-run snapshot atomically.
 
@@ -93,10 +102,14 @@ def _normalize_offers(offers: pd.DataFrame) -> pd.DataFrame:
         return pd.DataFrame(columns=_OFFER_KEEP_COLS)
     df = offers.copy()
     df = df.replace([np.inf, -np.inf], np.nan)
+    signal_cols = [c for c in _OFFER_SIGNAL_COLS if c in df.columns]
+    if signal_cols:
+        signal = df[signal_cols].fillna(0)
+        df = df.loc[(signal != 0).any(axis=1)]
     keep = [c for c in _OFFER_KEEP_COLS if c in df.columns]
     df = df[keep]
-    if "Model EV" in df.columns:
-        df = df.sort_values("Model EV", ascending=False, ignore_index=True)
+    if "Model" in df.columns:
+        df = df.sort_values("Model", ascending=False, ignore_index=True)
     return df
 
 

--- a/src/sportstradamus/prediction/persist.py
+++ b/src/sportstradamus/prediction/persist.py
@@ -14,6 +14,7 @@ import numpy as np
 import pandas as pd
 
 from sportstradamus.helpers.io import (
+    CURRENT_HISTORY_PATH,
     CURRENT_META_PATH,
     CURRENT_OFFERS_PATH,
     CURRENT_PARLAYS_PATH,
@@ -51,6 +52,14 @@ _OFFER_KEEP_COLS = [
     "DVPOA",
     "Team Correlation",
     "Opp Correlation",
+    "Stat",
+    "Dist",
+    "CV",
+    "Gate",
+    "Model R",
+    "Model Alpha",
+    "Model Sigma",
+    "Model Skew",
 ]
 
 # A row with no boost, no model edge, and no book edge carries no signal —
@@ -63,12 +72,76 @@ _OFFER_SIGNAL_COLS = ["Boost", "Model", "Books"]
 _PARLAY_DROP_COLS = ["Leg Probs", "Corr Pairs", "Boost Pairs", "Indep PB"]
 
 
+def write_player_history(offers_df: pd.DataFrame, stats_dict: dict) -> None:
+    """Write per-game player stat history for offers in the current run.
+
+    For each unique (Player, League, Stat) in offers_df, extract all game-level
+    stat values from the Stats object's short_gamelog (full season window).
+    Writes a long-format parquet with columns: Player, League, Market, GameDate,
+    Opponent, StatValue, GameNum (1=oldest).
+
+    Silent guards: skips players/stats that don't exist in stats_dict or gamelog.
+    """
+    history_rows = []
+    for (player, league, stat), group in offers_df.groupby(
+        ["Player", "League", "Stat"], dropna=False
+    ):
+        if not isinstance(stat, str) or pd.isna(stat):
+            continue
+        stat_obj = stats_dict.get(league)
+        if stat_obj is None or not hasattr(stat_obj, "short_gamelog"):
+            continue
+
+        player_col = stat_obj.log_strings.get("player")
+        date_col = stat_obj.log_strings.get("date")
+        opp_col = stat_obj.log_strings.get("opponent")
+        if not all([player_col, date_col, opp_col, stat in stat_obj.short_gamelog.columns]):
+            continue
+
+        player_games = stat_obj.short_gamelog[stat_obj.short_gamelog[player_col] == player]
+        if player_games.empty:
+            continue
+
+        for game_num, (_, row) in enumerate(player_games.iterrows(), 1):
+            history_rows.append(
+                {
+                    "Player": player,
+                    "League": league,
+                    "Market": stat,
+                    "GameDate": row[date_col],
+                    "Opponent": row[opp_col],
+                    "StatValue": row[stat],
+                    "GameNum": game_num,
+                }
+            )
+
+    if history_rows:
+        history_df = pd.DataFrame(history_rows)
+        _atomic_write_parquet(history_df, CURRENT_HISTORY_PATH)
+    else:
+        _atomic_write_parquet(
+            pd.DataFrame(
+                columns=[
+                    "Player",
+                    "League",
+                    "Market",
+                    "GameDate",
+                    "Opponent",
+                    "StatValue",
+                    "GameNum",
+                ]
+            ),
+            CURRENT_HISTORY_PATH,
+        )
+
+
 def write_current_offers(
     offers: pd.DataFrame,
     parlays: pd.DataFrame,
     leagues: Iterable[str],
     platforms: Iterable[str],
     contest_variant: str = "pooled",
+    stats_dict: dict | None = None,
 ) -> None:
     """Write the current-run snapshot atomically.
 
@@ -78,6 +151,9 @@ def write_current_offers(
     variant the parlays were scored under, recorded in meta so the dashboard
     can display which payout schedule the EV column reflects. Empty inputs
     are still written so the dashboard reflects the most recent run.
+
+    If `stats_dict` is provided, also writes current_history.parquet with
+    per-game stat values for each player+stat combo in the offers.
     """
     offers_out = _normalize_offers(offers)
     parlays_out = _normalize_parlays(parlays)
@@ -95,6 +171,9 @@ def write_current_offers(
         },
         CURRENT_META_PATH,
     )
+
+    if stats_dict:
+        write_player_history(offers_out, stats_dict)
 
 
 def _normalize_offers(offers: pd.DataFrame) -> pd.DataFrame:

--- a/src/sportstradamus/prediction/scoring.py
+++ b/src/sportstradamus/prediction/scoring.py
@@ -33,7 +33,7 @@ archive = Archive()
 
 
 @line_profiler.profile
-def process_offers(offer_dict, book, stats, *, contest_variant="power", legacy=False):
+def process_offers(offer_dict, book, stats, *, contest_variant="pooled", legacy=False):
     """Score all offers from one platform and return annotated DataFrames.
 
     Iterates every league/market pair in ``offer_dict``, adds DFS lines to

--- a/src/sportstradamus/stats/nba.py
+++ b/src/sportstradamus/stats/nba.py
@@ -675,9 +675,7 @@ class StatsNBA(Stats):
                     pbar.update(1)
                 break
             except Exception as e:
-                logger.warning(
-                    "NBA league endpoint fetch failed (attempt %d/10): %s", i + 1, e
-                )
+                logger.warning("NBA league endpoint fetch failed (attempt %d/10): %s", i + 1, e)
                 playerBios = []
                 shotData = {"rowSet": [], "headers": [{}, {"columnNames": []}]}
                 postup = {"rowSet": [], "headers": []}
@@ -923,9 +921,9 @@ class StatsNBA(Stats):
                     leave=False,
                 ) as pbar:
                     pbar.set_postfix_str("PlayerGameLogs:Base")
-                    nba_gamelog = nba.playergamelogs.PlayerGameLogs(
-                        **params
-                    ).get_normalized_dict()["PlayerGameLogs"]
+                    nba_gamelog = nba.playergamelogs.PlayerGameLogs(**params).get_normalized_dict()[
+                        "PlayerGameLogs"
+                    ]
                     pbar.update(1)
 
                     pbar.set_postfix_str("PlayerGameLogs:Advanced")
@@ -941,9 +939,9 @@ class StatsNBA(Stats):
                     pbar.update(1)
 
                     pbar.set_postfix_str("TeamGameLogs:Base")
-                    teamlog = nba.teamgamelogs.TeamGameLogs(
-                        **(params)
-                    ).get_normalized_dict()["TeamGameLogs"]
+                    teamlog = nba.teamgamelogs.TeamGameLogs(**(params)).get_normalized_dict()[
+                        "TeamGameLogs"
+                    ]
                     pbar.update(1)
 
                     pbar.set_postfix_str("TeamGameLogs:Scoring")
@@ -1050,9 +1048,7 @@ class StatsNBA(Stats):
 
                 break
             except Exception as e:
-                logger.warning(
-                    "NBA gamelog fetch failed (attempt %d/10): %s", i + 1, e
-                )
+                logger.warning("NBA gamelog fetch failed (attempt %d/10): %s", i + 1, e)
                 sleep(0.2)
                 i += 1
 

--- a/tests/golden/fixtures/prophecize_help.txt
+++ b/tests/golden/fixtures/prophecize_help.txt
@@ -10,11 +10,11 @@ Options:
                                   mixed insurance/power Boost overwrite. Removed
                                   next release; provided as a one-cycle escape
                                   hatch.
-  --contest-variant [power|flex|insurance|rivals]
-                                  Underdog contest variant for parlay scoring.
-                                  Default 'power' matches the displayed Boost
-                                  column historically; 'insurance' matches the
-                                  legacy ranking line.
+  --contest-variant [pooled|power|flex|insurance|rivals]
+                                  Underdog payout pool for parlay scoring.
+                                  Default 'pooled' combines power (2-3 legs) and
+                                  flex (4+ legs) into one pool; single-variant
+                                  names are kept for the pickem-build path.
   --log-level [DEBUG|INFO|WARNING|ERROR]
                                   Verbosity for the structured JSONL log.
   --help                          Show this message and exit.

--- a/tests/golden/test_archive_wal_recovery.py
+++ b/tests/golden/test_archive_wal_recovery.py
@@ -42,8 +42,7 @@ def _build_corrupt_wal(tmp_path: Path) -> Path:
         "entity TEXT, book TEXT, ev DOUBLE, sample_ts TIMESTAMP)"
     )
     con.execute(
-        "CREATE TABLE lines (league TEXT, market TEXT, game_date DATE, "
-        "entity TEXT, line DOUBLE)"
+        "CREATE TABLE lines (league TEXT, market TEXT, game_date DATE, " "entity TEXT, line DOUBLE)"
     )
     con.execute("CHECKPOINT")
     con.close()
@@ -93,20 +92,17 @@ def test_archive_recovers_from_stale_wal(tmp_path, monkeypatch):
             warnings.simplefilter("always")
             archive = Archive()
 
-        recovery_warnings = [
-            w for w in caught if "Discarded stale DuckDB WAL" in str(w.message)
-        ]
-        assert len(recovery_warnings) == 1, (
-            f"expected exactly one recovery warning, got {[str(w.message) for w in caught]}"
-        )
+        recovery_warnings = [w for w in caught if "Discarded stale DuckDB WAL" in str(w.message)]
+        assert (
+            len(recovery_warnings) == 1
+        ), f"expected exactly one recovery warning, got {[str(w.message) for w in caught]}"
 
         quarantined = [
-            p for p in tmp_path.iterdir()
-            if p.name.startswith("archive.duckdb.wal.corrupt-")
+            p for p in tmp_path.iterdir() if p.name.startswith("archive.duckdb.wal.corrupt-")
         ]
-        assert len(quarantined) == 1, (
-            f"expected one quarantined WAL, got {sorted(p.name for p in tmp_path.iterdir())}"
-        )
+        assert (
+            len(quarantined) == 1
+        ), f"expected one quarantined WAL, got {sorted(p.name for p in tmp_path.iterdir())}"
 
         assert archive._connection.execute("SELECT COUNT(*) FROM odds").fetchone() == (0,)
     finally:
@@ -131,5 +127,3 @@ def test_unrelated_catalog_exception_propagates(tmp_path, monkeypatch):
     finally:
         _reset_archive_singleton()
         monkeypatch.delenv("SPORTSTRADAMUS_ARCHIVE_DB", raising=False)
-
-

--- a/tests/integration/test_end_to_end.py
+++ b/tests/integration/test_end_to_end.py
@@ -167,7 +167,7 @@ def test_pipeline_smoke(
 
     snapshot_calls: list[dict] = []
 
-    def stub_write_current_offers(offers, parlays, leagues, platforms, contest_variant="power"):
+    def stub_write_current_offers(offers, parlays, leagues, platforms, contest_variant="power", stats_dict=None):
         snapshot_calls.append(
             {
                 "offers": offers,

--- a/tests/integration/test_end_to_end.py
+++ b/tests/integration/test_end_to_end.py
@@ -102,17 +102,16 @@ def test_pipeline_smoke(
         archive_obj._connection.execute("SELECT COUNT(*) FROM odds").fetchone()[0]
     )
     assert second_poll_rows > first_poll_rows, (
-        f"second confer poll did not append new rows: "
-        f"{first_poll_rows} -> {second_poll_rows}"
+        f"second confer poll did not append new rows: " f"{first_poll_rows} -> {second_poll_rows}"
     )
 
     sample_player = next(iter(pts_df.index))[1] if not pts_df.empty else None
     if sample_player is not None:
         history = archive_obj.get_ev_history("WNBA", "PTS", "2026-05-08", sample_player)
         if not history.empty:
-            assert history["observed_at"].is_monotonic_increasing, (
-                "get_ev_history must return rows ordered by observed_at"
-            )
+            assert history[
+                "observed_at"
+            ].is_monotonic_increasing, "get_ev_history must return rows ordered by observed_at"
 
     # ----- Phase 2: meditate (CLI invoked; ML stubbed; no writes) -----
     from sportstradamus.training import cli as training_cli
@@ -167,7 +166,9 @@ def test_pipeline_smoke(
 
     snapshot_calls: list[dict] = []
 
-    def stub_write_current_offers(offers, parlays, leagues, platforms, contest_variant="power", stats_dict=None):
+    def stub_write_current_offers(
+        offers, parlays, leagues, platforms, contest_variant="power", stats_dict=None
+    ):
         snapshot_calls.append(
             {
                 "offers": offers,

--- a/tests/test_archive_history.py
+++ b/tests/test_archive_history.py
@@ -305,9 +305,7 @@ def test_legacy_single_point_row_visible_to_at_queries_after_midnight(archive):
     )
 
     # Any at >= midnight returns the legacy observation.
-    assert archive.get_ev(
-        "WNBA", "PTS", "2026-05-08", "P", at=midnight
-    ) == pytest.approx(0.55)
+    assert archive.get_ev("WNBA", "PTS", "2026-05-08", "P", at=midnight) == pytest.approx(0.55)
     assert archive.get_ev(
         "WNBA", "PTS", "2026-05-08", "P", at=midnight + timedelta(hours=12)
     ) == pytest.approx(0.55)
@@ -343,13 +341,9 @@ def test_two_polls_accrue_distinct_observations(archive):
 
 def test_set_team_books_is_append_only(archive):
     """set_team_books no longer wipes prior rows; both observations survive."""
-    archive.set_team_books(
-        "MLB", "Moneyline", "2026-05-08", "NYY", {"pinnacle": 0.62}
-    )
+    archive.set_team_books("MLB", "Moneyline", "2026-05-08", "NYY", {"pinnacle": 0.62})
     archive.write()
-    archive.set_team_books(
-        "MLB", "Moneyline", "2026-05-08", "NYY", {"pinnacle": 0.65}
-    )
+    archive.set_team_books("MLB", "Moneyline", "2026-05-08", "NYY", {"pinnacle": 0.65})
     archive.write()
 
     history = archive.get_ev_history("MLB", "Moneyline", "2026-05-08", "NYY")
@@ -383,9 +377,7 @@ def test_archive_auto_migrates_pre_observed_at_schema(tmp_path, monkeypatch):
         "('WNBA', 'PTS', DATE '2026-05-08', 'P', 'fanduel', 0.52, "
         "  TIMESTAMP '2026-05-08 12:00:00')"
     )
-    con.execute(
-        "INSERT INTO lines VALUES ('WNBA', 'PTS', DATE '2026-05-08', 'P', 22.5)"
-    )
+    con.execute("INSERT INTO lines VALUES ('WNBA', 'PTS', DATE '2026-05-08', 'P', 22.5)")
     con.close()
 
     monkeypatch.setenv("SPORTSTRADAMUS_ARCHIVE_DB", str(db_path))


### PR DESCRIPTION
## Summary

Addresses the requested dashboard updates plus the supporting backend changes.

### Predictions — Today
- Default sort is now **descending by `Model`**.
- Zero-signal rows (no boost, no model edge, no book edge) are dropped at the snapshot writer and defensively in the page.
- `Model P` (probability of a hit) is shown in the main grid alongside `Model` and `Books` EV.
- **Numeric range filters** (sliders) for `Model P`, `Model`, and `Books`.
- The clutter columns (`Model EV`, `Push P`, `Avg 5`, `Avg H2H`, `Moneyline`, `O/U`, `DVPOA`) plus **`Model std`** and **recommended correlated bets** moved into a per-row detail popup (`st.dialog`) opened by selecting a row.

### Predictions — Parlays
- Removed the manual **Contest variant** selector. Payouts are now automatically **pooled**: `power` for 2–3 leg slips, `flex` for 4+ leg slips. Rivals legs are treated as any other leg (no separate contest). *Note: the JSON `insurance` table is an old alias of `flex` and is no longer consulted by the pooled path; the single-variant names remain only for the `pickem-build` path.*
- Added a **sort control**: Model EV / recommended bet size / fun metric.
- Per-game **independence families** (the existing up-to-3 Ward clusters) are now surfaced as a sub-dropdown under each game.

### Backend
- New `"pooled"` payout curve in `prediction/parlay.py`; threaded as the default through `correlation.py`, `scoring.py`, and the `prophecize` CLI (`--contest-variant` choices/default updated; golden help snapshot regenerated).
- `model_prob.py` now emits a display-only `Model STD`; `persist.py` carries `Model P`, `Model STD`, and the correlation strings into `current_offers.parquet`, drops zero-signal rows, and sorts by `Model`.
- Streamlit floor bumped to `>=1.38` for `st.dialog` width + dataframe row-selection support.

## Test plan
- [ ] `poetry run pytest tests/golden/` (CLI help snapshot updated)
- [ ] `poetry run pytest -m integration`
- [ ] `poetry run ruff check src/sportstradamus/` — changed files clean (10 pre-existing errors remain in untouched `stats/`/`training/` files)
- [ ] Manually exercise the Predictions and Parlays dashboard pages (row popup, range filters, family sub-dropdown, parlay sort)

> Note: the execution environment had no project dependencies installed (no numpy/torch/streamlit), so the pytest gates and Streamlit UI could not be run here and need verification in a full env.

https://claude.ai/code/session_0168a8t7fG1Jp9wm4AmCJipH

---
_Generated by [Claude Code](https://claude.ai/code/session_0168a8t7fG1Jp9wm4AmCJipH)_