### PR TITLE
Merge general coding principles into STYLE_GUIDE

### DIFF
--- a/.claude/agents/refactoring-specialist.md
+++ b/.claude/agents/refactoring-specialist.md
@@ -1,0 +1,238 @@
+---
+name: refactoring-specialist
+description: "Use to enforce docs/STYLE_GUIDE.md on files touched in the current session before pushing or updating a PR. Reviews and refactors Python sources in src/sportstradamus/ for orchestrator flatness, wrapper-function elimination, duplicate-code consolidation, and loop sanity — without changing behavior."
+tools: Read, Edit, Write, Bash, Glob, Grep
+model: sonnet
+---
+
+You are the Sportstradamus refactoring specialist. Your only job is to enforce
+`docs/STYLE_GUIDE.md` on a defined set of files — usually the files touched in
+the current Claude Code session — before those files land in a pushed branch
+or PR update. You operate inside this repository's conventions, not generic
+ones. When the style guide and a generic refactoring rule disagree, the style
+guide wins.
+
+## Mandatory reading on every invocation
+
+1. `docs/STYLE_GUIDE.md` — entire file. Cite section numbers (`§N`) in your
+   commit message and inline notes when you justify a change.
+2. `CLAUDE.md` — for project structure, package paths, hard rules
+   (no monoliths, no back-compat shims, no commented-out code, no orphan
+   methods, no magic numbers), and the three quality gates that must pass
+   before you claim success.
+3. `CONTRIBUTING.md` — package map, where new code should live.
+
+Skip the reading and you will miss the project-specific rules and your
+refactor will be reverted.
+
+## Hard preconditions
+
+Refuse to start if any of these are true:
+
+- The caller did not name the target files. Ask which files to refactor.
+  Do not scan the whole repo on your own initiative.
+- The working tree has uncommitted changes you did not produce in this
+  invocation. Either commit them first or abort. You will not refactor on
+  top of someone else's dirty state.
+- Tests are red on the target files' modules before you touch them. A red
+  baseline means you cannot tell whether your change broke anything.
+  Report the failure and stop.
+
+## What you look for (in priority order)
+
+### 1. Orchestrator flatness — STYLE_GUIDE §10, §2.8
+
+The CLI entry points are the workflow:
+
+- `meditate` → `sportstradamus.training`
+- `prophecize` → `sportstradamus.prediction`
+- `confer` → `sportstradamus.moneylines`
+- `reflect` → `nightly.py`
+- `dashboard` → `dashboard.py`
+
+A top-level orchestrator should read like a numbered list of named steps.
+Flag and fix:
+
+- A workflow step buried inside another helper when it belongs at the top
+  level. If a reader has to jump three files to find "score offers" or
+  "fit model", lift it back into the orchestrator.
+- An orchestrator that delegates to a single wrapper that does the real
+  work. Inline the wrapper; the orchestrator should hold the steps itself.
+- A "main" function that ends in one call to a private `_run_everything`
+  helper. That is hiding the workflow, not encapsulating it. Inline.
+
+### 2. Wrapper-function elimination — STYLE_GUIDE §12
+
+A function is a dead wrapper if it:
+
+- Forwards every argument unchanged to one other function and returns the
+  result, with no transformation, validation, or naming improvement.
+- Wraps a one-line expression that is already readable at the call site.
+- Exists only to rename an import for one caller.
+
+Inline these and update every caller. Do not preserve the wrapper "for
+backwards compatibility" — STYLE_GUIDE §18.8 forbids backwards-compat
+bloat. If a caller is external (a script outside `src/sportstradamus/`),
+update it too.
+
+### 3. Duplicate code — STYLE_GUIDE §2.6, §18.18
+
+The opposite trap is premature abstraction. Apply the rule:
+
+- Two similar blocks → leave them alone. Two is not a pattern.
+- Three similar blocks → extract a helper. Name it for what it does, not
+  for the duplication it removed.
+- Existing helper used by one caller → inline it back unless its name
+  genuinely clarifies the call site.
+
+When extracting, place the helper in the most specific module that needs
+it. Do not promote to `helpers/` unless ≥ 2 packages use it.
+
+### 4. Weird loops
+
+Flag and fix:
+
+- `for ... else` without a clear early-exit semantic the reader will
+  catch on first read. Rewrite with an explicit flag or early return.
+- Loops that mutate the iterable they're walking. Snapshot it first.
+- `while True:` with the real exit condition buried five lines down.
+  Rewrite with the condition at the top.
+- Nested loops where the inner is a list comprehension followed by an
+  identical comprehension on the result. Combine.
+- `for i in range(len(x))` when you actually want `for item in x` or
+  `enumerate(x)`.
+
+### 5. Functions buried where they belong at the surface
+
+A function that:
+
+- Is the headline step in a workflow but defined as a private helper
+  three levels deep.
+- Is called from multiple packages but lives in a module-private scope.
+- Would be the natural extension point for a future league/market but
+  is currently inlined.
+
+Lift it. Update imports. The CLI entry-point modules
+(`training/cli.py`, `prediction/cli.py`, `moneylines.py`, `nightly.py`,
+`dashboard.py`) are the public surface — workflow-shaping functions live
+there or one import-hop away, not buried in `_utils.py`.
+
+### 6. Magic numbers — STYLE_GUIDE §9, CLAUDE.md hard rule
+
+Promote inline literals that encode a policy decision (thresholds, rates,
+caps, page sizes, kelly fractions) to module-level `UPPER_SNAKE_CASE`
+constants with a one-line `# why` comment. Leave bare math (`0.5`, `2 *
+pi`) alone.
+
+### 7. Hard rules from CLAUDE.md
+
+- No new monoliths. If a file is approaching ~300 lines after your edit,
+  stop and split it along the package boundary.
+- No commented-out code. Delete; if it might return, move to
+  `src/deprecated/` with the archive header.
+- No orphan methods. After a removal, grep for callers. Zero-caller
+  methods go to `src/deprecated/`.
+- No back-compat shims. Old import paths are gone — fix callers, do not
+  re-export.
+
+## What you do NOT do
+
+- Behavior changes. Outputs, schema keys, Sheet column order, training
+  report numbers, archive rows, CLI flag names — all frozen. If a refactor
+  would change any of these, stop and surface the risk per
+  STYLE_GUIDE §18.9.
+- Performance "improvements" without a baseline. STYLE_GUIDE §18.6.
+- Adding error handling for cases that cannot happen. STYLE_GUIDE §11.
+- Adding dependencies. STYLE_GUIDE §13.
+- Touching `data/`, `archive/`, `creds/`, trained model pickles, or
+  generated artifacts.
+- Reorganizing files the caller did not name as in-scope.
+- Speculative abstraction. Two similar lines stay as two.
+
+## Workflow
+
+Execute in this exact order. Do not interleave.
+
+### Phase 1 — Baseline
+
+1. Read STYLE_GUIDE.md, CLAUDE.md, CONTRIBUTING.md.
+2. Read every file in the named scope, in full.
+3. Run the three quality gates and record they are green:
+   - `poetry run ruff check src/sportstradamus/`
+   - `poetry run pytest tests/golden/`
+   - `poetry run pytest -m integration`
+4. If any gate is red, stop. Report and exit.
+
+### Phase 2 — Survey
+
+For each file in scope, produce an internal punch list with the items
+below. Do not edit yet.
+
+- Orchestrator-flatness violations (§10).
+- Wrapper functions to inline (§12, §18.7).
+- Duplicate blocks at ≥ 3 occurrences (§2.6, §18.18).
+- Weird-loop rewrites.
+- Buried functions to lift to the surface.
+- Magic numbers to extract (§9).
+- CLAUDE.md hard-rule violations.
+
+For each item, note: file, function, line range, the §N you are citing,
+and a one-sentence intended change. If the punch list is empty, say so
+and exit — there is nothing to do.
+
+### Phase 3 — One seam at a time
+
+Per STYLE_GUIDE §15. For each item on the punch list:
+
+1. Make the change. One change. No drive-by tidying.
+2. Run `poetry run ruff check` on the affected file.
+3. Run the relevant test slice (`pytest tests/golden/` minimum;
+   integration suite if the change touched a CLI or pipeline seam).
+4. If anything regressed, revert that change and move on. Do not chain
+   uncertain edits.
+5. Update callers in the same step. No half-migrations.
+
+After every five items, run the full three-gate suite to catch drift.
+
+### Phase 4 — Final validation
+
+1. Run all three quality gates clean.
+2. `git diff --stat` the scope. Confirm: only the named files changed
+   (plus their callers if the refactor required it). No `data/`, no
+   `archive/`, no `creds/`.
+3. Re-read each modified file end to end. If any change feels speculative
+   or changed behavior, revert it.
+
+### Phase 5 — Report
+
+Output a structured summary the caller can paste into a PR comment or a
+commit body:
+
+```
+Refactor scope: <files>
+Quality gates: ruff ✓ / golden ✓ / integration ✓
+
+Changes by category:
+- Orchestrator flatness (§10): <count> — <one-line each>
+- Wrappers inlined (§12, §18.7): <count> — <one-line each>
+- Duplicates consolidated (§2.6): <count> — <one-line each>
+- Loops rewritten: <count> — <one-line each>
+- Functions lifted: <count> — <one-line each>
+- Magic numbers extracted (§9): <count> — <one-line each>
+- Hard-rule fixes (CLAUDE.md): <count> — <one-line each>
+
+Behavior preserved: yes (no schema/output/flag changes)
+Risks called out: <list, or "none">
+```
+
+If you stopped at structural cleanup because a numerical or behavioral
+risk was unclear, say so explicitly per STYLE_GUIDE §18.9 and name what
+the caller should validate before merging.
+
+## Communication style
+
+- Talk like caveman per CLAUDE.md. Short sentences. Concrete file:line
+  references.
+- Cite §N for every justification. "Inlined because §12 dead-helper rule"
+  beats "cleaner now".
+- Never claim success without showing the three green gates.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,32 @@ Do not undo that work:
 * **No magic numbers.** Named constants at module level with a one-line reason comment.
   See STYLE_GUIDE.md §9.
 
+## MANDATORY: run refactoring-specialist before any push or PR update
+
+This is not a suggestion. Before you `git push`, before you call any GitHub MCP
+tool that creates or updates a PR, and before you reply "done" on a task that
+edited Python sources, you MUST invoke the `refactoring-specialist` subagent on
+every file you touched in the current session. No exceptions for "small"
+edits, "obvious" fixes, doc tweaks that grazed a `.py`, or tests-only changes.
+If you wrote to a `.py` file under `src/sportstradamus/`, the subagent runs.
+
+How to invoke:
+
+* Use the `Agent` tool with `subagent_type: "refactoring-specialist"`.
+* In the prompt, list every Python file you modified, created, or moved this
+  session. The subagent refuses to scan the whole repo on its own; you must
+  hand it the scope.
+* Wait for its report. Do not push while it is still running.
+* If it reverts any of your edits or flags a behavior risk per STYLE_GUIDE
+  §18.9, address the items it raised — re-invoke if needed — before pushing.
+
+Skipping this step is the single most common way Claude sessions ship code
+that violates the style guide. The PR review will catch it and you will redo
+the work. Just run the subagent.
+
+The subagent definition lives at `.claude/agents/refactoring-specialist.md`.
+Read it once per session so you know its scope and limits.
+
 ## Commands
 
 ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ Do not undo that work:
   call sites of the affected method. Zero-caller methods go to `src/deprecated/`, not
   into the next refactor's surprise pile.
 * **No magic numbers.** Named constants at module level with a one-line reason comment.
-  See STYLE_GUIDE.md §8.
+  See STYLE_GUIDE.md §9.
 
 ## Commands
 

--- a/docs/PHASE_3_IMPLEMENTATION.md
+++ b/docs/PHASE_3_IMPLEMENTATION.md
@@ -95,7 +95,7 @@ Roadmap §1.2 follow-up. Inline literals like `0.95`, `0.05`, `0.9`,
 several EV/correlation cutoffs at `correlation.py:624` and `:411`
 ride alongside the already-named `_BEAM_WIDTH` and
 `_KELLY_BANKROLL_FRACTION`. Promote them to module-level constants per
-STYLE_GUIDE §8 (named, ALL_CAPS, single-line "why" comment).
+STYLE_GUIDE §9 (named, ALL_CAPS, single-line "why" comment).
 
 **Constraint:** behavior must be unchanged. This is a rename pass, not
 a tune.
@@ -360,7 +360,7 @@ because Step 4 demonstrated those names mean different things. Keep
 the value semantics: `1.0` = no shrink, `0.0` = degenerate to
 no-information.
 
-### 5.c Constants (STYLE_GUIDE §8)
+### 5.c Constants (STYLE_GUIDE §9)
 
 | Name | Value | Reason |
 |---|---|---|
@@ -412,7 +412,7 @@ roadmap-aligned with `CLV_SEGMENT_MIN_N=20` (we use 25 here so the
 ramp starts above the bare reporting threshold).
 
 Document the blending rule and constants in the `kelly.py` module
-docstring with the same one-line "why" comment per STYLE_GUIDE §8.
+docstring with the same one-line "why" comment per STYLE_GUIDE §9.
 
 **Tests:** `tests/golden/test_kelly.py` (extends Step 5.g):
 - `n=10` → output equals `training_bss`.

--- a/docs/STYLE_GUIDE.md
+++ b/docs/STYLE_GUIDE.md
@@ -21,7 +21,40 @@ with `ruff`, fix whichever is wrong and make them agree.
 
 ---
 
-## 2. Standards We Adopt
+## 2. Core Principles
+
+These principles set the default posture for every change. Later sections
+spell out the mechanics; this section is the spirit.
+
+1. **Preserve behavior unless the task explicitly requests a behavior change.**
+   Refactors that change outputs are not refactors.
+2. **Prefer clarity over micro-optimization.** Readability is the
+   long-running cost driver in this codebase.
+3. **Make data flow and assumptions explicit.** Build named intermediate
+   variables for multi-step transformations rather than burying logic in
+   deeply nested expressions.
+4. **Keep numerically or logically sensitive areas stable and
+   well-documented.** Model training, calibration, EV blending, and the
+   Archive schema are this category — see §6 docstring rules for the
+   extra fields they need.
+5. **Add tests before or alongside structural refactors.** Characterization
+   tests come first, then the seam, then the next seam. See §14.
+6. **Prefer the simplest correct implementation over architectural
+   cleverness.** Three similar lines beat a premature abstraction. Extract
+   on the third concrete reuse, not the first.
+7. **Do not add hidden control logic** (fallbacks, retries, line searches,
+   damping, secondary loops) unless explicitly requested. Silent fallbacks
+   are how training reports start lying.
+8. **Keep top-level orchestrators flat and readable.** The CLI entry
+   points (`meditate`, `prophecize`, `confer`, `reflect`) should read like
+   a numbered list of workflow steps. Do not hide a core step behind
+   extra indirection just to shorten the orchestrator — the orchestrator
+   *is* the workflow. Extract a helper when a step has its own internal
+   branching, not to flatten the call count.
+
+---
+
+## 3. Standards We Adopt
 
 We deliberately pull from these sources. They are cited rather than copied
 wholesale.
@@ -29,7 +62,7 @@ wholesale.
 - **PEP 8** — layout, whitespace, naming. Enforced via `ruff`.
 - **PEP 257** — docstring conventions. Enforced via `ruff` (`D` rules).
 - **PEP 484 / 604** — type hints. Advisory `mypy` check; annotations
-  required on public APIs (see §7).
+  required on public APIs (see §8).
 - **PEP 20 (Zen of Python)** — readability beats cleverness; flat beats
   nested; explicit beats implicit.
 - **Google Python Style Guide** — docstring *format* (Args/Returns/Raises
@@ -45,7 +78,7 @@ wholesale.
 
 ---
 
-## 3. Formatting
+## 4. Formatting
 
 - **Formatter:** `ruff format`. Run it before committing; pre-commit enforces.
 - **Line length:** 100 characters.
@@ -54,10 +87,13 @@ wholesale.
 - **Trailing commas:** on multi-line collections and signatures.
 - **Blank lines:** 2 between top-level definitions, 1 between methods,
   0 inside functions unless separating logical sections.
+- Follow the existing style in each file touched (indentation, spacing,
+  quote style) when it disagrees with the above only for local consistency
+  within a tight block.
 
 ---
 
-## 4. Imports
+## 5. Imports
 
 - Three groups, separated by a blank line, each alphabetized:
   stdlib / third-party / first-party (`sportstradamus.*`). `ruff` sorts
@@ -67,10 +103,12 @@ wholesale.
   over importing many names from a module, unless the names are used many
   times or the source is a type or constant.
 - Relative imports inside a package are fine (`from .base import Stats`).
+- Remove unused imports in the same commit that orphans them. `ruff`'s
+  `F401` rule catches the obvious cases.
 
 ---
 
-## 5. Naming
+## 6. Naming
 
 - Modules and packages: `snake_case`.
 - Classes and type aliases: `PascalCase`.
@@ -78,16 +116,20 @@ wholesale.
 - Module-level constants: `UPPER_SNAKE_CASE`.
 - Private (module- or class-internal): leading underscore (`_helper`,
   `_CACHE`).
+- Use descriptive, purpose-revealing names. A reader landing in the middle
+  of a function should understand what each name means without scrolling.
 - Never use single-letter names in public APIs. Single letters are only
   acceptable inside a short block when they mirror a math formula (`mu`,
   `sigma`, `x`, `y`) and that formula is cited in a comment.
 - Don't use `l`, `O`, or `I` as names (visually confusable with digits).
 - Method names describe what the method *does* from the caller's view
   (`get_training_matrix`), not how it works internally.
+- Avoid numbering-based names (`step1`, `phase_2`, `eq4`) in identifiers
+  unless they cite a published equation or the user explicitly asks for them.
 
 ---
 
-## 6. Docstrings
+## 7. Docstrings
 
 - **Every module** in `src/sportstradamus/` has a module-level docstring:
   one line describing the purpose, then a paragraph on any non-obvious
@@ -99,6 +141,14 @@ wholesale.
 - **Format:** Google-style sections, in order: one-line summary, optional
   elaboration paragraph, `Args:`, `Returns:`, `Raises:`. Skip any section
   that does not apply.
+
+For numerical, statistical, or physics-facing functions (model training,
+calibration, EV blending, distribution fusion), also document:
+
+- The state-vector or data convention (column order, key names, shapes).
+- Units for inputs and outputs (probabilities, log-odds, dollars, EV cents).
+- Any numerical assumption or sensitivity (zero-inflation regime,
+  clip ranges, shape ceilings).
 
 ```python
 def fused_loc(model_loc, book_loc, model_weight, dist):
@@ -126,13 +176,13 @@ def fused_loc(model_loc, book_loc, model_weight, dist):
 ```
 
 - Reference domain terms in docstrings so readers can look them up in the
-  glossary (§12) without grepping the codebase.
+  glossary (§17) without grepping the codebase.
 - Math in docstrings: use plain ASCII or Unicode mathematical operators.
   LaTeX is overkill.
 
 ---
 
-## 7. Type Hints
+## 8. Type Hints
 
 - **Required** on every public function and class method signature,
   including the return type.
@@ -149,12 +199,15 @@ def fused_loc(model_loc, book_loc, model_weight, dist):
 
 ---
 
-## 8. Comments
+## 9. Comments
 
 - Explain **why**, not **what**. Well-named code already says what.
 - Good triggers for a comment: a hidden constraint, an invariant, a
-  workaround for a specific bug, a non-obvious reason for a value.
-- Avoid comments that restate the line below them.
+  workaround for a specific bug, a non-obvious reason for a value, a
+  numerical heuristic, a domain or physical assumption, a sequencing
+  dependency between two lines that otherwise look independent.
+- Avoid comments that restate the line below them or narrate straightforward
+  assignments and simple loops.
 - Do not leave `# TODO` without a name, date, or issue reference. Anonymous
   TODOs decay into permanent lies.
 - Do not comment out code. Delete it; `git log` keeps the history.
@@ -174,20 +227,31 @@ extraction.
 
 ---
 
-## 9. Functions
+## 10. Functions
 
 - **Target length:** ≤ 60 logical lines. Hard suggestion ~120.
+- **One clear purpose per function.** If the docstring reads "loads data,
+  fits a model, writes the report", that's three functions. Extract helpers
+  when branching becomes hard to follow.
+- **Build explicit intermediate variables** for multi-step transformations.
+  A named local that holds the result of one step makes the next step
+  reviewable without re-deriving the expression.
+- **Use early returns or guards** for parameter validation and impossible-
+  state shortcuts.
 - **Deep nesting** (> 4 levels of control flow) is a refactor signal,
   not a feature. Flatten with early returns or extracted helpers.
-- **One responsibility per function.** If the docstring reads "loads data,
-  fits a model, writes the report", that's three functions.
+- **Keep top-level orchestrators flat.** A CLI entry point should read as
+  a sequence of named steps. Don't hide a workflow step behind an extra
+  indirection layer just to shorten the orchestrator — that layer makes
+  the workflow harder to follow, not easier. Extract a helper when the
+  step has its own logic worth naming; inline it when it does not.
 - **Avoid boolean flag arguments** that switch behavior. Prefer two
   functions, or an enum, or polymorphism.
 - Default arguments must be immutable. Never `def f(x=[])`.
 
 ---
 
-## 10. Error Handling
+## 11. Error Handling
 
 - Validate at system boundaries: HTTP responses, file I/O, user input.
   Inside the package, trust your own types.
@@ -197,10 +261,13 @@ extraction.
 - Raise specific exception types (`ValueError`, `KeyError`,
   `FileNotFoundError`). Custom exceptions only when the caller needs to
   distinguish them.
+- Do **not** add error handling for scenarios that cannot happen. Trust
+  internal invariants. Boundary code validates; interior code does not
+  re-validate.
 
 ---
 
-## 11. Dead Code
+## 12. Dead Code
 
 - Delete unused code in the commit where it becomes unused. `git log` is the
   history.
@@ -209,10 +276,75 @@ extraction.
   and add a TODO to `README.md`. Do not leave it commented out in place.
 - Stale imports (a module imports `foo` but never uses it) are dead code.
   `ruff` catches them via the `F401` rule.
+- Dead helper layers — a function that only forwards to one other function
+  with no added clarity — count as dead code. Inline them.
 
 ---
 
-## 12. Domain Glossary
+## 13. Dependencies
+
+- Don't add a new dependency unless it pulls real weight. A 30-line helper
+  is cheaper than a new transitive tree.
+- Pin via Poetry (`pyproject.toml` + `poetry.lock`). Loose constraints in
+  the lockfile defeat the point of having one.
+- PyTorch is CPU-only and pulled from a custom Poetry source (see
+  `CLAUDE.md`). Don't replace that source without weighing the install-time
+  impact on the production server.
+
+---
+
+## 14. Testing Expectations
+
+- Run the full quality-gate suite from the repository root before claiming
+  any task is done:
+  - `poetry run ruff check src/sportstradamus/`
+  - `poetry run pytest tests/golden/`
+  - `poetry run pytest -m integration` (fake-mode, no network)
+- Add characterization tests for current behavior before deep structural
+  edits, especially around the training pipeline, Archive schema, and
+  Sheets export.
+- Keep all existing tests passing after changes. A flaky test is a real
+  test until proven otherwise.
+- Add tests for any new helper that affects outputs, contracts, or schemas.
+- Regenerate CLI help snapshots only when a flag change is intentional:
+  `REGENERATE_SNAPSHOTS=1 poetry run pytest tests/golden/test_cli_help.py`.
+
+---
+
+## 15. Refactor Workflow
+
+The order matters. Skipping a step is how you ship a "behavior-preserving"
+refactor that quietly changes a metric.
+
+1. **Capture baseline behavior.** Run the full test suite and, where
+   relevant, record the script outputs you intend to keep stable
+   (training report numbers, golden-test snapshots, Sheets payload).
+2. **Add or extend tests** around weakly covered behavior touching the
+   seam.
+3. **Refactor one seam at a time.** One module per session per CLAUDE.md.
+4. **Re-run tests after each seam.** If something drifted, fix it before
+   moving on.
+5. **Review for contract drift** before committing: signatures, key names,
+   schemas, output formats, file paths, Sheet column order.
+
+---
+
+## 16. Documentation Updates
+
+Update documentation in the same commit that changes the contract or
+workflow it describes. At minimum, consider:
+
+- `README.md` — contributor-facing pointers and quickstart commands.
+- `CONTRIBUTING.md` — package map, where to add a league or market.
+- `CLAUDE.md` — diagnostic schemas, deployment notes, training report
+  fields. The Training Report Diagnostics section in particular must stay
+  in sync with `training/report.py`.
+- This guide (`docs/STYLE_GUIDE.md`) — when conventions change.
+- Tests — when contracts are clarified, freeze the new contract in a test.
+
+---
+
+## 17. Domain Glossary
 
 A paragraph each for the terms that appear everywhere. Skim this before
 grepping the codebase for meaning.
@@ -265,37 +397,69 @@ grepping the codebase for meaning.
 
 ---
 
-## 13. For Claude and Other LLM Contributors
+## 18. For Claude and Other LLM Contributors
 
-These rules exist because LLM edits are paid for per token. Violating them
-makes the refactor expensive.
+These rules exist because LLM edits are paid for per token, and because
+silent behavior changes from an automated contributor are harder to catch
+than the same change from a human. Violating them makes the refactor
+expensive *and* risky.
 
-- **Read this guide once per session.** After that, cite sections by number
-  instead of re-reading.
-- **Prefer `Edit` over `Write`.** `Write` sends the entire new file;
-  `Edit` sends only the diff. Use `Write` only for genuinely new files
-  or complete rewrites.
-- **Use `ruff format` and `ruff check --fix` before manually editing style.**
-  Mechanical fixes cost nothing; hand-editing the same issues costs
-  thousands of tokens.
-- **Refactor one module per session.** Don't carry full context for more
-  than one file at a time. Commit and start fresh.
-- **Consult the glossary (§12) before grepping.** The term you're looking
-  up is probably there.
-- **Preserve public APIs during splits.** When you split a module into a
-  package, re-export the old names from `__init__.py`. Callers don't change;
-  no cross-codebase grep-and-update needed.
-- **Dispatch parallel subagents for independent work.** Per-league stats
-  subclasses, per-book scrapers, etc. Each subagent gets one file.
-- **Subagent prompts should name this guide by path**
-  (`docs/STYLE_GUIDE.md`), not transmit its body. Subagents can read it
-  themselves.
-- **Do not speculatively abstract.** Three similar lines of code are better
-  than a premature abstraction. Extract only after the third concrete reuse.
+**Posture and scope:**
+
+1. **Assume no behavior changes by default.** If your patch alters an
+   output, a key name, a Sheet column, or a metric value, that is a
+   feature change. Either it was requested or you should stop and ask.
+2. **Preserve existing public interfaces, output keys, and file schemas.**
+   When you split a module into a package, re-export the old names from
+   `__init__.py` until callers are migrated. Don't break the world to
+   tidy a name.
+3. **Prefer small, reviewable patches.** One module per session, per
+   CLAUDE.md. Commit and start fresh.
+4. **Do not add features, refactors, or "improvements" beyond what was
+   asked.** Speculative cleanup is how scope grows quietly.
+5. **Do not add error handling for scenarios that cannot happen.** See §11.
+6. **Avoid speculative performance optimizations** unless requested and
+   validated against a baseline.
+7. **Remove or avoid dead helper layers** that do not improve clarity or
+   correctness. A one-line pass-through is not a helper.
+8. **Avoid backwards-compatibility bloat.** Trace changes through the
+   codebase and fix function signatures where necessary. If a change
+   forces regeneration of a large artifact (model pickle, training
+   matrix, archive snapshot), call it out explicitly in the patch
+   description.
+9. **If uncertain about numerical or behavioral impact, stop at structural
+   cleanup and call out the risk explicitly.** Don't guess at the training
+   pipeline.
+
+**Workflow:**
+
+10. **Read this guide once per session.** After that, cite sections by
+    number instead of re-reading.
+11. **Prefer `Edit` over `Write`.** `Write` sends the entire new file;
+    `Edit` sends only the diff. Use `Write` only for genuinely new files
+    or complete rewrites.
+12. **Use `ruff format` and `ruff check --fix` before manually editing
+    style.** Mechanical fixes cost nothing; hand-editing the same issues
+    costs thousands of tokens.
+13. **Add docstrings and only meaningful inline comments — do not pad.**
+    See §7 and §9.
+14. **Run or explicitly request validation** before claiming completion.
+    The three quality gates from §14 must pass; if you can't run them in
+    your environment, say so and ask the user to.
+15. **Consult the glossary (§17) before grepping.** The term you're
+    looking up is probably there.
+16. **Dispatch parallel subagents for independent work.** Per-league stats
+    subclasses, per-book scrapers, etc. Each subagent gets one file.
+17. **Subagent prompts should name this guide by path**
+    (`docs/STYLE_GUIDE.md`), not transmit its body. Subagents can read it
+    themselves.
+18. **Do not speculatively abstract.** Three similar lines of code are
+    better than a premature abstraction. Extract only after the third
+    concrete reuse.
 
 ---
 
-## 14. Enforcement
+## 19. Enforcement
 
 These tools run in CI and locally via `pre-commit`:
 

--- a/docs/odds_archive_history_plan.md
+++ b/docs/odds_archive_history_plan.md
@@ -182,7 +182,7 @@ Also extend `src/sportstradamus/scripts/migrate_archive_to_duckdb.py:_iter_leagu
 
 No changes needed in `moneylines.py`, `prediction/model_prob.py`, `prediction/scoring.py`, or `training/calibration.py` — they all route through `Archive` and the default `at=None` preserves their behavior.
 
-## Constants (per STYLE_GUIDE §8)
+## Constants (per STYLE_GUIDE §9)
 
 In `src/sportstradamus/helpers/archive.py`:
 

--- a/docs/sportstradamus_roadmap_v2.md
+++ b/docs/sportstradamus_roadmap_v2.md
@@ -206,7 +206,7 @@ The audit prompt asks the agent to read the code, answer those questions, and wr
 > - Metadata file is written and contains the right keys.
 > - The `--rebuild-correlations` flag runs without touching `data/models/`.
 >
-> Constraint: do not change the LightGBMLSS training pipeline. This work is confined to `training/correlate.py`, `training/cli.py`, `prediction/correlation.py`, and the new tests. Magic numbers go in named module-level constants per `STYLE_GUIDE.md` §8.
+> Constraint: do not change the LightGBMLSS training pipeline. This work is confined to `training/correlate.py`, `training/cli.py`, `prediction/correlation.py`, and the new tests. Magic numbers go in named module-level constants per `STYLE_GUIDE.md` §9.
 >
 > When done: ruff clean, golden tests pass, regenerate CLI snapshots since `--rebuild-correlations` is new. Run `poetry run meditate --rebuild-correlations --league NBA` end-to-end and confirm the new CSVs appear. Summarize the methodological changes and any audit findings that turned out not to need a fix.
 
@@ -225,7 +225,7 @@ follow-ups):**
 - The Σ matrix passed to `multivariate_normal.cdf` is built pair-by-pair;
   singular submatrices are dropped rather than nearest-PSD-projected.
 - Beam width 1000, EV cutoff 1.05, boost bands, and final EV floors are
-  inline magic numbers — violates STYLE_GUIDE.md §8.
+  inline magic numbers — violates STYLE_GUIDE.md §9.
 - `data/banned_combos.json` is a soft modifier; no pair is hard-banned.
   Decide whether banlist semantics are desired and add a hard-ban path.
 - Same-player guarding is fragile substring matching. Switch to canonical
@@ -1552,7 +1552,7 @@ handful of items that aren't in any phase but matter for long-term health.
 - **Magic-number purge in `correlation.py`.** Roadmap mentions this in
   passing for Phase 1.2 follow-up; the audit's lit list (`K=1000`, EV
   cutoffs, boost bands, `[0, 0, 3.5, 6.5, 6, 10, 25]` payout array) is
-  long enough that it deserves its own commit per STYLE_GUIDE.md §8.
+  long enough that it deserves its own commit per STYLE_GUIDE.md §9.
 - **`prediction/parlay.py` split.** CONTRIBUTING.md advertises this
   module; in practice both `find_correlation` and `beam_search_parlays`
   live in `correlation.py`. Either split per the contract or update

--- a/src/deprecated/README.md
+++ b/src/deprecated/README.md
@@ -56,4 +56,4 @@ canonical reference.
 ## Provenance
 
 The initial sweep landed on 2026-04-21 as Phase 2 of the maintainability
-refactor. See `docs/STYLE_GUIDE.md` §11 for the dead-code policy.
+refactor. See `docs/STYLE_GUIDE.md` §12 for the dead-code policy.

--- a/tests/golden/conftest.py
+++ b/tests/golden/conftest.py
@@ -1,7 +1,7 @@
 """Shared pytest fixtures for the golden-snapshot suite.
 
 These tests protect the public CLI surface during the readability refactor.
-See docs/STYLE_GUIDE.md §14 and the Phase 1 section of the refactor plan at
+See docs/STYLE_GUIDE.md §19 and the Phase 1 section of the refactor plan at
 /home/trevor/.claude/plans/my-codebase-has-gotten-toasty-bonbon.md.
 """
 


### PR DESCRIPTION
## Summary

Merges the general coding style guide you brought from another repo into `docs/STYLE_GUIDE.md`, preserving every project-specific specific that was already established. Focus on the two pieces you flagged — flat orchestrators (originally §2) and AI-contributor guidance (originally §7).

### New sections

- **§2 Core Principles** — posture for every change: preserve behavior, prefer clarity, make data flow explicit, keep numerically sensitive areas stable, add tests before structural refactors, no hidden control logic (fallbacks/retries/damping).
- **§10 Functions** gained an orchestrator bullet: CLI entry points (`meditate`, `prophecize`, `confer`, `reflect`) should read as a sequence of named steps — don't hide a workflow step behind extra indirection just to shorten the orchestrator.
- **§13 Dependencies, §14 Testing Expectations, §15 Refactor Workflow, §16 Documentation Updates** — each scoped to this repo's quality gates (ruff / golden / fake-mode integration) and CLAUDE.md commitments.
- **§18 (Claude/LLM Contributors)** expanded with posture rules from §7 of the general guide: assume no behavior changes by default, preserve public interfaces and output schemas, no speculative abstraction, no error handling for impossible cases, stop and surface risk on numerical uncertainty, no backwards-compat bloat.

### Preserved

All the project-specific details stay: PEP-citation table, ruff/mypy enforcement, Google-style docstring example for `fused_loc`, magic-number rule with `MIN_CONFIDENCE` example, dead-code → `src/deprecated/` policy, the full domain glossary (Offer / Market / Archive / Stats / fused_loc / DIAG / the five CLI entry points), and the enforcement matrix.

### Cross-reference fixes

Renumbering cascaded through the file. Updated live citations so `§N` lands on the right section:

- `CLAUDE.md` §8 → §9 (magic numbers / Comments)
- `src/deprecated/README.md` §11 → §12 (Dead Code)
- `tests/golden/conftest.py` §14 → §19 (Enforcement)
- `docs/PHASE_3_IMPLEMENTATION.md`, `docs/odds_archive_history_plan.md`, `docs/sportstradamus_roadmap_v2.md` — all `§8` references for magic-number guidance bumped to `§9`.

## Test plan

- [ ] Skim `docs/STYLE_GUIDE.md` end-to-end and confirm nothing project-specific was dropped.
- [ ] Confirm §2 Core Principles and §10 orchestrator bullet match the intent of the general guide's §2.
- [ ] Confirm §18 captures the AI-contributor posture from the general guide's §7.
- [ ] Spot-check the updated §N citations in CLAUDE.md, src/deprecated/README.md, tests/golden/conftest.py, and the docs/ planning files.

https://claude.ai/code/session_01AcBEiX7RTtfQcXjvMXELDu

---
_Generated by [Claude Code](https://claude.ai/code/session_01AcBEiX7RTtfQcXjvMXELDu)_