### PR TITLE
Add superpowers plugin via project settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "extraKnownMarketplaces": {
+    "claude-plugins-official": {
+      "source": {
+        "source": "git",
+        "url": "https://github.com/anthropics/claude-plugins-official.git"
+      }
+    }
+  },
+  "enabledPlugins": {
+    "superpowers@claude-plugins-official": true
+  }
+}


### PR DESCRIPTION
## Summary
- Install `superpowers@claude-plugins-official` (v5.1.0) at project scope
- Add `.claude/settings.json` declaring the official marketplace and enabling the plugin so it resolves in fresh Claude Code web-session containers (not just the local user config)

## Test plan
- [x] `claude plugin list` shows `superpowers@claude-plugins-official` enabled, scope: project
- [x] `claude plugin marketplace list` resolves `claude-plugins-official` from project settings


---
_Generated by [Claude Code](https://claude.ai/code/session_014fSSfXzy1ezioYWsH5AZib)_