### PR TITLE
Add caveman output style and merge upstream Claude settings

### DIFF
--- a/.claude/output-styles/caveman.md
+++ b/.claude/output-styles/caveman.md
@@ -1,0 +1,52 @@
+---
+name: Caveman
+description: Aggressive token-compressed caveman speak. Saves ~75% output tokens. Drops articles/pronouns/filler. Code and tool calls unchanged.
+---
+
+# Caveman Style
+
+Talk like caveman in all user-facing text. Goal: smallest token count that still convey meaning. Cut ~75% of usual prose.
+
+## Speech rules
+
+- Drop articles: "the", "a", "an" — gone.
+- Drop pronouns when subject obvious: "I", "you", "it", "we" — drop unless needed.
+- Drop linking verbs: "is", "are", "was" — drop when obvious.
+- Drop filler: "just", "really", "actually", "basically", "simply", "I think", "let me", "I'll", "I'm going to", "now I will".
+- No hedging: no "might", "perhaps", "maybe" unless genuine uncertainty.
+- Short fragments over full sentences. Period.
+- Lowercase fine. Punctuation minimal.
+- No greetings, no sign-offs, no apologies.
+- No restating user request back.
+- No section headers in replies unless multi-topic.
+- No bullets for one item. No tables for two rows.
+- No emoji. No em-dash.
+
+## Examples
+
+Bad: "I'm going to read the settings file and then update the permissions section to include the new bash commands you requested."
+Good: "read settings, add bash perms."
+
+Bad: "I've successfully completed the task. The file has been updated with the new configuration values and the tests are now passing."
+Good: "done. file updated. tests pass."
+
+Bad: "It looks like there might be an issue with the import path. Let me check the module structure to confirm."
+Good: "import path wrong. check module."
+
+Bad: "Here is a summary of what I changed:\n- Added X\n- Removed Y\n- Updated Z"
+Good: "added X, removed Y, updated Z."
+
+## Hard rules unchanged
+
+These NOT compressed — accuracy matters more than tokens:
+
+- Code blocks: write normal code. No caveman in code, comments, strings, commit messages, PRs, docstrings.
+- Tool args: normal English/JSON. Tool calls not visible to user anyway.
+- File paths, function names, error messages quoted verbatim.
+- When user asks question needing real answer (architecture, root cause, plan), give real answer. Compress style, not content.
+- If user says "explain more" or "be clear", drop caveman that reply.
+- Safety/destructive warnings stay clear: "this delete database. confirm?"
+
+## Pre-send check
+
+Before reply: scan for "the/a/I/you/is/are/just/really/actually". Cut what not needed.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,91 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "env": {
+    "CLAUDE_BASH_MAINTAIN_PROJECT_WORKING_DIR": "1",
+    "CLAUDE_CODE_DISABLE_FEEDBACK_SURVEY": "1",
+    "DISABLE_BUG_COMMAND": "1",
+    "DISABLE_ERROR_REPORTING": "1",
+    "MAX_MCP_OUTPUT_TOKENS": "40000",
+    "CLAUDE_CODE_EFFORT_LEVEL": "max",
+    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",
+    "CLAUDE_CODE_ENABLE_FINE_GRAINED_TOOL_STREAMING": "1",
+    "CLAUDE_CODE_NEW_INIT": "1",
+    "CLAUDE_CODE_NO_FLICKER": "1",
+    "ENABLE_PROMPT_CACHING_1H": "1",
+    "CLAUDE_CODE_AUTO_COMPACT_WINDOW": "400000",
+    "SLASH_COMMAND_TOOL_CHAR_BUDGET": "60000"
+  },
+  "permissions": {
+    "defaultMode": "plan",
+    "allow": [
+      "Bash(find:*)",
+      "Bash(rg:*)",
+      "Bash(echo:*)",
+      "Bash(grep:*)",
+      "Bash(ls:*)",
+      "Bash(wc:*)",
+      "Bash(cat:*)",
+      "Bash(sed:*)",
+      "Bash(tree:*)",
+      "Bash(tail:*)",
+      "Bash(pgrep:*)",
+      "Bash(ps:*)",
+      "Bash(sort:*)",
+      "Bash(ruff:*)",
+      "Bash(poetry run ruff:*)",
+      "Bash(poetry run pytest:*)",
+      "Bash(poetry run pre-commit:*)",
+      "Bash(tmux ls:*)",
+      "Bash(tmux capture-pane:*)",
+      "Bash(tmux list-sessions:*)",
+      "Bash(tmux list-windows:*)",
+      "Bash(tmux has-session:*)",
+      "Bash(tmux new-session:*)",
+      "Bash(git branch --show-current:*)",
+      "Bash(git diff:*)",
+      "Bash(git status:*)",
+      "Bash(git rev-parse:*)",
+      "Bash(git log:*)",
+      "Bash(git fetch --prune:*)",
+      "Bash(git worktree list:*)",
+      "Bash(git show:*)",
+      "Bash(python --version:*)",
+      "Bash(python -c:*)",
+      "Bash(python3 -c:*)",
+      "Bash(python -m json.tool:*)",
+      "Bash(jq:*)",
+      "Bash(mkdir -p:*)",
+      "WebSearch",
+      "WebFetch(domain:anthropic.com)",
+      "WebFetch(domain:docs.anthropic.com)",
+      "WebFetch(domain:github.com)",
+      "WebFetch(domain:raw.githubusercontent.com)",
+      "WebFetch(domain:pypi.org)"
+    ]
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -c 'CMD=$(jq -r \".tool_input.command\"); if ! echo \"$CMD\" | rg -qP \"(\\brm\\s+-|\\brm\\s+/|\\brmdir\\b|shutil\\.rmtree|os\\.remove|os\\.unlink|os\\.system|\\bopen\\(.*[\\x27\\\"]w|\\bcurl\\s|\\bwget\\s|\\bpip\\s+install|\\bkill\\s|\\bpkill\\b|\\bchmod\\b|\\bchown\\b|\\bdd\\s|\\bmkfs\\b|\\bgit\\s+stash|\\bgit\\s+rebase|\\bgit\\s+clean|\\bgit\\s+branch\\s+-[dD]|\\bgit\\s+reset\\s+--hard|\\bgit\\s+checkout\\s+\\.|\\bapt\\s|\\byum\\s|\\bbrew\\s+install|\\bnpm\\s+install|\\bsudo\\s|\\bdocker\\s|\\bkubectl\\s|>\\s+/|>>\\s+/)\"; then printf \"{\\\"hookSpecificOutput\\\":{\\\"hookEventName\\\":\\\"PreToolUse\\\",\\\"permissionDecision\\\":\\\"allow\\\"}}\"; else printf \"{\\\"hookSpecificOutput\\\":{\\\"hookEventName\\\":\\\"PreToolUse\\\",\\\"permissionDecision\\\":\\\"ask\\\",\\\"permissionDecisionReason\\\":\\\"contains destructive operation, review carefully\\\"}}\"; fi'"
+          }
+        ]
+      }
+    ]
+  },
+  "outputStyle": "Caveman",
+  "alwaysThinkingEnabled": true,
+  "showThinkingSummaries": true,
+  "autoDreamEnabled": true,
+  "spinnerTipsEnabled": false,
+  "autoScrollEnabled": false,
+  "showClearContextOnPlanAccept": false,
+  "cleanupPeriodDays": 9999,
+  "autoUpdatesChannel": "latest",
+  "skillListingBudgetFraction": 0.02,
   "extraKnownMarketplaces": {
     "claude-plugins-official": {
       "source": {


### PR DESCRIPTION
Pulls in selected pieces of `fcakyon/claude-codex-settings` into project `.claude/settings.json` and tackles their TODO-listed caveman output style locally.

**What landed:**
- `.claude/output-styles/caveman.md` — aggressive token-compressed caveman speak (active via `outputStyle: "Caveman"`); code, tool args, commit messages stay normal
- `env`: caching, token limits, effort=max, fine-grained streaming, no-flicker, 400k auto-compact window (skipped upstream's model overrides since you're already on opus-4-7)
- `permissions.defaultMode: "plan"` + allowlist for safe `find`/`rg`/`git status|diff|log`/`poetry run ruff|pytest`/`tmux ls`/etc. and a few WebFetch domains
- `hooks.PreToolUse` for `Bash`: pattern-asks on `rm`/`pip install`/`sudo`/`docker`/`git reset --hard`/etc. (pipe-tested both safe and destructive paths)
- UI flags: `alwaysThinkingEnabled`, `showThinkingSummaries`, `autoDreamEnabled`, `cleanupPeriodDays: 9999`, `autoUpdatesChannel: latest`
- Existing `superpowers@claude-plugins-official` plugin and official marketplace preserved untouched

**Worth knowing:**
- `defaultMode: plan` means every fresh session starts in plan mode — exit with shift+tab when ready to execute
- The destructive-bash hook does NOT block `git push` or `git commit` (removed from upstream's pattern since auto-push is part of the cloud workflow)

No Python touched, so `refactoring-specialist` not required per CLAUDE.md.

https://claude.ai/code/session_01JVpGUcNuYyaW99E9Cn5Tow

---
_Generated by [Claude Code](https://claude.ai/code/session_01JVpGUcNuYyaW99E9Cn5Tow)_