### PR TITLE
docs(devel-foundation): reworked gbdt plan + roadmap + ship_gate onto devel

### DIFF
--- a/docs/gbdt_mean_regression_plan.md
+++ b/docs/gbdt_mean_regression_plan.md
@@ -9,6 +9,264 @@
 > phase's code, the harness run-log entries, and the status updates below land
 > as commits on that one PR; do not open separate PRs per phase.
 
+## Top priority — baseline breadth (≥ 75% of markets per league)
+
+**The North Star for this project is breadth, not depth: get a baseline *set* for
+at least three-quarters of the markets in every covered league (NBA ≥ 16/21,
+WNBA ≥ 14/18, NFL ≥ 15/20).** This
+supersedes the earlier framing where the only ship was a ≥ 5% top-decile-MAE
+*improvement*. The Stage B1.5 §7a verdict showed top-decile compression is
+family-invariant — a GBT leaf-averaging property no strategy or distribution swap
+removes — so gating the *first* ship on a ≥ 5% compression improvement blocks most
+cells from ever shipping (the NBA sweep set a baseline on only 2 of 21 markets
+under that bar). The objective is making money on as many markets as possible; the
+gate is reframed to measure that directly.
+
+### Two-tier ship model
+
+Every cell is in one of two regimes:
+
+**Tier 0 — set the first baseline (absolute gates only). This is the priority.** A
+cell with no baseline set gets one as soon as *any* candidate clears the
+**absolute** gates. Nothing relative is required, because there is no prior
+baseline to improve on:
+
+1. **Bench-warmer (bottom-quartile) absolute gate** — bottom-quartile signed bias
+   within the one-sided over-prediction bound (under-prediction tolerated).
+2. **Star (top-decile) absolute gate** — top-decile signed bias within the
+   bidirectional bound.
+3. **BSS in the tolerated range** — `brier_skill_score ≥ 0` (beats the book) on
+   the full-quality retrain. Phase-0 floor; this is the knob for reaching 75% — if
+   a league can't get three-quarters of its markets to ≥ 0, widen toward the
+   Gate-2 −0.02 tolerance rather than ship a book-losing cell.
+
+The **incumbent devel/default strategy is itself a candidate** in this test. Of
+*every* candidate that clears the absolute gates for a cell, the one with the
+highest `brier_skill_score` — after a full, non-deterministic retrain — is shipped
+as the baseline, because live production can only A/B one strategy per cell at a
+time (tiebreaker detail in [docs/ship_gate.md](ship_gate.md)).
+
+**Tier 1 — supersede an established baseline (absolute + relative gates).** Once a
+cell's baseline is set, a challenger must clear **both** the absolute gates **and**
+the relative gates — the full Universal decision threshold below: ≥ 5%
+top-decile-MAE improvement, global MAE not worse, BSS not worse, and
+bottom-quartile bias not more positive. The ≥ 5% compression bar's correct role is
+here — it prevents churning an established baseline without a real improvement, not
+blocking the first ship.
+
+**Gate 2 — live graduation** is unchanged: a newly-set baseline soaks ≥ 14 days,
+then graduates on settled-offer book-BSS, calibration, and profit-sim.
+
+### What "absolute gate" means here
+
+The bench-warmer and star absolute gates are the per-band signed-**bias**
+(calibration) bounds built this session — bottom-quartile one-sided on
+over-prediction, top-decile bidirectional — at the wide Phase-0 values (30% of the
+band's empirical mean, floor 0.10). Current numbers and the BSS tiebreaker live in
+[docs/ship_gate.md](ship_gate.md). (`compression_eval.verdict()` currently encodes
+only the Tier-1 path; the Tier-0 absolute-only mode is the immediate next code
+step.)
+
+### Roadmap to 75%
+
+1. **Audit (do first):** run the absolute-only Tier-0 gate over every cell ×
+   candidate (incl. the incumbent) in all three leagues; record per league how
+   many already clear it and on which strategy. That is the breadth baseline.
+2. **Fill the gap:** for cells that don't yet clear the absolute gates, apply the
+   Stage B1.6 feature/bias track (post-hoc bias correction, expanding-mean
+   encoding, opponent-defense / blowout features) until ≥ 75% per league can be
+   set. Post-hoc bias correction in particular pulls both bands toward zero, so it
+   serves the absolute gates directly.
+3. **Set + soak:** ship the highest-BSS passer per cell to `devel`; start the
+   14-day Gate-2 soak.
+
+**Immediate next steps (Step 1 audit is done — see below; Step 2 is now the work).** The
+first **code** task is adding **`compression_eval.verdict()` Tier-0 absolute-only mode** —
+today `verdict()` encodes only the Tier-1 relative path, so the breadth audit's Tier-0
+calls are not yet a first-class code path; this is the Stage B1.6 prerequisite. With that
+landed, run the **Stage B1.6** feature/bias track to close the gaps (NBA −3, WNBA −4,
+NFL −2), then set + soak. The depth tracks (A2/B2/B3) follow only once breadth is met.
+
+**Step 1 result — breadth baseline (2026-05-21).** Tier-0 audit over all four
+candidate strategies (incumbent `ratio_meanyr`, `centered_additive_mean10`,
+`centered_additive_eb_meanyr_k10`, and `ratio_meanyr` + hurdle) on the
+deterministic A/B test sets, after the NFL gamelog numeric-coercion bug was fixed
+(NFL candidates were previously un-generatable). BSS here is on crippled-HP
+deterministic models — **conservative**; the final per-cell pick is the highest
+*full-retrain* BSS. The absolute bias gates are HP-robust.
+
+| League | passes bias gates | bias + BSS ≥ 0 | 75% target | gap |
+|---|---|---|---|---|
+| NBA | 14/21 | 13/21 | 16 | −3 |
+| WNBA | 10/18 | 10/18 | 14 | −4 |
+| NFL | 17/20 | 16/20 | 15 | **MEETS (+1)** |
+
+**The binding constraint is the absolute bias gates, not the BSS floor.** The
+failing cells are the low-mean count markets — NBA AST/BLK/BLST/FG3M/OREB/STL/TOV,
+WNBA those + FTM, NFL passing-tds/receiving-tds/rushing-tds — exactly the
+family-invariant-compression cells Stage B1.5 routed to the feature/bias track.
+The crippled-HP BSS floor excludes only one extra cell per league beyond the bias
+failures (NBA PF, NFL interceptions — both "bias-only"), so a full retrain should
+recover several. Winning strategy varies by cell: `ratio_meanyr` takes most NFL
+high-volume markets + every fantasy-points cell; `centered_additive_eb_meanyr_k10`
+takes the NBA/WNBA volume markets (FGA, MIN, DREB, PA, PR, PRA, REB); the hurdle
+wins once (NFL sacks-taken). Per-cell selection is material — no single strategy
+dominates. **Gap to close (Step 2):** NBA +3, WNBA +4 via the feature/bias track
+(post-hoc bias correction first, aimed at the bias-failing count cells); NFL +2 —
+the screen's 16/20 fell to **13/20 confirmed at full HP** (qb-tds, rushing-yards,
+and sacks-taken failed Tier-0 on the real retrain; see Step 3).
+
+**Step 3 result — baselines locked (2026-05-21).** Full-HP retrain driven by the
+per-cell `ship_config.json` (`--force`, non-deterministic). Methodology finding: a
+fresh retrain's test sets ARE `compression_eval`-scoreable (they carry the
+book-odds columns), unlike the pre-existing May-8 production sets — so full-HP BSS
+confirmation is available going forward, not just the crippled-HP screen.
+
+- **NBA — 13/13 locked, confirmed at full HP.** Every baseline-able cell passes
+  Tier-0 at full HP (BSS +0.027 … +0.352: MIN +0.284, fpp +0.352, DREB +0.251,
+  REB +0.131, PTS +0.097, FGM +0.094, FGA +0.093, FTM +0.087, PR +0.074, FG3A
+  +0.061, RA +0.060, PA +0.049, PRA +0.027). The crippled-HP "centered wins" in
+  the Step-1 audit were all 0–2pp noise; the incumbent `ratio_meanyr` is confirmed
+  best-or-equal, so all 13 lock as `ratio_meanyr`. Committed to `ship_config.json`.
+- **WNBA — 10/10 baseline-able cells locked, confirmed at full HP (TOR fix landed).**
+  The retrain had crashed in `get_stats`: `teamProfile.loc[…]` raised
+  `KeyError: ['TOR']` because Toronto Tempo (the 2026 WNBA expansion team) is absent
+  from `teamProfile`. Root cause was a pair of hardcoded `"GSV"` (2025 Golden State
+  Valkyries) guards that only papered over the *prior* season's expansion. Fixed with
+  a league-agnostic `_profile_rows_for_teams` helper
+  ([base.py:51](../src/sportstradamus/stats/base.py#L51)) that `reindex`es the profile
+  so any absent franchise yields an all-NaN row (LightGBM consumes it as a missing
+  feature) — robust to future expansions; both GSV guards deleted; regression test
+  `tests/golden/test_profile_team_lookup.py`. The full-HP retrain then completed all
+  10 markets cleanly, every cell passing Tier-0 (BSS +0.013 … +0.230: fpp +0.230,
+  MIN +0.189, FGA +0.137, DREB +0.096, PA +0.050, PR +0.048, REB +0.041, RA +0.036,
+  PTS +0.033, PRA +0.013). DREB locks as `centered_additive_mean10` (the sole Tier-0
+  passer in the screen — incumbent fails the bench gate — and fully plumbed, no
+  `zinb_mode` gap), the other 9 as `ratio_meanyr`. Committed to `ship_config.json`.
+  This is 10/18 of all WNBA markets baselined; the remaining +4 to the 14/18 North
+  Star is the Step-2 feature/bias track on the count markets (FG3M/FTM/STL …).
+- **NFL — 13/16 baseline-able locked, confirmed at full HP.** The per-cell
+  `zinb_mode` plumbing was built first (object-form `ship_config` cells +
+  `resolve_cell_zinb_mode`; `ZINB_MODES` in `baselines.py`) so sacks-taken *could*
+  ship as `ratio_meanyr`+hurdle. The full-HP `--force` retrain then **confirmed
+  only 13 of the 16 screen-passers** — the crippled-HP screen was optimistic for
+  3: `qb tds` (full-HP bench +0.39 / star +0.68 over the bounds), `rushing yards`
+  (`centered_additive_mean10` BSS −0.006; incumbent also failed it), and **`sacks
+  taken`** (hurdle: star-bias +0.67 > 0.50 — the plumbing works end-to-end, pickle
+  `is_hurdle=True`/`zinb_mode=hurdle`, but the cell fails Tier-0 anyway). Locked 13:
+  `passing first downs`→`eb`, `receptions`→`mean10`, the other 11→`ratio_meanyr`.
+  The centered transforms blow up on NFL yardage (passing-yards `eb` top-decile MAE
+  2629, qb-yards `mean10` 44902) — incumbent unambiguously correct there. **NFL
+  lands 13/20, short of the 15/20 North Star by 2** (the screen's "16" was
+  crippled-HP-optimistic); the 3 pruned + 4 never-baseline-able = a 7-cell Step-2
+  pool. Full per-cell results + the devel ship handoff are in
+  [docs/lockin_ship_handoff.md](lockin_ship_handoff.md).
+
+Depth work — superseding baselines via the ≥ 5% compression improvement, the Track
+A tail-head and Track B family builds — is **secondary** to reaching 75% breadth.
+
+## Market cell status — Gate 1 / `devel` / `main`
+
+Per-cell shipping status, to prioritize which markets to work next. Sourced from
+committed state only — the locked baselines in
+[`data/ship_config.json`](../src/sportstradamus/data/ship_config.json), the market roster
+in [`training/markets.py`](../src/sportstradamus/training/markets.py) (`ALL_MARKETS`), the
+declared distribution family in
+[`data/stat_dist.json`](../src/sportstradamus/data/stat_dist.json), and the locked
+2026-05-21 breadth audit above. No verdict is recomputed here.
+
+- **Gate 1** = passes the Tier-0 absolute gates. A locked baseline ⇒ Gate 1 passed.
+- **`devel`** = baseline shipped to the live beta (the per-cell entry in `ship_config.json`).
+- **`main`** = graduated on the 14-day Gate-2 live soak. **No cell has begun a soak yet**
+  (`data/live_metrics_per_market.parquet` is not yet populated), so every `main` cell is
+  ⏳ pending.
+- Unbaselined cells (no `ship_config.json` entry) are the **Step-2 feature/bias-track
+  (B1.6)** work pool.
+
+**Baselined: NBA 13/21, WNBA 10/18, NFL 13/20.** 75% target / gap: NBA 16 (**−3**),
+WNBA 14 (**−4**), NFL 15 (**−2**). These are the full-HP **locked** counts from Step 3;
+the Step-1 screen table above reports the crippled-HP bias-pass counts (e.g. NFL 17/20),
+three of which (NFL rushing-yards, qb-tds, sacks-taken) failed Tier-0 on the full-HP
+retrain — Step 3 is the real shipping state.
+
+**NBA — 13/21 baselined**
+
+| Market | Family | Baseline strategy | Gate 1 | `devel` | `main` | Next step |
+|---|---|---|---|---|---|---|
+| MIN | SkewNormal | `ratio_meanyr` | ✅ | ✅ 2026-05-21 | ⏳ | Gate-2 soak |
+| PTS | SkewNormal | `ratio_meanyr` | ✅ | ✅ 2026-05-21 | ⏳ | Gate-2 soak |
+| REB | SkewNormal | `ratio_meanyr` | ✅ | ✅ 2026-05-21 | ⏳ | Gate-2 soak |
+| AST | SkewNormal | — | ❌ | — | — | Step-2 (B1.6) |
+| PRA | SkewNormal | `ratio_meanyr` | ✅ | ✅ 2026-05-21 | ⏳ | Gate-2 soak |
+| PR | SkewNormal | `ratio_meanyr` | ✅ | ✅ 2026-05-21 | ⏳ | Gate-2 soak |
+| RA | SkewNormal | `ratio_meanyr` | ✅ | ✅ 2026-05-21 | ⏳ | Gate-2 soak |
+| PA | SkewNormal | `ratio_meanyr` | ✅ | ✅ 2026-05-21 | ⏳ | Gate-2 soak |
+| FG3M | ZINB | — | ❌ | — | — | Step-2 (B1.6) |
+| fantasy points prizepicks | SkewNormal | `ratio_meanyr` | ✅ | ✅ 2026-05-21 | ⏳ | Gate-2 soak |
+| FG3A | SkewNormal | `ratio_meanyr` | ✅ | ✅ 2026-05-21 | ⏳ | Gate-2 soak |
+| FTM | ZINB | `ratio_meanyr` | ✅ | ✅ 2026-05-21 | ⏳ | Gate-2 soak |
+| FGM | SkewNormal | `ratio_meanyr` | ✅ | ✅ 2026-05-21 | ⏳ | Gate-2 soak |
+| FGA | SkewNormal | `ratio_meanyr` | ✅ | ✅ 2026-05-21 | ⏳ | Gate-2 soak |
+| STL | ZINB | — | ❌ | — | — | Step-2 (B1.6) |
+| BLK | ZINB | — | ❌ | — | — | Step-2 (B1.6) |
+| BLST | ZINB | — | ❌ | — | — | Step-2 (B1.6) |
+| TOV | ZINB | — | ❌ | — | — | Step-2 (B1.6) |
+| OREB | ZINB | — | ❌ | — | — | Step-2 (B1.6) |
+| DREB | SkewNormal | `ratio_meanyr` | ✅ | ✅ 2026-05-21 | ⏳ | Gate-2 soak |
+| PF | ZINB | — | ❌ | — | — | Step-2 (B1.6) |
+
+**WNBA — 10/18 baselined**
+
+| Market | Family | Baseline strategy | Gate 1 | `devel` | `main` | Next step |
+|---|---|---|---|---|---|---|
+| MIN | SkewNormal | `ratio_meanyr` | ✅ | ✅ 2026-05-21 | ⏳ | Gate-2 soak |
+| AST | SkewNormal | — | ❌ | — | — | Step-2 (B1.6) |
+| FG3M | ZINB | — | ❌ | — | — | Step-2 (B1.6) |
+| PA | SkewNormal | `ratio_meanyr` | ✅ | ✅ 2026-05-21 | ⏳ | Gate-2 soak |
+| PR | SkewNormal | `ratio_meanyr` | ✅ | ✅ 2026-05-21 | ⏳ | Gate-2 soak |
+| PTS | SkewNormal | `ratio_meanyr` | ✅ | ✅ 2026-05-21 | ⏳ | Gate-2 soak |
+| RA | SkewNormal | `ratio_meanyr` | ✅ | ✅ 2026-05-21 | ⏳ | Gate-2 soak |
+| REB | SkewNormal | `ratio_meanyr` | ✅ | ✅ 2026-05-21 | ⏳ | Gate-2 soak |
+| OREB | ZINB | — | ❌ | — | — | Step-2 (B1.6) |
+| DREB | SkewNormal | `centered_additive_mean10` | ✅ | ✅ 2026-05-21 | ⏳ | Gate-2 soak |
+| FGA | SkewNormal | `ratio_meanyr` | ✅ | ✅ 2026-05-21 | ⏳ | Gate-2 soak |
+| BLK | ZINB | — | ❌ | — | — | Step-2 (B1.6) |
+| STL | ZINB | — | ❌ | — | — | Step-2 (B1.6) |
+| BLST | ZINB | — | ❌ | — | — | Step-2 (B1.6) |
+| TOV | ZINB | — | ❌ | — | — | Step-2 (B1.6) |
+| FTM | ZINB | — | ❌ | — | — | Step-2 (B1.6) |
+| PRA | SkewNormal | `ratio_meanyr` | ✅ | ✅ 2026-05-21 | ⏳ | Gate-2 soak |
+| fantasy points prizepicks | SkewNormal | `ratio_meanyr` | ✅ | ✅ 2026-05-21 | ⏳ | Gate-2 soak |
+
+**NFL — 13/20 baselined**
+
+| Market | Family | Baseline strategy | Gate 1 | `devel` | `main` | Next step |
+|---|---|---|---|---|---|---|
+| targets | SkewNormal | `ratio_meanyr` | ✅ | ✅ 2026-05-21 | ⏳ | Gate-2 soak |
+| carries | SkewNormal | `ratio_meanyr` | ✅ | ✅ 2026-05-21 | ⏳ | Gate-2 soak |
+| attempts | SkewNormal | `ratio_meanyr` | ✅ | ✅ 2026-05-21 | ⏳ | Gate-2 soak |
+| passing yards | SkewNormal | `ratio_meanyr` | ✅ | ✅ 2026-05-21 | ⏳ | Gate-2 soak |
+| rushing yards | SkewNormal | — | ❌ | — | — | Step-2 (B1.6) † |
+| receiving yards | SkewNormal | `ratio_meanyr` | ✅ | ✅ 2026-05-21 | ⏳ | Gate-2 soak |
+| yards | SkewNormal | `ratio_meanyr` | ✅ | ✅ 2026-05-21 | ⏳ | Gate-2 soak |
+| qb yards | SkewNormal | `ratio_meanyr` | ✅ | ✅ 2026-05-21 | ⏳ | Gate-2 soak |
+| fantasy points prizepicks | SkewNormal | `ratio_meanyr` | ✅ | ✅ 2026-05-21 | ⏳ | Gate-2 soak |
+| fantasy points underdog | SkewNormal | `ratio_meanyr` | ✅ | ✅ 2026-05-21 | ⏳ | Gate-2 soak |
+| passing tds | ZINB | — | ❌ | — | — | Step-2 (B1.6) |
+| tds | ZINB | `ratio_meanyr` | ✅ | ✅ 2026-05-21 | ⏳ | Gate-2 soak |
+| rushing tds | ZINB | — | ❌ | — | — | Step-2 (B1.6) |
+| receiving tds | ZINB | — | ❌ | — | — | Step-2 (B1.6) |
+| qb tds | ZINB | — | ❌ | — | — | Step-2 (B1.6) † |
+| completions | SkewNormal | `ratio_meanyr` | ✅ | ✅ 2026-05-21 | ⏳ | Gate-2 soak |
+| receptions | SkewNormal | `centered_additive_mean10` | ✅ | ✅ 2026-05-21 | ⏳ | Gate-2 soak |
+| interceptions | ZINB | — | ❌ | — | — | Step-2 (B1.6) |
+| sacks taken | ZINB | — | ❌ | — | — | Step-2 (B1.6) † |
+| passing first downs | SkewNormal | `centered_additive_eb_meanyr_k10` | ✅ | ✅ 2026-05-21 | ⏳ | Gate-2 soak |
+
+† Passed the crippled-HP Step-1 screen but failed Tier-0 on the full-HP retrain (Step 3).
+`sacks taken`'s `ratio_meanyr`+hurdle plumbing works end-to-end (pickle `is_hurdle=True`),
+but the cell's star-bias still exceeds the bound — these three join the Step-2 pool.
+
 ## Status / progress log
 
 | Phase | State | Notes |
@@ -25,6 +283,7 @@
 | **Stage A1.5 — factor-ICC de-risk (T5 fork gate)** | ✅ done, result: **T5 KILLED as a wholesale architecture; A2 pivots to T3 tail head** | research-analyst brief (`/tmp/researcher_factor_icc.md`) computed factor-level ICC read-only by reusing A1's tested engine — reference markets reproduce the A1 parquet ICCs to 1e-6 (NBA MIN 0.3468, FGA 0.4890), so factor ICCs inherit A1's 15-test coverage and sit on the same scale. **Per-league band verdict (median ICC(volume) − median ICC(efficiency), pre-registered bands 0.20/0.10):** NBA gap **+0.232** (vol 0.391 / eff 0.158) → **MIXED** — gap-confirmed but the volume clause FAILED (0/3 NBA volume factors ≥ 0.5: MIN 0.347, FGA 0.489, FGA-per-MIN 0.391 all ambiguous, the same band where P1 shipped EB on FGA yet KILLED PA); WNBA gap **+0.456** (vol 0.559 / eff 0.103) → **CONFIRMED but low-confidence** (single computable efficiency factor — WNBA has no `FGM`/`FG3A` *markets*, so true FG%/3P% are uncomputable; needs new efficiency test cases — see caveat #3); NFL gap **+0.291** (vol 0.507 / eff 0.216) → **CONFIRMED** (carries 0.666, targets 0.507 high; yards-per-* efficiency genuinely heavy-tailed, skew +2.9 to +4.4). Efficiency factors are low-ICC in all three leagues (**8/8 ≤ 0.30**, the A1 tail-extension ceiling) — the "efficiency = noise" half is strongly confirmed and matches Franks et al. 2016 (DOI 10.1515/jqas-2016-0098); the "volume = stable identity" half is FALSE for NBA. **Literature OVERRIDES the band-only CONFIRMED to a T5 KILL on the body of the stat:** Goodman's exact variance-of-products (DOI 10.1080/01621459.1960.10483369) gives CV²(XY) = CV²(X)+CV²(Y)+CV²(X)CV²(Y), and on the actual NBA top-mean-decile PTS data, recomposing FGA × (PTS/FGA) inflates the within-player-season CV to **0.423 vs 0.334 modeling PTS directly (+27%)** — independent Monte-Carlo recomposition discards the structural volume↔efficiency negative covariance and re-inflates the priced tail; the disaggregate-forecasting result (ECB WP 1365, 2011) says factorization wins only with known-DGP components, not estimated GBDT heads. The plan's line-492 "DFS-industry consensus" is practitioner **lore** (no peer-reviewed tail-bias validation). **A2 fork: build T3 (spliced/Pareto or normalizing-flow tail head, 1–2 wk) as the primary; do NOT build T5 (2–3 wk + the largest inference change in the plan, 36 cells).** T5's internal logic survives only as a narrow **NFL per-factor route** (carries/targets → EB, yards-per-* → T3) as an A3/A4 follow-on — routing, not Monte-Carlo recomposition, so it avoids the +27% penalty. No `src/` change; verdict-only gate. |
 | **Stage A1.6 — NFL position-split matrix cleanup + WNBA test-case fix** | ✅ done | Moved the NFL position confound from a read-side workaround (A1's `icc_diagnostics.py` nonzero-fraction filter) to a **write-side fix**: `NFL_MARKET_POSITIONS` constant + `_market_position_filter` hook (no-op default in [base.py](../src/sportstradamus/stats/base.py), NFL override in [nfl.py](../src/sportstradamus/stats/nfl.py)) called in `get_training_matrix` before the usage cutoff. Scoping: passing + QB total-offense (`passing yards`, `attempts`, `completions`, `passing tds`/`first downs`, `interceptions`, `sacks taken`, `qb yards`, `qb tds`) → **QB**; rushing (`rushing yards`, `carries`, `rushing tds`) → **QB+RB**; receiving + skill scrimmage (`receiving yards`/`tds`, `targets`, `receptions`, `yards`, `tds`) → **WR+RB+TE**; only the fantasy-points composites stay all-position. Existing cached parquets cleaned in-place via [scripts/prune_nfl_matrix_positions.py](../src/sportstradamus/scripts/prune_nfl_matrix_positions.py) (one source of truth — codes derived from `StatsNFL.positions`): **passing-yards 15000→2646 rows, mean 38.1→215.9**; attempts 5.4→30.4; qb-yards→QB-only 45.3→228.0. **ICC re-run (`icc-diagnostics`): NBA/WNBA value-identical (untouched); all NFL shifts downward and explained by exact scoping removing gadget players A1's nonzero-fraction proxy retained** — passing-yards 0.420→0.405, receiving/targets/receptions ≤0.001, but **qb-yards 0.790→0.423** (RB rows removed, 632→222 player-seasons — the 0.790 was a QB-vs-RB between-position artifact), yards 0.470→0.440, carries 0.666→0.627 / rushing-yards 0.502→0.475 (≈47 WR/TE gadget rushers like Deebo removed), attempts 0.458→0.436 / completions 0.451→0.429 (Taysom-Hill-type passers removed). New NFL ICCs are computed on the *correct modeled population* and supersede A1's for A2 routing. No pickle/inference/default-flag change; parquets gitignored ⇒ PR diff is code + script + plan only. WNBA efficiency test cases chosen: `FTM_per_FGA` + `FG3M_per_FGA` (distinct regimes) with `PTS_per_FGA` (0.103) anchor. **New Stage A4 entry T11: per-position model-split bias experiment** (selective, overfitting-guarded, gated behind A2/A3). Two flagged inference edges for A2: QB-only `qb yards` vs Underdog "Total Yards"; QB+RB `carries` excludes gadget WR-rushers. Gates green; determinism green; refactoring-specialist run. |
 | P3–P10 | ⬜ | see priority list; P10 (GPBoost) already prototyped and failed deterministically — annotated below |
+| **Docs rework — breadth-led reorg + roadmap sync** | ✅ done (docs-only) | Reorganized this plan so the breadth North Star + per-cell status table lead, depth Tracks A/B are explicitly labeled secondary, the diminishing-returns pre/post-break split is marked, and a "Branches & model-promotion flow" section was added (four-branch pipeline + `devel-ship-curator`). Synced `docs/sportstradamus_roadmap_v2.md`: snapshot → 2026-05-21, model work promoted to a leading "Active Track" phase, post-break tail deferred into Phase 6, Standing rules + a "Tools and CLIs built" section added. No `.py`/`.json`/threshold changes; no retrain. |
 
 ## Scope — leagues this plan covers
 
@@ -165,19 +424,36 @@ new baseline must be computed there identically and leakage-safe. STYLE_GUIDE
 §9 (named constants), §18.9 (no orphan methods), and the CLAUDE.md
 "no new monoliths" rule all apply.
 
-**Universal decision threshold (every experiment, every market, every covered league):**
-ship a strategy only if it (1) reduces **top-mean-decile MAE by ≥ 5%** vs the
-current production strategy, (2) does not worsen **global MAE by > 1%**, (3) does
-not worsen `brier_skill_score` on the existing report, and (4) does not buy the
-top-decile win with **low-volume over-prediction** — the **bottom-mean-decile
-signed bias** (mean predicted − mean actual, lowest decile) must not become more
-positive than the current default's, and its magnitude must stay ≤ 10% of that
-decile's empirical mean (absolute floor 0.05 for cells whose bottom-decile mean
-< 0.5). Condition (4) was added after the Stage B1.5 §7a pre-check found two cells
-whose only MAE "wins" came from over-predicting low-volume players (FG3M bottom
-decile predicted ~3.4× actual) — the inverse of the under-predicted-stars symptom
-this plan targets; the initial tolerances are tunable but the *direction* (a
-top-decile win must not be financed by bottom-decile over-prediction) is fixed. The
+**Universal decision threshold — the Tier-1 gate that supersedes an established
+baseline (every market, every covered league):** once a cell's baseline is set
+(Tier 0, see "Top priority — baseline breadth" above), a challenger ships only if
+it (1) reduces **top-mean-decile MAE by ≥ 5%** vs the current baseline, (2) does not
+worsen **global MAE by > 1%**, (3) does not worsen `brier_skill_score` on the
+existing report, and (4) does not buy the top-decile win with **low-volume
+over-prediction**. The **Tier-0 first-baseline gate is the absolute subset of
+this**: condition (4)'s absolute bounds (bottom-quartile + top-decile bias) plus
+`brier_skill_score ≥ 0`; the relative conditions (1), (2), and (4)'s relative part
+are dropped, because there is no prior baseline to improve on. Condition (4) has a
+**relative** part and **absolute backstops on both ends**, gated *asymmetrically*
+by betting risk. For the **bottom quartile** (lowest 25% of players by season mean
+— the bench warmers) the failure mode is **over-prediction only**, so the
+**bottom-mean-quartile signed bias** (mean predicted − mean actual) must (a) not
+become more positive than the current default's (*relative*) and (b) not
+over-predict beyond a fraction of that quartile's empirical mean (*absolute,
+one-sided* — currently **+30%**, floor **0.10**); **under-prediction of bench
+warmers is tolerated for now** (it trips neither check). For the **top decile**
+(stars) the gate is **bidirectional**: the |signed bias| must stay within a
+fraction of that decile's mean (currently **30%**, floor **0.10**) — no systematic
+over- *or* under-prediction. The lowest quartile is pooled coarsely on purpose —
+bench warmers generalize more than stars, so a quartile aggregate is more
+representative than a single decile; the absolute bounds start **wide and tighten
+as the bias-correction track lands real improvements**. Condition (4) was added
+after the Stage B1.5 §7a pre-check found two cells whose only MAE "wins" came from
+over-predicting low-volume players (FG3M bottom buckets predicted ~3.4× actual) —
+the inverse of the under-predicted-stars symptom this plan targets; the bounds are
+tunable but the *direction* (a top-decile win must not be financed by
+bottom-quartile over-prediction) is fixed. A standalone quick-reference of the
+current values lives at [docs/ship_gate.md](ship_gate.md). The
 threshold must hold on **every market in every covered league** — or the routing
 config records the per-market/per-league exceptions. Otherwise kill it
 and move on. The harness —
@@ -222,6 +498,22 @@ the engineering effort elsewhere**. The plan is a backlog, not a queue.
 (If the residual or cost analysis behind a stop/continue call is ambiguous,
 dispatch the `research-analyst` agent before deciding.)
 
+**The break — what is active vs the speculative tail.** This principle is the cut line
+that splits the model work in two, and it drives the
+[roadmap](sportstradamus_roadmap_v2.md) phase split:
+
+- **Pre-break (active — worth the effort).** Reach 75% breadth first — the Tier-0 audit
+  code (`compression_eval.verdict()` absolute-only mode) then the **Stage B1.6**
+  feature/bias track — then the core depth methods expected to pay off: **A2** (T3
+  tail-head), **A3** (calibration polish — orthogonal, stacks on A2; classified active,
+  not tail), **B2** (routing + orthogonal feature engineering), **B3** (MZINB /
+  marginalized-hurdle family build). This is the roadmap's leading "Active Track" phase.
+- **Post-break (speculative tail — deferred).** **Stage A4** (novel risky retries, only
+  if A2/A3 leave a gap), **Stage B4** (tuning/polish — optional), and any long-shot
+  method. All stage bodies stay in this plan (it remains the home of record), but they are
+  **deferred — tracked under roadmap Phase 6** alongside the original 6.1–6.5 refinements.
+  None of the tail was ever the urgent work.
+
 ### Lifecycle: offline gate → production test → live gate → graduation
 
 Every (league, market) cell moves through three states. Two gates control
@@ -239,23 +531,33 @@ not-shipped  ─[Gate 1: offline]→  in-production-test  ─[Gate 2: live]→  
 
 Computed on the **held-out validation + test split** that `train_market`
 already produces (lines 547-553 in [pipeline.py](../src/sportstradamus/training/pipeline.py)
-and the deterministic test_set CSVs under `data/test_sets/`). This is the
-existing universal decision threshold restated as a per-cell gate.
+and the deterministic test_set CSVs under `data/test_sets/`). Gate 1 has **two
+tiers** (see "Top priority — baseline breadth" above): **Tier 0** sets a cell's
+*first* baseline from the **absolute** rows only; **Tier 1** supersedes an
+*established* baseline and additionally requires the **relative** rows. The Tier
+column tags which rows apply when.
 
-| Offline metric | Threshold | Where it lives |
-|---|---|---|
-| Top-mean-decile MAE on the test split | ≥ 5% better than current default strategy on the same cell | `compression_eval --baseline ... --candidate ...` output |
-| Global MAE on the test split | not worse by > 1% vs current default | `compression_eval` global summary |
-| `brier_skill_score` on the validation split (book baseline) | not worse than current default | `model_stats.parquet` for the candidate run |
-| Determinism gate (when changing the deterministic-mode pipeline) | green for every league with cached parquets | `tests/integration/test_determinism_gate.py` (current NBA-only; Stage 0 prerequisite extends to WNBA + NFL) |
-| Bottom-mean-decile signed bias on the test split | not more positive than current default; magnitude ≤ 10% of that decile's empirical mean (abs. floor 0.05 for sub-0.5-mean cells) | per-decile signed-bias column in `compression_eval` — proven in the Stage B1.5 harness (`/tmp/precheck_harness.py`); **to be promoted to a standard `compression_eval` output** (brief reality-check R4) |
+| Offline metric | Threshold | Tier | Where it lives |
+|---|---|---|---|
+| Top-mean-decile MAE on the test split | ≥ 5% better than the current baseline on the same cell | Tier 1 only | `compression_eval --baseline ... --candidate ...` output |
+| Global MAE on the test split | not worse by > 1% vs current baseline | Tier 1 only | `compression_eval` global summary |
+| `brier_skill_score` (book baseline) | **Tier 0:** ≥ 0 (beats book); **Tier 1:** not worse than the established baseline | both | `model_stats.parquet` for the candidate run |
+| Bottom-quartile bias — **absolute** | over-prediction ≤ +30% of quartile mean (floor 0.10); under-prediction tolerated | both | `bottom_quartile_bias` / `bottom_quartile_mean` in `compression_eval` |
+| Bottom-quartile bias — **relative** | not more positive than the established baseline | Tier 1 only | `verdict()` condition 4a |
+| Top-decile bias — **absolute** | \|bias\| ≤ 30% of decile mean (floor 0.10), bidirectional | both | `top_decile_bias` / `top_decile_mean` in `compression_eval` |
+| Determinism gate (when changing the deterministic-mode pipeline) | green for every league with cached parquets | both | `tests/integration/test_determinism_gate.py` (current NBA-only; Stage 0 prerequisite extends to WNBA + NFL) |
 
-If **all five** clear on every cell in every covered league (or the
-routing config records the exceptions), the strategy is allowed to
-promote: change becomes the new default for those cells on `devel`, runs
-in production for the **mandatory ≥ 14-day soak window** before the live
-gate is evaluated. During the soak, the previous version's pickle stays
-archived under `data/old_models/` so revert is one cron-pull away.
+**Tier 0 — set the first baseline (the priority):** the "both" rows must clear —
+bottom-quartile + top-decile absolute bias and `brier_skill_score ≥ 0`. Of every
+candidate (incl. the incumbent default) that clears them on a cell, the
+highest-BSS full retrain is set as that cell's baseline and promoted to the
+**mandatory ≥ 14-day soak window**.
+
+**Tier 1 — supersede an established baseline:** all rows must clear — the absolute
+rows plus the relative ≥ 5% top-decile, global-MAE-not-worse, BSS-not-worse, and
+bottom-quartile-not-more-positive checks — on every cell in every covered league
+(or the routing config records the exceptions). On promotion the previous pickle
+stays archived under `data/old_models/` so revert is one cron-pull away.
 
 ### Gate 2 — Live graduation gate (cell graduates from the track)
 
@@ -269,7 +571,7 @@ in `nightly.py`. A cell graduates from the track — no further stage work
 | Settled book-BSS (30 days, ≥ 200 offers) | ≥ 0 AND ≥ training-set `brier_skill_score − 0.02` (no live-vs-offline regression > 0.02) | Stage 0 deliverable 0.1 (`compute_book_brier_skill_score`); persisted by 0.2 in `data/live_metrics_per_market.parquet` |
 | Empirical over-rate vs predicted over-rate on settled offers | within ±0.03 over ≥ 200 settled offers | same parquet — Stage 0 0.2 |
 | Top-decile live MAE on settled bets | ≥ 5% better than prior-version live MAE on the same cell, OR within 5% of the offline compression_eval test-set MAE (i.e. no live-vs-offline drift) | Stage 0 deliverable 0.3 (`compression_eval --live-window 30`) |
-| Bottom-mean-decile signed bias on settled bets | within ±10% of that decile's empirical settled mean (abs. floor 0.05 for sub-0.5-mean cells) over ≥ 100 settled offers in the decile, AND not more positive than the prior version | Stage 0 deliverable 0.3 (`compression_eval --live-window 30`), per-decile bias column (live analog of the Gate 1 row) |
+| Bottom-quartile bias (one-sided) + top-decile bias (bidirectional) on settled bets | mirrors Gate 1 cond. 4 over ≥ 100 settled offers: bottom-quartile over-prediction ≤ +30% of band mean (floor 0.10) AND not more positive than prior; top-decile \|bias\| ≤ 30% (floor 0.10) | Stage 0 deliverable 0.3 (`compression_eval --live-window 30`), `bottom_quartile_bias` column (live analog of the Gate 1 row) |
 | Profit-sim parlay yield | non-negative on slates containing the cell | dashboard Stats Profit Sim page; Stage 0 0.2 aggregates per-cell into the same parquet |
 
 If a cell graduates, mark it ✅ in the Status table with the graduating
@@ -362,6 +664,42 @@ Production (`devel`)"**. Every per-market ship PR (and any further foundation la
 `statsmodels`), keeps the Gate-1 verdict as PR prose rather than committed code, and
 verifies the three gates. The initial Phase A foundation PR is carved by hand (the
 one exception).
+
+### Branches & model-promotion flow
+
+Four branches map to the two gates. Candidate work is built and offline-tested on a
+research branch, trimmed into a clean production base, shipped to the live beta, and
+finally graduated to the shipped models:
+
+- **`model-research`** — where candidate updates are developed and offline-tested
+  (deterministic A/B, research scaffolding, cached test sets). All experimentation bloat
+  lives here. *(This is the intended rename of the current
+  `claude/fix-gbdt-mean-regression-GcY1g` branch; the rename is **documented here, not
+  performed** — it is entangled with PR #46, whose head ref is that branch, so renaming it
+  now would orphan the PR. Sequence the rename for after PR #46 merges, or retarget the PR
+  first.)*
+- **`devel-foundation`** — the trimmed, clean "production shipping foundation":
+  `model-research` minus the testing bloat (the denylist below). The clean base `devel`
+  builds on.
+- **`devel`** — the **live beta**. Candidates that pass **Gate 1** (offline ship) ship
+  here and soak on live data through the 14-day **Gate 2** window. The remote server
+  tracks `devel` (CLAUDE.md), so this is the real beta environment.
+- **`main`** — the **final shipped models**. A cell graduates to `main` once it passes
+  **Gate 2** on live data.
+
+```
+model-research ─(build + offline-test)→ trim → devel-foundation
+   ─(Gate-1 passers)→ devel [live beta / Gate-2 soak] ─(Gate-2 graduates)→ main
+```
+
+The `devel-foundation` / `model-research` →(Gate-1 passers)→ `devel` crossing is carved by
+the **`devel-ship-curator`** agent (`.claude/agents/devel-ship-curator.md`): it branches
+off `devel`, brings only production-runtime code + the single `data/ship_config.json`
+toggle for one cleared cell, **hard-excludes** the research-scaffolding denylist
+(`compression_eval`, `zinb_routing_diagnostics`, `icc_diagnostics`, `statsmodels`, `/tmp`
+harnesses), carries the offline verdict as **PR prose, not code**, verifies the three
+gates, and **never pushes** (the human approves). It does not decide *whether* to ship —
+Gate 1 already did — it selects, excludes, verifies, and packages.
 
 ### Track-wide stop condition
 
@@ -534,9 +872,20 @@ Work proceeds on two independent tracks. Stages within a track are sequential
 infrastructure (the harness, the determinism gate, the per-strategy registry)
 but the diagnostics and method choices diverge.
 
+> **Depth work — secondary to 75% breadth.** Both tracks are *depth* work: superseding a
+> set baseline with a better one (the Tier-1 ≥ 5% compression bar). They are secondary to
+> the breadth North Star at the top of this plan and **begin once the 75%-per-league
+> breadth gap closes** (NBA −3, WNBA −4, NFL −2 as of 2026-05-21). The active pre-break
+> work is the breadth push (Tier-0 audit → Stage B1.6) plus the core depth methods
+> A2/A3/B2/B3; the post-break tail (A4/B4) is deferred — see
+> [roadmap](sportstradamus_roadmap_v2.md) Phase 6.
+
 ---
 
 ## Track A — SkewNormal markets
+
+*Depth work — secondary to 75% breadth; begins after the breadth gap closes. A2/A3 are
+the active (pre-break) core depth; A4 is the deferred post-break tail (roadmap Phase 6).*
 
 Source: `/tmp/researcher_skewnormal.md`. Scope: PTS, REB, AST, PRA, FGA, MIN,
 PA, PR, FG3A, FGM, fantasy points. After P1, FGA ships with EB(MeanYr, K=10)
@@ -770,6 +1119,8 @@ framing is superseded by this fork.
 
 ### Stage A4 — Novel risky retries (only if Stage A2/A3 leave a gap)
 
+> **Deferred — post-break speculative tail; tracked under [roadmap](sportstradamus_roadmap_v2.md) Phase 6.** Body kept here (home of record); not active until A2/A3 leave a gap *and* breadth is met.
+
 | Method | Source | Cost | Direct effect | Notes |
 |---|---|---|---|---|
 | **T4. MEGB / GBMixed** *(replaces original P10 GPBoost retry)* | Tier 3 (Skew) | 1–2 weeks (MEGB), more for GBMixed | EM/BLUP-based mixed-effects boosting that fixes the bias GPBoost was criticized for in Prevett et al. 2025. MEGB is on CRAN + github.com/rid4stat/MEGB; GBMixed has no public code. **Different mechanism from GPBoost** — prior failure does not predict failure here. | Point prediction only for MEGB; use for loc, keep LightGBMLSS for scale/shape. Port GBMixed from the paper if MEGB ships. |
@@ -827,6 +1178,10 @@ framing is superseded by this fork.
 ---
 
 ## Track B — ZINB markets (FTM, STL kill recovery + 6 SHIP hardening)
+
+*Depth work — secondary to 75% breadth; begins after the breadth gap closes. B1.6 (the
+feature/bias track) is the active breadth lever; B2/B3 are the active (pre-break) core
+depth; B4 is the deferred post-break tail (roadmap Phase 6).*
 
 Source: `/tmp/researcher_zinb.md`. Scope: FG3M, FTM, OREB, PF, STL, TOV, BLK,
 BLST. After P2.B, 6/8 ship under hurdle mode; FTM and STL kill. The
@@ -1146,9 +1501,10 @@ actual is 0.20), the inverse of the under-prediction-of-stars compression Track 
 targets. A trivial bias re-centering (subtract mean signed bias, change nothing else)
 recovers 41% (FG3M) / 47% (rushing-tds) of the gain with **no family change**; the
 remainder is better mean-fit from a fresh GBM, not orthogonal dispersion. Under the
-bottom-mean-decile-bias ship gate (Universal decision threshold condition 4, added
-in response to this finding), both cells **fail Gate 1** — the low-volume
-over-prediction their top-decile wins rely on is exactly what that gate now blocks.
+calibration ship gate (Universal decision threshold condition 4, added in response
+to this finding — now a bottom-quartile relative check + wide absolute backstops on
+both ends), both cells **fail Gate 1** — the low-volume over-prediction their
+top-decile wins rely on is exactly what that gate now blocks.
 
 **3. No CMPμ candidate among the NBA/WNBA cells.** Conditional Dunn–Smyth RQR variance
 (Dunn & Smyth 1996, doi:10.1080/10618600.1996.10474708; power for count GOF: Feng et
@@ -1211,14 +1567,15 @@ condition at the end of this stage. Lock the eval protocol before refitting (Cam
 
 **Sequencing (cheapest, highest-leverage first): (1) → (2) → (3).** Do the post-hoc
 correction first — days of work, directly attacks the family-invariant compression,
-and on its own is expected to clear the new bottom-decile-bias gate on FG3M/rushing-tds.
+and on its own is expected to clear the new calibration (bottom-quartile) gate on
+FG3M/rushing-tds.
 Re-run `compression_eval` per cell after each workstream and **promote every cell that
 clears Gate 1's five conditions to the 14-day live soak immediately** — do not wait for
 later workstreams or for other cells.
 
 **Decision points (gate logic for Stage B1.6):**
-- After (1): any cell now clearing Gate 1 (incl. the new bottom-decile-bias condition)
-  ships to soak. Expect FG3M/rushing-tds to flip from "bias-driven nominal SHIP" to a
+- After (1): any cell now clearing Gate 1 (incl. the new calibration / bottom-quartile
+  condition) ships to soak. Expect FG3M/rushing-tds to flip from "bias-driven nominal SHIP" to a
   *legitimate* SHIP once the over-prediction is corrected rather than exploited.
 - After (1)+(2)+(3): cells that clear Gate 1 ship; cells that still kill carry to the
   re-entry check below.
@@ -1341,6 +1698,8 @@ evaluate the bigger structural change.
   larger than MZINB's parameter-contract change.
 
 ### Stage B4 — Tuning, polish, specialized fixes (optional)
+
+> **Deferred — post-break speculative tail; tracked under [roadmap](sportstradamus_roadmap_v2.md) Phase 6.** Body kept here (home of record); optional, not active until B2/B3 leave a gap *and* breadth is met.
 
 | Method | Source | Cost | Direct effect | Implementation site |
 |---|---|---|---|---|
@@ -1703,11 +2062,18 @@ returns `HTTP 401`, the user needs to re-auth.
 
 ### Branch / PR / commit refs
 
-- Branch: `claude/fix-gbdt-mean-regression-GcY1g`
-- PR: #46 (→ `devel`)
-- HEAD at this plan rewrite: `6e913b1` ("docs: add research handoff for
-  centered-target negative result")
-- Latest shipped: P2.B HurdleZINB (commit `cee5625` ships
-  `centered_additive_eb_meanyr_k10`; subsequent commits add the verdict and
-  the HurdleZINB landing); P1 follow-up `1d0e65e` adds
+See **"Branches & model-promotion flow"** above for the four-branch pipeline
+(`model-research` → `devel-foundation` → `devel` → `main`) and why the `model-research`
+rename is deferred behind PR #46.
+
+- Branch: `claude/fix-gbdt-mean-regression-GcY1g` (the intended future `model-research`).
+- PR: #46 (→ `devel`); HEAD `fbec3cc` ("feat(ship): per-cell `zinb_mode` plumbing + lock
+  13 NFL baselines (full-HP confirmed)").
+- Earlier plan-rewrite HEAD: `6e913b1` ("docs: add research handoff for centered-target
+  negative result").
+- Latest shipped: 13 NBA + 10 WNBA + 13 NFL baselines locked in `data/ship_config.json`
+  (`b5d2609` / `c9fcf01` / `fbec3cc`); P2.B HurdleZINB (`cee5625` ships
+  `centered_additive_eb_meanyr_k10`); P1 follow-up `1d0e65e` adds
   `centered_additive_mean10` as the path-wide A/B counterexample.
+- This breadth-led docs reorg + roadmap sync landed on `claude/roadmap-rework-docs-h13so`
+  (cut off `fbec3cc`; PR → `devel`, stacked on PR #46).

--- a/docs/lockin_ship_handoff.md
+++ b/docs/lockin_ship_handoff.md
@@ -1,0 +1,136 @@
+# GBDT mean-regression — baseline lock-in results & devel ship handoff
+
+**Date:** 2026-05-21
+**Research branch:** `claude/fix-gbdt-mean-regression-GcY1g`
+**Status:** Lock-in complete for NBA + WNBA + NFL. **36 cells locked** in
+`data/ship_config.json` (NBA 13, WNBA 10, NFL 13), all full-HP Tier-0 confirmed.
+Nothing has shipped to production yet — this document is the handoff for the
+`devel-ship-curator` to carry it there.
+
+---
+
+## 1. What must reach `devel` first — foundation-update scope
+
+Production tracks `devel`. `devel-foundation` (cut 2026-05-21 12:58, the one-time
+production-runtime foundation) is **8 commits ahead of `devel`, not yet merged**,
+and is **missing two production-runtime deltas** added on the research branch
+*after* it was cut. Both are foundation-grade (production code, not per-market
+data) and **must be folded into `devel-foundation` before any cell ships**:
+
+| Delta | Files | Commit | Why it is foundation-grade |
+|---|---|---|---|
+| **TOR expansion-team fix** | `src/sportstradamus/stats/base.py` (`_profile_rows_for_teams`) + `tests/golden/test_profile_team_lookup.py` | `c9fcf01` | Without it, production WNBA `meditate`/`prophecize` crashes with `KeyError: ['TOR']` (Toronto Tempo, 2026 expansion). Live bug for every WNBA cell. |
+| **Per-cell `zinb_mode` plumbing** | `training/baselines.py` (`ZINB_MODES`), `training/ship_config.py` (object-form cells + `resolve_cell_zinb_mode` + `_validate_cell`), `training/cli.py` (wiring), `training/pipeline.py` (validation) + `tests/test_ship_config.py` | (this branch HEAD) | Lets a `ship_config` cell pin `zinb_mode` via the object form `{"strategy", "zinb_mode"}`. If an object-form cell reaches a `devel` whose `ship_config.py` is still string-only, `load_ship_config` raises `ValueError` and the `meditate` cron dies at startup. |
+
+**Order of operations (all carved by `devel-ship-curator`, which enforces the
+diagnostic denylist — no `compression_eval` / `zinb-routing-diagnostics` /
+`icc-diagnostics` / `statsmodels`):**
+
+1. Update `devel-foundation` with the two deltas above (a "further foundation layer").
+2. Merge `devel-foundation` → `devel` (the first foundation merge; production then
+   runs the ship system for the first time).
+3. Layer the per-market ship deltas (the `ship_config.json` blocks below + trained
+   pickles) on top.
+
+> **Note on the object form:** after NFL pruning (§4), **no `ship_config` cell
+> currently uses the object form** — sacks-taken, the plumbing's motivating cell,
+> failed full-HP Tier-0 and was pruned. The `zinb_mode` plumbing therefore ships
+> as **tested infrastructure with no live consumer yet**, ready for the first
+> hurdle cell that passes. It is still required on `devel` because the string-only
+> loader and the object-aware loader are the same file; shipping the new
+> `ship_config.py` is what makes a future hurdle cell a one-line edit.
+
+---
+
+## 2. Locked `ship_config.json` (the per-market ship payload)
+
+All 36 cells passed full-HP Tier-0 (bench bias one-sided ≤ bound, star bias
+bidirectional ≤ bound, `brier_skill_score` ≥ 0). `ratio_meanyr` is the incumbent.
+
+### NBA — 13/13 (commit `b5d2609`)
+All `ratio_meanyr`: DREB, FG3A, FGA, FGM, FTM, MIN, PA, PR, PRA, PTS, RA, REB,
+fantasy points prizepicks. (Crippled-HP "centered wins" were 0–2 pp noise;
+incumbent confirmed best-or-equal.)
+
+### WNBA — 10/10 (commit `c9fcf01`)
+`DREB` → `centered_additive_mean10`; the other 9 → `ratio_meanyr` (FGA, MIN, PA,
+PR, PRA, PTS, RA, REB, fantasy points prizepicks). Unblocked by the TOR fix.
+
+### NFL — 13/16 baseline-able (this branch HEAD)
+`passing first downs` → `centered_additive_eb_meanyr_k10`; `receptions` →
+`centered_additive_mean10`; the other 11 → `ratio_meanyr` (attempts, carries,
+completions, fantasy points prizepicks, fantasy points underdog, passing yards,
+qb yards, receiving yards, targets, tds, yards).
+
+---
+
+## 3. Breadth vs the 75% North Star
+
+| League | Locked | All markets | North Star (75%) | Gap |
+|---|---|---|---|---|
+| NBA | 13 | 13 baseline-able / (full set) | met for baseline-able | — |
+| WNBA | 10 | 18 | 14 | **−4** (Step-2 count markets: FG3M/FTM/STL …) |
+| NFL | 13 | 20 | 15 | **−2** (see §4) |
+
+---
+
+## 4. NFL full-HP Tier-0 verdict (the analysis)
+
+The deterministic screen (crippled HP) flagged 16 NFL cells as baseline-able.
+A fresh `--force` full-HP retrain (real Optuna), scored on the regenerated
+test sets, **confirmed only 13**. The screen was optimistic for 3 cells:
+
+### Shipped (13) — `brier_skill_score`
+| Market | Strategy | BSS |
+|---|---|---|
+| tds | ratio_meanyr | +0.756 |
+| qb yards | ratio_meanyr | +0.198 |
+| passing first downs | centered_additive_eb_meanyr_k10 | +0.139 |
+| targets | ratio_meanyr | +0.135 |
+| fantasy points underdog | ratio_meanyr | +0.115 |
+| fantasy points prizepicks | ratio_meanyr | +0.093 |
+| passing yards | ratio_meanyr | +0.085 |
+| receptions | centered_additive_mean10 | +0.074 |
+| yards | ratio_meanyr | +0.060 |
+| attempts | ratio_meanyr | +0.037 |
+| carries | ratio_meanyr | +0.032 |
+| completions | ratio_meanyr | +0.027 |
+| receiving yards | ratio_meanyr | +0.026 |
+
+### Pruned (3) — failed full-HP Tier-0
+| Market | Strategy tried | Failure | BSS |
+|---|---|---|---|
+| qb tds | ratio_meanyr | bench-bias +0.39 > 0.34 **and** star-bias +0.68 > 0.35 (over-predicts at full HP; screen under-predicted) | +0.076 |
+| rushing yards | centered_additive_mean10 | BSS −0.006 < 0 (incumbent `ratio_meanyr` also failed it on the screen) | −0.006 |
+| sacks taken | ratio_meanyr + **hurdle** | star-bias +0.67 > 0.50 | +0.003 |
+
+### Never baseline-able on the screen (4) → Step-2 feature/bias track
+interceptions, passing tds, rushing tds, receiving tds.
+
+**NFL Step-2 pool = 7 cells** (the 3 pruned + the 4 above). Closing +2 of them
+reaches the 15/20 North Star.
+
+### Plumbing verification
+The sacks-taken model pickle baked `is_hurdle=True`, `zinb_mode="hurdle"`,
+`target_strategy="ratio_meanyr"` — the per-cell `zinb_mode` plumbing flows
+end-to-end into a production hurdle model. The plumbing is **correct**; the cell
+it was built for simply does not clear Tier-0 at full HP.
+
+---
+
+## 5. Gates & process
+
+- All three gates green on the plumbing: `ruff` clean; `pytest tests/golden/
+  tests/test_ship_config.py` = 166 passed / 6 skipped (15 are the new
+  `ship_config` tests); `pytest -m integration` = 11 passed (determinism intact).
+- `refactoring-specialist` run on every touched `src/` Python file (base.py;
+  baselines/ship_config/cli/pipeline) — clean, no behavior change.
+- TOR fix and `zinb_mode` plumbing both built TDD (RED→GREEN).
+
+### Open follow-ups (not done here — for the curator / next session)
+- Carve the foundation update (§1) and the per-market ship deltas (§2).
+- NFL Step-2 feature/bias track (§4) to reach 15/20.
+- WNBA Step-2 count markets to reach 14/18.
+- `ZINB_MODES` lives in `baselines.py` (the per-cell-decision constants home);
+  refactoring-specialist flagged a *future* move to a dedicated training-config
+  module — deferred (5-file touch, zero behavior change).

--- a/docs/ship_gate.md
+++ b/docs/ship_gate.md
@@ -1,0 +1,127 @@
+# Ship gate — current thresholds (quick reference)
+
+At-a-glance reference for the model that promotes a `(league, market)` cell from
+research → `devel` → graduated. Keep this updated whenever a threshold changes; it
+is the human-readable mirror of the code.
+
+**Top priority:** get a baseline *set* for **≥ 75% of the markets in every league**
+(NBA ≥ 16/21, WNBA ≥ 14/18, NFL ≥ 15/20). Breadth first — see the "Top priority —
+baseline breadth" section of [docs/gbdt_mean_regression_plan.md](gbdt_mean_regression_plan.md).
+
+**Source of truth (code):** the constants and `verdict()` in
+[src/sportstradamus/scripts/compression_eval.py](../src/sportstradamus/scripts/compression_eval.py).
+Note: `verdict()` currently encodes only the **Tier 1** path; the **Tier 0**
+absolute-only mode is the next code step.
+
+The bounds are **deliberately wide for Phase 0**. Tighten the fractions/floor as the
+bias-correction track lands improvements.
+
+_Last updated: 2026-05-21._
+
+---
+
+## The two-tier ship model
+
+A cell is in one of two regimes. The split: relative checks only make sense once a
+baseline exists to improve on, so the *first* ship is absolute-only.
+
+- **Tier 0 — set the first baseline (the priority).** A cell with no baseline gets
+  one as soon as *any* candidate (including the incumbent default) clears the
+  **absolute** gates. Pick the highest-BSS passer (see Tiebreaker). No relative /
+  ≥5%-improvement requirement.
+- **Tier 1 — supersede an established baseline.** A challenger must clear **both**
+  the absolute gates **and** the relative gates to replace a set baseline. The
+  ≥5% top-decile bar lives here — it stops needless churn, it does not block the
+  first ship.
+- **Gate 2 — live graduation.** A newly-set baseline soaks ≥ 14 days, then
+  graduates on settled-offer metrics.
+
+---
+
+## Gate 1 — offline gate
+
+Computed on the held-out validation + test split (`compression_eval --baseline … --candidate …`).
+The **Tier** column says which conditions apply when.
+
+| # | Condition | Current threshold | Tier | Constant |
+|---|-----------|-------------------|------|----------|
+| 1 | Top-mean-decile MAE improvement vs baseline | **≥ 5%** better | Tier 1 only | `MIN_TOP_DECILE_MAE_IMPROVEMENT = 0.05` |
+| 2 | Global MAE regression vs baseline | **≤ 1%** worse | Tier 1 only | `MAX_GLOBAL_MAE_REGRESSION = 0.01` |
+| 3 | `brier_skill_score` (BSS) | **Tier 0:** ≥ 0 (beats book); **Tier 1:** no regression vs baseline | both | `MAX_BRIER_SKILL_REGRESSION = 0.0` |
+| 4a | Bottom-quartile bias — **relative** | not more **positive** than baseline | Tier 1 only | — |
+| 4b | Bottom-quartile bias — **absolute** | over-predict ≤ **+30%** of quartile mean (floor **0.10**) | both | `BOTTOM_QUARTILE_BIAS_MAGNITUDE_FRAC = 0.30`, `BIAS_ABS_FLOOR = 0.10` |
+| 4c | Top-decile bias — **absolute** | **\|bias\| ≤ 30%** of decile mean (floor **0.10**) | both | `TOP_DECILE_BIAS_MAGNITUDE_FRAC = 0.30`, `BIAS_ABS_FLOOR = 0.10` |
+
+**Tier 0 (set first baseline):** rows **3, 4b, 4c** must hold (BSS ≥ 0 + both
+absolute bias bounds). The **BSS ≥ 0 floor is the breadth knob** — if a league
+can't get three-quarters of its markets to ≥ 0, widen toward the Gate-2 −0.02
+tolerance rather than ship a book-losing cell.
+
+**Tier 1 (supersede):** all rows (1, 2, 3, 4a, 4b, 4c) must hold.
+
+Plus, when changing the deterministic-mode pipeline: the determinism gate must be
+green for every league with cached parquets (`tests/integration/test_determinism_gate.py`).
+
+### Condition 4 semantics — the calibration gate (both tiers)
+
+The compression pathology has two symptoms; condition 4 guards each according to
+its betting risk, **not** symmetrically:
+
+- **Bench warmers (bottom quartile = lowest 25% of players by season mean):** the
+  failure mode is **over-prediction only** (predicting a low-volume player higher
+  than reality → false EV on overs). Both 4a (relative) and 4b (absolute) are
+  **one-sided on the positive side**. **Under-prediction of bench warmers is
+  tolerated for now.** Pooled into a quartile (coarser than a decile) on purpose:
+  low-volume players generalize more than stars.
+- **Stars (top decile = highest 10%):** gated **bidirectionally** (4c, on
+  `|bias|`). No systematic over- *or* under-prediction — either is a calibration
+  defect at the high-stakes end.
+
+### How to tighten later
+
+- Bench-warmer over-prediction stricter → lower `BOTTOM_QUARTILE_BIAS_MAGNITUDE_FRAC`
+  (and/or `BIAS_ABS_FLOOR`).
+- Star calibration stricter → lower `TOP_DECILE_BIAS_MAGNITUDE_FRAC`.
+- Breadth too loose / too tight → move the Tier-0 BSS floor.
+- If bench-warmer **under**-prediction ever becomes a concern, make 4b two-sided
+  (`abs(...) >`), as the top-decile bound already is.
+
+### Tiebreaker — when more than one candidate passes (mainly Tier 0)
+
+`verdict()` is pairwise and does **not** rank candidates; `ship_config.json` holds
+one strategy per cell, and live production can A/B only **one** strategy per cell at
+a time. When several clear the gate (the common Tier-0 case — incumbent + each
+strategy compete), pick in two stages:
+
+1. **Screen (deterministic A/B):** rank survivors by **top-decile MAE improvement**
+   — the clean signal the crippled-HP deterministic models isolate. Brier on
+   crippled models is noisy; don't tiebreak on it here. Treat near-ties (~1-2 pp)
+   as equal; carry the top 1-2 forward.
+2. **Final pick (retrain survivors at full, non-deterministic HPs):** choose the
+   highest **`brier_skill_score`** — the money metric (drives Kelly staking; what
+   Gate 2 measures live). Ties → smaller global-MAE regression, then operational
+   simplicity (prefer a strategy already shipped elsewhere; avoid `*_hurdle` until
+   per-cell `zinb_mode` plumbing exists).
+
+The offline brier pick is a pre-ship heuristic; the 14-day live soak (Gate 2) is
+the real arbiter.
+
+---
+
+## Gate 2 — live graduation gate
+
+Computed on the last 30 days of settled production offers
+(`compression_eval --live-window 30`, `nightly.py` rolling aggregator). A cell
+graduates (no further track work) when all hold:
+
+| Live metric | Current threshold |
+|-------------|-------------------|
+| Settled book-BSS (30 d, ≥ 200 offers) | ≥ 0 **and** ≥ training `brier_skill_score − 0.02` |
+| Empirical vs predicted over-rate | within **±0.03** over ≥ 200 settled offers |
+| Top-decile live MAE | ≥ 5% better than prior-version live MAE, **or** within 5% of offline test-set MAE |
+| Calibration (bottom-quartile + top-decile bias) | **mirrors Gate 1 cond. 4** over ≥ 100 settled offers: bottom-quartile over-prediction ≤ +30% of band mean (floor 0.10) and not more positive than prior; top-decile \|bias\| ≤ 30% (floor 0.10) |
+| Profit-sim parlay yield | non-negative on slates containing the cell |
+
+Promotion requires a **mandatory ≥ 14-day soak** between setting a baseline and
+Gate 2; the prior pickle stays archived under `data/old_models/` for a one-pull
+revert.

--- a/docs/sportstradamus_roadmap_v2.md
+++ b/docs/sportstradamus_roadmap_v2.md
@@ -8,10 +8,30 @@ The result: **Phase 1 is no longer about reviving missing code; it's about audit
 
 ---
 
-## Current Status Snapshot (audited 2026-05-08)
+## Current Status Snapshot (audited 2026-05-21)
 
 A walk through the live tree against this roadmap. Status markers are inlined per
 sub-phase below; this section is the executive summary.
+
+> **Audit refresh (2026-05-21).** Since the 2026-05-08 audit, the headline change is a
+> model-correctness-and-breadth track that is now the project's **active** work — see the
+> new leading **"Active Track — Model Correctness & Market Breadth"** phase below (Phases
+> 1–6 keep their original numbers). The Phase-1 follow-ups (1.2, 1.6) and deferred Phases
+> 4–6 are otherwise unchanged.
+
+**ACTIVE — Model Correctness & Market Breadth (IN PROGRESS).** Home of record:
+[`docs/gbdt_mean_regression_plan.md`](gbdt_mean_regression_plan.md). Prompted by **defects
+found in the live implementation**, not optional polish: GBDT regression-toward-the-mean
+(top-decile compression), SkewNormal overconfidence, ZINB joint-fit per-row blowups
+(compression up to ~5357×, predicted means up to ~1437) fixed by HurdleZINB, the blanket
+ZINB label being wrong for ≥ 13 markets, and an NFL position-confound that put the
+passing-yards training mean at **38 instead of 216**. Shipped so far: P0 offline harness,
+P0.5 determinism gate, P1 centered-target verdict (FGA ship / family kill), P2.B
+HurdleZINB (6/8 NBA ZINB ship), Stage 0 live instrumentation, Stage B1/B1.5 routing
+diagnostics, A1/A1.5/A1.6 ICC diagnostics + NFL position-split cleanup. **Goal: ≥ 75% of
+markets per league carry a set baseline.** Current: NBA 13/21, WNBA 10/18, NFL 13/20 —
+**gap NBA −3, WNBA −4, NFL −2**. Immediate next: Tier-0 audit code → Stage B1.6
+feature/bias track → depth tracks A2/B2/B3; follow until diminishing returns.
 
 **Phase 1 — Audit and Strengthen the Foundation: ~80% complete.**
 
@@ -135,11 +155,120 @@ Every prompt is written for a Claude Code or GitHub Copilot Chat session inside 
 **Standing rules for every session, regardless of phase:**
 
 - Open with: "Read `CLAUDE.md` and `CONTRIBUTING.md` first."
-- Close with: "Run `poetry run ruff check src/sportstradamus/` and `poetry run pytest tests/golden/`. Both must pass."
+- **Close with the full always-on gate set — all must pass:**
+  ```bash
+  poetry run ruff check src/sportstradamus/
+  poetry run pytest tests/golden/
+  poetry run pytest -m integration      # fake-mode, no network
+  REGENERATE_SNAPSHOTS=1 poetry run pytest tests/golden/test_cli_help.py   # when CLI flags change
+  ```
+- **Run the `refactoring-specialist` subagent before any of five triggers** on Python
+  edits: a `git push`, a PR create/update, replying "done", dispatching a code-review
+  subagent, or asking the user for a review. Mandated by `CLAUDE.md`; the single most
+  important workflow item — reviewers should not spend attention on style nits the
+  specialist would catch. Hand it the explicit list of `.py` files touched this session.
+- **Dispatch the `research-analyst` subagent** (`subagent_type: "research-analyst"`) when
+  a diagnostic result is ambiguous or a path-forward decision needs literature + stats
+  synthesis. Read-only; writes a cited brief to `/tmp/researcher_{topic}.md`.
+- **End-of-phase handoff via the `prompt-engineer` agent** (part of the Definition of
+  Done): produce the next-stage handoff prompt in the 10-section structure, written to
+  `/tmp/{stage}_handoff_prompt.md`; on user acceptance, commit it to
+  `docs/handoffs/{stage}.md`.
+- **Cross-league testing policy:** run a smoke phase (1–2 markets per league) first; only
+  after smoke passes run full verification (all markets in all covered leagues for the
+  affected distribution branch). A smoke regression is a hard stop.
+- **Determinism gate before any cross-league A/B:** `poetry run pytest tests/integration/test_determinism_gate.py -v -m integration`.
 - Scope to one module per subagent (dispatch in parallel for multi-module work), then commit.
-- When adding a CLI flag or command, regenerate snapshots: `REGENERATE_SNAPSHOTS=1 poetry run pytest tests/golden/test_cli_help.py`
 - When adding a dependency, specify the Poetry group (core, `[bayes]`, `[strategy]`, `[alerts]`) so it doesn't dump into core.
 - Money values are always `Decimal`, never `float`.
+
+---
+
+## Tools and CLIs built
+
+Infrastructure hardened during the model-correctness track (above). Most diagnostics are
+**dev-only** — they stay off `devel` per the CONTRIBUTING.md "Shipping to Production
+(`devel`)" denylist; the live-metrics + graduation tooling is production runtime.
+
+**Offline A/B + verdict**
+- `compression_eval` (`src/sportstradamus/scripts/compression_eval.py`) — offline A/B
+  harness over the cached `data/test_sets/` artifacts; `--baseline` / `--candidate` /
+  `--live-window N` flags. `verdict()` currently encodes only the **Tier-1** relative
+  gate; the **Tier-0** absolute-only mode is the next code step. *(dev-only)*
+
+**Live metrics + lifecycle (production runtime)**
+- `check-graduation` (`scripts/check_graduation.py`) — joins Gate 1
+  (`data/model_stats.parquet`) × Gate 2 (`data/live_metrics_per_market.parquet`, 30-day
+  window) and prints the lifecycle state per (league, market): not-shipped / in-test /
+  graduated / demoted.
+- `backfill-live-metrics` (`scripts/backfill_live_metrics.py`) — walks settled history
+  backwards with `--days` / `--step` controls; idempotent day-precision dedup.
+
+**Diagnostics (dev-only)**
+- `icc-diagnostics` (`scripts/icc_diagnostics.py`) — ICC₁ per (league, market) cell →
+  `data/icc/{LEAGUE}_icc.parquet`.
+- `zinb-routing-diagnostics` (`scripts/zinb_routing_diagnostics.py`) — per-league ×
+  per-market dispersion routing → `data/zinb_routing/{LEAGUE}_diagnostics.parquet` (pulls
+  the `statsmodels` dep — denylisted off `devel`).
+
+**`meditate` flags**
+- `meditate --deterministic` — opt-in deterministic mode (debug-only, never publish):
+  RNGs pinned, Optuna swapped for fixed params, writes redirected to
+  `data/{test_sets,models}/deterministic/`.
+- `meditate --market <name>` — per-market scoped training (added Stage B1).
+
+**Persisted artifacts**
+- `data/live_metrics_per_market.parquet` — live BSS, 10-column / 2-window schema (Gate 2).
+- `data/model_stats.parquet` — offline training report (Gate 1).
+- `data/icc/`, `data/zinb_routing/` — diagnostic parquets.
+
+**Shipping mechanism**
+- `data/ship_config.json` — per-cell strategy config, nested `{league: {market:
+  strategy}}`; the single toggle a ship PR flips.
+- `devel-ship-curator` agent (`.claude/agents/devel-ship-curator.md`) — carves per-market
+  production-delta ship PRs to `devel`, enforcing the research-scaffolding denylist
+  (`compression_eval`, `zinb_routing_diagnostics`, `icc_diagnostics`, `statsmodels`,
+  `/tmp` harnesses). Never pushes; the human approves.
+- [`docs/ship_gate.md`](ship_gate.md) — human-readable mirror of the `compression_eval`
+  threshold constants. Update it whenever a threshold changes.
+
+---
+
+## Active Track — Model Correctness & Market Breadth (IN PROGRESS)
+
+> **This leads the remaining work**, ahead of the deferred Phase 4 (alerts/dashboard) and
+> Phase 5 (best ball). It is not a Phase-6 "refinement": it was prompted by **defects
+> discovered in the live implementation**, which makes it production-quality *correction*
+> work. Phases 1–6 keep their original numbers; this section is the current focus.
+
+**Home of record:** [`docs/gbdt_mean_regression_plan.md`](gbdt_mean_regression_plan.md).
+This entry is a pointer + status, not a duplicate of the stage detail.
+
+**Why it is urgent (the discovered defects):**
+- GBDT regression-toward-the-mean — top-decile compression, a family-invariant
+  leaf-averaging bias.
+- SkewNormal overconfidence / level bias.
+- ZINB joint-fit catastrophic per-row blowups (compression up to ~5357×, predicted means
+  up to ~1437) on BLK/OREB/PF/BLST — fixed by HurdleZINB.
+- The blanket ZINB label being wrong for ≥ 13 markets (underdispersed → should route to
+  CMP).
+- An NFL position-confound that put the passing-yards training mean at **38 instead of
+  216** (and similar across passing/rushing markets).
+
+**Goal:** ≥ 75% of markets per league carry a *set baseline* (NBA ≥ 16/21, WNBA ≥ 14/18,
+NFL ≥ 15/20). **Current:** NBA 13/21, WNBA 10/18, NFL 13/20 — **gap NBA −3, WNBA −4,
+NFL −2**.
+
+**Scope (pre-break — the active work):** reach 75% breadth (Tier-0 audit code → Stage
+B1.6 feature/bias track), then the core depth methods expected to pay off — A2 (T3
+tail-head), A3 (calibration polish), B2 (routing + feature engineering), B3 (MZINB /
+marginalized-hurdle family build). The post-break speculative tail (Stage A4 / B4 /
+long-shots) is deferred into **Phase 6** below. **Follow the track until diminishing
+returns**, then stop it per-cell.
+
+**Immediate next steps:** Tier-0 audit code → Stage B1.6 feature/bias track → A2/B2/B3.
+See the gbdt plan's "Roadmap to 75%" and "Diminishing returns — stop-the-track principle"
+sections.
 
 ---
 
@@ -1317,6 +1446,17 @@ Smaller scope than Best Ball. Ship this before tackling advance equity.
 
 **Estimated time:** opportunistic, 1–4 weekends per item
 
+> **What Phase 6 is now (2026-05-21).** This phase is the home for **deferred** model work
+> of two kinds: (1) the **speculative tail** of the active model track — the
+> post-diminishing-returns stages from
+> [`docs/gbdt_mean_regression_plan.md`](gbdt_mean_regression_plan.md): **Stage A4** (novel
+> risky retries), **Stage B4** (tuning/polish — optional), and any long-shot method; plus
+> (2) the **original refinements** 6.1–6.5 below. None of Phase 6 was ever the urgent work
+> — the urgent work is fixing the discovered defects and reaching 75% breadth (see the
+> leading "Active Track — Model Correctness & Market Breadth" phase). Everything here is
+> **deferred until breadth is met**. The gbdt plan stays the home of record for the
+> A4/B4 stage detail; this Phase-6 entry is a pointer, not a duplicate.
+
 ### 6.1 Bayesian hierarchical for low-sample players
 
 **Prompt:**
@@ -1481,30 +1621,36 @@ A realistic minimum-viable path was: **Phase 1.1 (correlate) + 1.2 (parlay) + 2 
 
 ## Updated Critical Path (post-2026-05-08 audit, scope-reduced)
 
-The modeling and CLV foundations are in place (1.1 + 1.2 + 2.x + 3.2).
-With placed-bet tracking explicitly out of scope, the remaining work is
-narrower: close out Phase 1 follow-ups, ship Kelly + Underdog-native
-recommendation, and add useful alerts. Recommended order:
+The model-correctness-and-breadth track now **leads** the critical path. The modeling and
+CLV foundations are in place (1.1 + 1.2 + 2.x + 3.x); Kelly (3.1) and the Underdog-native
+CLI (3.3) have **landed since the 2026-05-08 audit**. With placed-bet tracking explicitly
+out of scope, the genuinely remaining non-model work is narrow: close out the Phase 1
+follow-ups and the dashboard recommendations tab. Recommended order:
 
-1. **Phase 1.2 follow-up — open audit findings (1 weekend).** Fix the
+1. **Model Correctness & Market Breadth — ACTIVE (lead).** Reach ≥ 75% baseline breadth
+   per league (gap NBA −3, WNBA −4, NFL −2): Tier-0 audit code → Stage B1.6 feature/bias
+   track → core depth A2/B2/B3. Follow until diminishing returns; the speculative tail
+   (A4/B4) is deferred to Phase 6. Home of record:
+   [`docs/gbdt_mean_regression_plan.md`](gbdt_mean_regression_plan.md).
+2. **Phase 1.2 follow-up — open audit findings (1 weekend).** Fix the
    `find_correlation` pairwise-EV unbounded score, replace inline magic
    numbers with named constants, swap substring same-player guarding for
    `player_id` joins, and reconcile the `Boost`-column overwrite at
    `correlation.py:498` so the displayed multiplier matches the EV that
    ranked the parlay. Re-run `audit_parlay_calibration.py` on production
    archive data and commit a real plot.
-2. **Phase 1.6 — deprecated triage (½ weekend).** `correlation.py` and
+3. **Phase 1.6 — deprecated triage (½ weekend).** `correlation.py` and
    `opt_parlay.py` in `src/deprecated/` can be deleted; `opt_kelley_bet.py`
    should be marked REVIVE for the next session. Cheap and unblocks
    confusion for future agents.
-3. **Phase 3.1 — Kelly module (1 weekend).** Genuinely missing. The
-   parlay search produces ranked candidates that nothing currently sizes.
-   Output is a recommendation, not a placed-bet trigger — users decide
-   whether to actually wager.
-4. **Phase 3.3 — Underdog-native strategy CLI (1 weekend).** Single
-   `pickem-build` CLI that produces today's ranked, Kelly-sized
-   recommendations as YAML / Sheets export.
-5. **Phase 4.2 dashboard — Today's Recommendations tab only.** Reads
+4. **Phase 3.1 — Kelly module — ✅ landed since the audit.** `strategies/kelly.py`
+   (`fractional_kelly_stake`, `joint_kelly_portfolio`, the resolution chain) plus the
+   `kelly` CLI. Retained here for order; the parlay search's ranked candidates are now
+   sized. Output is a recommendation, not a placed-bet trigger.
+5. **Phase 3.3 — Underdog-native strategy CLI — ✅ landed since the audit.** The
+   `pickem-build` CLI emits today's ranked, Kelly-sized recommendations to
+   `data/recommendations/{date}.yaml`. Retained here for order.
+6. **Phase 4.2 dashboard — Today's Recommendations tab only.** Reads
    `data/recommendations/{today}.yaml`. Skip the Open Entries / Settled
    History / Bankroll tabs. The dashboard refresh covers the alerting
    role at current polling cadence.


### PR DESCRIPTION
## Summary

Clean, non-stacking carve of the reworked planning docs onto the production-shipping foundation. **4 files, docs-only** — no production code, no research scaffolding, none of the research branch's 51 commits.

| File | Change |
|---|---|
| `docs/gbdt_mean_regression_plan.md` | breadth-led rework (cell status table, diminishing-returns split, branch-flow section); supersedes devel's older `63b4b84` carve |
| `docs/sportstradamus_roadmap_v2.md` | snapshot → 2026-05-21, leading Active Track phase, expanded Standing rules, Tools section |
| `docs/ship_gate.md` | **new** — threshold mirror the gbdt plan links to |
| `docs/lockin_ship_handoff.md` | **new** — the devel ship handoff the gbdt plan links to |

## Why only 4 files (not the originally-scoped 6)

`devel` already carries **newer** versions of `CONTRIBUTING.md` and `.claude/agents/devel-ship-curator.md` from the `63b4b84` foundation commit — the "ship any market" paragraph and the curator's "always `git fetch origin` first" safety rule. The research-branch copies are older and would have **reverted** those, so they are deliberately left untouched on `devel`.

## Topology

- Replaces the stacked PR #50 (`claude/roadmap-rework-docs-h13so` → `devel`, which dragged all 51 research commits). #50 is being closed.
- `devel-foundation` was a stale pointer behind `devel`; this fast-forwarded it to `devel` + the 4 curated docs (no commits lost).
- The research branch is being renamed to `model-research` (its home-of-record role).

## Test plan

- [x] `git diff --stat origin/devel..origin/devel-foundation` → exactly the 4 docs, 0 code/scaffolding.
- [x] `CONTRIBUTING.md` + curator agent left at devel's (newer) versions.
- [x] gbdt plan is a heading-superset of devel's; roadmap retains devel's subagent-scope edits.
- [ ] Human review of the 4-file curated delta.

https://claude.ai/code/session_01RKZ8HsZ31ttoEfth2fGy7V

---
_Generated by [Claude Code](https://claude.ai/code/session_01RKZ8HsZ31ttoEfth2fGy7V)_