### PR TITLE
Skip markets with no trained model instead of crashing

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# SessionStart hook: install the GitHub CLI so the Claude Code on the web
+# console's PR-status indicator (which shells out to `gh pr checks`) works.
+#
+# - Skips on local sessions; only runs in remote envs.
+# - Idempotent: if `gh` is already on PATH, exits immediately.
+# - Auth is left to the user: set GH_TOKEN in your Claude Code on the web
+#   environment-variables config and `gh` will pick it up automatically.
+
+set -euo pipefail
+
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+if command -v gh >/dev/null 2>&1; then
+  exit 0
+fi
+
+if ! command -v wget >/dev/null 2>&1; then
+  sudo apt-get update -qq
+  sudo apt-get install -y -qq wget
+fi
+
+sudo mkdir -p -m 755 /etc/apt/keyrings
+wget -qO- https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+  | sudo tee /etc/apt/keyrings/githubcli-archive-keyring.gpg >/dev/null
+sudo chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg
+
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+  | sudo tee /etc/apt/sources.list.d/github-cli.list >/dev/null
+
+sudo apt-get update -qq
+sudo apt-get install -y -qq gh
+
+if [ -z "${GH_TOKEN:-}" ] && [ -z "${GITHUB_TOKEN:-}" ]; then
+  echo "gh installed. Set GH_TOKEN in your Claude Code on the web env to authenticate." >&2
+fi

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -64,6 +64,16 @@
     ]
   },
   "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ],
     "PreToolUse": [
       {
         "matcher": "Bash",

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
         args: ["--maxkb=1024"]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.6.9
+    rev: v0.15.8
     hooks:
       - id: ruff
         args: ["--fix"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,6 @@ repository = "https://github.com/tjjerome/sportstradamus"
 
 [tool.poetry.dependencies]
 python = ">=3.11,<3.12"
-python-snappy = "^0.6.1"
 google-auth-oauthlib = ">=1.0.0"
 gspread = ">=5.8.0"
 mlb-statsapi = ">=1.6.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,7 @@ smogn = "^0.1.2"
 seaborn = "^0.13.1"
 flask = "^2.3.2"
 flask-table = "^0.5.0"
-ruff = "^0.6.0"
+ruff = "^0.15.0"
 mypy = "^1.10.0"
 pre-commit = "^3.7.0"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,8 @@ shap = ">=0.44.0,<0.45.0"
 lightgbmlss = ">=0.6"
 torch = {version = "2.1.2", source = "pytorch_cpu"}
 line-profiler = "^4.1.3"
-klepto = {extras = ["archives"], version = "^0.2.5"}
+klepto = "^0.2.5"
+h5py = ">=3.9"
 duckdb = "^1.1.0"
 nflreadpy = "^0.1.2"
 polars = "^1.33.1"

--- a/src/sportstradamus/helpers/archive.py
+++ b/src/sportstradamus/helpers/archive.py
@@ -476,8 +476,7 @@ class Archive:
         devig_over = np.nan if not over_probs else float(np.mean(over_probs))
 
         sample_sql = (
-            "SELECT observed_at FROM odds "
-            "WHERE league=? AND market=? AND game_date=? AND entity=?"
+            "SELECT observed_at FROM odds WHERE league=? AND market=? AND game_date=? AND entity=?"
         )
         sample_params: list = [league, market, d, entity]
         if at is not None:
@@ -603,7 +602,7 @@ class Archive:
             out["close_line"] = float(line_hist["line"].iloc[-1])
             out["peak_line"] = float(line_hist["line"].max())
             out["trough_line"] = float(line_hist["line"].min())
-            out["n_obs"] = int(len(line_hist))
+            out["n_obs"] = len(line_hist)
             out["n_moves"] = int(line_hist["line"].diff().fillna(0).ne(0).sum())
             span = line_hist["observed_at"].iloc[-1] - line_hist["observed_at"].iloc[0]
             out["time_span_minutes"] = float(span.total_seconds() / 60.0)

--- a/src/sportstradamus/helpers/config.py
+++ b/src/sportstradamus/helpers/config.py
@@ -93,11 +93,7 @@ stat_std: dict[str, dict[str, float | None]] = {
     for league, markets in stat_meta.items()
 }
 stat_zi: dict[str, dict[str, float]] = {
-    league: {
-        market: cell["zi"]
-        for market, cell in markets.items()
-        if cell.get("zi") is not None
-    }
+    league: {market: cell["zi"] for market, cell in markets.items() if cell.get("zi") is not None}
     for league, markets in stat_meta.items()
 }
 

--- a/src/sportstradamus/pages/2_🎯_Predictions_Parlays.py
+++ b/src/sportstradamus/pages/2_🎯_Predictions_Parlays.py
@@ -163,7 +163,7 @@ for game, group in view.groupby("Game", sort=False):
             fam_group = group.loc[group["Family"] == fam]
             shown = fam_group.head(int(top_n))
             # Always show the family name — single-family games included.
-            st.markdown(f"**{labels[fam]}** — showing {len(shown)} of " f"{len(fam_group)} parlays")
+            st.markdown(f"**{labels[fam]}** — showing {len(shown)} of {len(fam_group)} parlays")
             for _, row in shown.iterrows():
                 _render_parlay(row, offers)
 

--- a/src/sportstradamus/pages/4_📊_Stats_Diagnostics.py
+++ b/src/sportstradamus/pages/4_📊_Stats_Diagnostics.py
@@ -408,7 +408,7 @@ if has_crps:
         cov_display = pd.DataFrame(
             [
                 {
-                    "Nominal Level": f"{int(level*100)}%",
+                    "Nominal Level": f"{int(level * 100)}%",
                     "Actual Coverage": f"{cov:.1%}",
                     "Status": "Good"
                     if abs(cov - level) < 0.05
@@ -451,7 +451,7 @@ if has_crps:
                         y=nom,
                         line_dash="dot",
                         line_color="gray",
-                        annotation_text=f"{int(nom*100)}% target",
+                        annotation_text=f"{int(nom * 100)}% target",
                     )
                 fig_cov.update_layout(height=400)
                 st.plotly_chart(fig_cov, use_container_width=True)

--- a/src/sportstradamus/pages/6_📊_Stats_Profit_Sim.py
+++ b/src/sportstradamus/pages/6_📊_Stats_Profit_Sim.py
@@ -384,8 +384,10 @@ for name, result in all_results.items():
 
     # Sharpe-like ratio
     daily_returns = result.groupby("run").apply(
-        lambda x: x["daily_pnl"].values
-        / np.maximum(x["bankroll"].shift(1).fillna(initial_bankroll).values, 1)
+        lambda x: (
+            x["daily_pnl"].values
+            / np.maximum(x["bankroll"].shift(1).fillna(initial_bankroll).values, 1)
+        )
     )
     all_returns = np.concatenate(daily_returns.values)
     sharpe = np.mean(all_returns) / np.std(all_returns) if np.std(all_returns) > 0 else 0

--- a/src/sportstradamus/prediction/scoring.py
+++ b/src/sportstradamus/prediction/scoring.py
@@ -136,6 +136,8 @@ def match_offers(offers, league, market, platform, stat_data):
 
             filename = "_".join([league, market]).replace(" ", "-")
             filepath = pkg_resources.files(data) / f"models/{filename}.mdl"
+            if not filepath.is_file():
+                return pd.DataFrame()
             with open(filepath, "rb") as infile:
                 expected_cols = pickle.load(infile)["expected_columns"]
             playerStats = playerStats[expected_cols]

--- a/src/sportstradamus/scripts/check_graduation.py
+++ b/src/sportstradamus/scripts/check_graduation.py
@@ -76,7 +76,7 @@ def _print_row(row: pd.Series) -> None:
         f"{_format_metric(row.get('profit_sim_yield')):>8} "
         f"{row['lifecycle_state']:<12}"
     )
-    color = _STATE_COLORS.get(row["lifecycle_state"], None)
+    color = _STATE_COLORS.get(row["lifecycle_state"])
     click.secho(line, fg=color)
 
 

--- a/src/sportstradamus/scripts/compression_eval.py
+++ b/src/sportstradamus/scripts/compression_eval.py
@@ -1343,7 +1343,7 @@ def write_scatter(df: pd.DataFrame, pred_col: str, out_path: Path, title: str) -
 def _print_table(table: pd.DataFrame) -> None:
     """Pretty-print the decile table to stdout."""
     click.echo(
-        f"{'decile':>6} {'meanyr':>8} {'n':>6} {'mae':>8} " f"{'bias':>8} {'pred':>8} {'actual':>8}"
+        f"{'decile':>6} {'meanyr':>8} {'n':>6} {'mae':>8} {'bias':>8} {'pred':>8} {'actual':>8}"
     )
     for _, r in table.iterrows():
         click.echo(

--- a/src/sportstradamus/scripts/evaluate_comp_features.py
+++ b/src/sportstradamus/scripts/evaluate_comp_features.py
@@ -289,8 +289,7 @@ def run_marginal_analysis(
         current_features, full_profile, position, lookups, min_comps, max_comps
     )
     print(
-        f"  Baseline: {baseline_score:.5f} "
-        f"({baseline_n} players, {len(current_features)} features)"
+        f"  Baseline: {baseline_score:.5f} ({baseline_n} players, {len(current_features)} features)"
     )
 
     unused = [f for f in available_features if f not in current_features]
@@ -342,7 +341,7 @@ def greedy_forward_selection(
             break
 
         best_feat, best_delta = None, 0.0
-        for feat in tqdm(unused, desc=f"  Fwd step {step+1}", leave=False):
+        for feat in tqdm(unused, desc=f"  Fwd step {step + 1}", leave=False):
             test = [*features, feat]
             s, _ = score_feature_set(test, full_profile, position, lookups, min_comps, max_comps)
             delta = s - score
@@ -350,14 +349,14 @@ def greedy_forward_selection(
                 best_feat, best_delta = feat, delta
 
         if best_delta < threshold:
-            print(f"    Step {step+1}: no feature improves score by >= {threshold}")
+            print(f"    Step {step + 1}: no feature improves score by >= {threshold}")
             break
 
         features.append(best_feat)
         unused.remove(best_feat)
         score += best_delta
         history.append((f"+{best_feat}", score, len(features)))
-        print(f"    Step {step+1}: +{best_feat} -> {score:.5f} ({best_delta:+.5f})")
+        print(f"    Step {step + 1}: +{best_feat} -> {score:.5f} ({best_delta:+.5f})")
 
     return features, score, history
 
@@ -383,7 +382,7 @@ def greedy_backward_elimination(
             break
 
         best_feat, best_delta = None, 0.0
-        for feat in tqdm(features, desc=f"  Bwd step {step+1}", leave=False):
+        for feat in tqdm(features, desc=f"  Bwd step {step + 1}", leave=False):
             test = [f for f in features if f != feat]
             s, _ = score_feature_set(test, full_profile, position, lookups, min_comps, max_comps)
             delta = s - score
@@ -391,13 +390,13 @@ def greedy_backward_elimination(
                 best_feat, best_delta = feat, delta
 
         if best_delta < threshold:
-            print(f"    Step {step+1}: no removal improves score by >= {threshold}")
+            print(f"    Step {step + 1}: no removal improves score by >= {threshold}")
             break
 
         features.remove(best_feat)
         score += best_delta
         history.append((f"-{best_feat}", score, len(features)))
-        print(f"    Step {step+1}: -{best_feat} -> {score:.5f} ({best_delta:+.5f})")
+        print(f"    Step {step + 1}: -{best_feat} -> {score:.5f} ({best_delta:+.5f})")
 
     return features, score, history
 
@@ -474,9 +473,9 @@ def main():
     positions = args.position or list(current_weights.get(args.league, {}).keys())
 
     for position in positions:
-        print(f"\n{'='*60}")
+        print(f"\n{'=' * 60}")
         print(f"{args.league} {position}")
-        print(f"{'='*60}")
+        print(f"{'=' * 60}")
 
         if position not in current_weights.get(args.league, {}):
             print(f"  No current weights found for {args.league} {position}")
@@ -525,7 +524,7 @@ def main():
 
         # ── Phase 1: Marginal analysis ──
         print("\n  Phase 1: Marginal Analysis")
-        print(f"  {'-'*50}")
+        print(f"  {'-' * 50}")
         baseline, additions, removals = run_marginal_analysis(
             current_features,
             available_names,
@@ -552,8 +551,8 @@ def main():
 
         # ── Phase 2: Greedy forward selection ──
         print("\n  Phase 2: Greedy Forward Selection")
-        print(f"  {'-'*50}")
-        fwd_features, fwd_score, fwd_history = greedy_forward_selection(
+        print(f"  {'-' * 50}")
+        fwd_features, _fwd_score, _fwd_history = greedy_forward_selection(
             current_features,
             available_names,
             pos_profile,
@@ -566,8 +565,8 @@ def main():
 
         # ── Phase 3: Greedy backward elimination ──
         print("\n  Phase 3: Greedy Backward Elimination")
-        print(f"  {'-'*50}")
-        best_features, best_score, bwd_history = greedy_backward_elimination(
+        print(f"  {'-' * 50}")
+        best_features, best_score, _bwd_history = greedy_backward_elimination(
             fwd_features,
             pos_profile,
             position,
@@ -578,9 +577,9 @@ def main():
         )
 
         # ── Summary ──
-        print(f"\n  {'='*50}")
+        print(f"\n  {'=' * 50}")
         print(f"  RESULTS for {args.league} {position}")
-        print(f"  {'='*50}")
+        print(f"  {'=' * 50}")
         print(f"  Baseline score: {baseline:.5f} ({len(current_features)} features)")
         print(f"  Best score:     {best_score:.5f} ({len(best_features)} features)")
         print(f"  Improvement:    {best_score - baseline:+.5f}")
@@ -602,7 +601,7 @@ def main():
         # ── Phase 4: Optional weight optimization ──
         if args.optimize and (best_score > baseline or added or removed):
             print("\n  Phase 4: Weight Optimization on best feature set")
-            print(f"  {'-'*50}")
+            print(f"  {'-' * 50}")
 
             profile = pos_profile[best_features].copy()
             for col in profile.columns:

--- a/src/sportstradamus/scripts/evaluate_model_features.py
+++ b/src/sportstradamus/scripts/evaluate_model_features.py
@@ -210,9 +210,9 @@ def print_market_report(league: str, market: str, result: dict, drop_threshold: 
     adds = result["add_candidates"]
 
     model_tag = "[model]" if has_model else "[no model]"
-    print(f"\n{'='*70}")
+    print(f"\n{'=' * 70}")
     print(f"  {league}  {market}  {model_tag}  (n={n_train:,})")
-    print(f"{'='*70}")
+    print(f"{'=' * 70}")
 
     # Current features table
     hdr = f"  {'Feature':<45s} {'Score':>6s}"
@@ -386,9 +386,9 @@ def main():
     # ── Save ──
     if args.save:
         if changes:
-            print(f"\n{'='*70}")
+            print(f"\n{'=' * 70}")
             print("SAVING changes to feature_filter.json")
-            print(f"{'='*70}")
+            print(f"{'=' * 70}")
             for market, ch in changes.items():
                 print(f"  {args.league}/{market}:")
                 for f in ch["removed"]:

--- a/src/sportstradamus/scripts/generate_ship_config.py
+++ b/src/sportstradamus/scripts/generate_ship_config.py
@@ -142,8 +142,7 @@ def main(branch, prune, meta, model_stats, live_metrics, dry_run) -> None:
             for league, market, old, new in changes:
                 click.echo(f"  {league}/{market}: shipped {old} -> {new}")
             click.echo(
-                f"# branch=main: {len(changes)} shipping changes "
-                f"(graduated={len(graduated)} cells)"
+                f"# branch=main: {len(changes)} shipping changes (graduated={len(graduated)} cells)"
             )
         if not dry_run and changes:
             _write_meta(meta_path, meta_map)
@@ -153,12 +152,8 @@ def main(branch, prune, meta, model_stats, live_metrics, dry_run) -> None:
     else:
         # branch == "devel": validate + summarize.
         config = load_ship_config(branch="devel", path=meta_path)
-        n_active = sum(
-            1 for lg in config for mk in config[lg] if config[lg][mk] != WITHHELD
-        )
-        n_withheld = sum(
-            1 for lg in config for mk in config[lg] if config[lg][mk] == WITHHELD
-        )
+        n_active = sum(1 for lg in config for mk in config[lg] if config[lg][mk] != WITHHELD)
+        n_withheld = sum(1 for lg in config for mk in config[lg] if config[lg][mk] == WITHHELD)
         click.echo(
             f"# branch=devel: active={n_active} withheld={n_withheld} "
             f"(stat_meta.json validated; no mutation)"

--- a/src/sportstradamus/scripts/model_calibration/test_model_weight.py
+++ b/src/sportstradamus/scripts/model_calibration/test_model_weight.py
@@ -513,9 +513,9 @@ def main():
     }
 
     for league, market in markets:
-        print(f"\n{'='*70}")
+        print(f"\n{'=' * 70}")
         print(f" {league} {market}")
-        print(f"{'='*70}")
+        print(f"{'=' * 70}")
 
         try:
             data = load_market(league, market)
@@ -530,15 +530,15 @@ def main():
         )
         if data["alpha"] is not None:
             print(
-                f"  mean_model_alpha={data['alpha'].mean():.2f}, book_alpha={1/data['cv']**2:.2f}"
+                f"  mean_model_alpha={data['alpha'].mean():.2f}, book_alpha={1 / data['cv'] ** 2:.2f}"
             )
         if data["r"] is not None:
-            print(f"  mean_model_r={data['r'].mean():.2f}, book_r={1/data['cv']:.2f}")
+            print(f"  mean_model_r={data['r'].mean():.2f}, book_r={1 / data['cv']:.2f}")
 
         # --- CURRENT PIPELINE: blend first, then dispersion cal ---
         print("\n  === CURRENT: blend → dispersion_cal ===")
         print(f"  {'Objective':<20} {'Opt w':>8}  {'Acc@opt':>8}  {'Cov@opt':>8}")
-        print(f"  {'-'*50}")
+        print(f"  {'-' * 50}")
         for name, fn in objectives.items():
             try:
                 w_opt = optimize_weight(data, fn, name)
@@ -558,7 +558,7 @@ def main():
             if data_dc["r"] is not None:
                 print(f"  corrected_r={data_dc['r'].mean():.2f} (was {data['r'].mean():.2f})")
             print(f"  {'Objective':<20} {'Opt w':>8}  {'Acc@opt':>8}  {'Cov@opt':>8}")
-            print(f"  {'-'*50}")
+            print(f"  {'-' * 50}")
             for name, fn in objectives.items():
                 try:
                     w_opt = optimize_weight(data_dc, fn, name)

--- a/src/sportstradamus/scripts/optimize_comp_weights.py
+++ b/src/sportstradamus/scripts/optimize_comp_weights.py
@@ -524,9 +524,7 @@ def prepare_nfl(stats_obj, features_by_pos, target_markets_by_pos, validation_cu
         # power-back RBs (e.g. rec_adv_YPRR with no routes run) mean "no
         # receiving role", not "missing data". dropna() here would drop those
         # rows and starve the RB block below the min-count threshold.
-        positionProfile = (
-            positionProfile[features].replace([np.nan, np.inf, -np.inf], 0).fillna(0)
-        )
+        positionProfile = positionProfile[features].replace([np.nan, np.inf, -np.inf], 0).fillna(0)
 
         if len(positionProfile) < 10:
             continue
@@ -999,7 +997,7 @@ def main():
         print("COMPOSITE SCORE SUMMARY")
         print("=" * 60)
         print(f"  {'Group':<15s}  {'Current':>10s}  {'Optimized':>10s}  {'Change':>10s}")
-        print(f"  {'-'*15}  {'-'*10}  {'-'*10}  {'-'*10}")
+        print(f"  {'-' * 15}  {'-' * 10}  {'-' * 10}  {'-' * 10}")
         for group, (cur, opt) in sorted(score_report.items()):
             delta = opt - cur
             print(f"  {group:<15s}  {cur:>10.5f}  {opt:>10.5f}  {delta:>+10.5f}")

--- a/src/sportstradamus/scripts/plot_parlay_hist.py
+++ b/src/sportstradamus/scripts/plot_parlay_hist.py
@@ -121,7 +121,7 @@ def reflect():
 
                     if result.empty or result.iat[0] == line:
                         legs -= 1
-                    elif result.iat[0] < line and over or result.iat[0] > line and not over:
+                    elif (result.iat[0] < line and over) or (result.iat[0] > line and not over):
                         misses += 1
 
             return legs, misses
@@ -132,13 +132,15 @@ def reflect():
     parlays.dropna(subset=["Legs"], inplace=True)
     parlays[["Legs", "Misses"]] = parlays[["Legs", "Misses"]].astype(int)
     parlays["Profit"] = parlays.apply(
-        lambda x: np.clip(
-            payout_table[x.Platform][x.Legs][x.Misses]
-            * (x.Boost if x.Boost < 2 or x.Misses == 0 else 1),
-            None,
-            100,
-        )
-        - 1,
+        lambda x: (
+            np.clip(
+                payout_table[x.Platform][x.Legs][x.Misses]
+                * (x.Boost if x.Boost < 2 or x.Misses == 0 else 1),
+                None,
+                100,
+            )
+            - 1
+        ),
         axis=1,
     )
 

--- a/src/sportstradamus/scripts/test_comp_factors.py
+++ b/src/sportstradamus/scripts/test_comp_factors.py
@@ -45,9 +45,9 @@ for position in ["QB", "RB", "WR", "TE"]:
         )
         playerFolder = pkg_resources.files(data) / f"player_data/NFL/{year}"
         if os.path.exists(playerFolder):
-            for file in os.listdir(playerFolder):
-                if file.endswith(".csv"):
-                    df = pd.read_csv(playerFolder / file)
+            for file in playerFolder.iterdir():
+                if file.name.endswith(".csv"):
+                    df = pd.read_csv(file)
                     df.index = df.player_id
                     playerProfile = playerProfile.combine_first(df)
 

--- a/src/sportstradamus/scripts/test_distributions.py
+++ b/src/sportstradamus/scripts/test_distributions.py
@@ -231,7 +231,7 @@ def compute_metrics(ev, y_true, lines, sigma_or_shape, dist_type, gate=None):
         results["over_pct"] = float("nan")
 
     results["n_confident"] = int(conf_mask.sum())
-    results["n_total"] = int(len(y_true))
+    results["n_total"] = len(y_true)
 
     return results
 
@@ -458,7 +458,7 @@ def main():
         print(f"  {market_name}  (current dist: {cfg['dist']})")
         print(f"{'=' * 60}")
 
-        X_train, X_val, X_test, y_train, y_val, y_test, meta_val, meta_test = load_market(
+        X_train, X_val, X_test, y_train, y_val, y_test, _meta_val, meta_test = load_market(
             cfg["file"], cfg["zi"], cfg["continuous"]
         )
 

--- a/src/sportstradamus/stats/nba.py
+++ b/src/sportstradamus/stats/nba.py
@@ -535,10 +535,12 @@ class StatsNBA(Stats):
             bad_pos = ~self.gamelog[pos_col].apply(lambda x: isinstance(x, str))
             if bad_pos.any():
                 self.gamelog.loc[bad_pos, pos_col] = self.gamelog.loc[bad_pos].apply(
-                    lambda x: self.players.get(x.SEASON_YEAR, {})
-                    .get(x.TEAM_ABBREVIATION, {})
-                    .get(x.PLAYER_NAME, {})
-                    .get("POS"),
+                    lambda x: (
+                        self.players.get(x.SEASON_YEAR, {})
+                        .get(x.TEAM_ABBREVIATION, {})
+                        .get(x.PLAYER_NAME, {})
+                        .get("POS")
+                    ),
                     axis=1,
                 )
 
@@ -1326,10 +1328,12 @@ class StatsNBA(Stats):
                 axis=1,
             )
             self.gamelog.loc[:, self.log_strings["position"]] = self.gamelog.apply(
-                lambda x: self.players.get(x.SEASON_YEAR, {})
-                .get(x.TEAM_ABBREVIATION, {})
-                .get(x.PLAYER_NAME, {})
-                .get("POS", x.POS),
+                lambda x: (
+                    self.players.get(x.SEASON_YEAR, {})
+                    .get(x.TEAM_ABBREVIATION, {})
+                    .get(x.PLAYER_NAME, {})
+                    .get("POS", x.POS)
+                ),
                 axis=1,
             )
 

--- a/src/sportstradamus/stats/nfl.py
+++ b/src/sportstradamus/stats/nfl.py
@@ -712,17 +712,21 @@ class StatsNFL(Stats):
         six_years_ago = datetime.today().date() - timedelta(days=_GAMELOG_RETENTION_DAYS)
         self.gamelog = self.gamelog[
             self.gamelog["gameday"].apply(
-                lambda x: six_years_ago
-                <= datetime.strptime(x, "%Y-%m-%d").date()
-                <= datetime.today().date()
+                lambda x: (
+                    six_years_ago
+                    <= datetime.strptime(x, "%Y-%m-%d").date()
+                    <= datetime.today().date()
+                )
             )
         ]
         self.gamelog = self.gamelog[~self.gamelog["opponent"].isin(["AFC", "NFC"])]
         self.teamlog = self.teamlog[
             self.teamlog["gameday"].apply(
-                lambda x: six_years_ago
-                <= datetime.strptime(x, "%Y-%m-%d").date()
-                <= datetime.today().date()
+                lambda x: (
+                    six_years_ago
+                    <= datetime.strptime(x, "%Y-%m-%d").date()
+                    <= datetime.today().date()
+                )
             )
         ]
         self.gamelog.drop_duplicates(inplace=True)

--- a/src/sportstradamus/stats/nfl_fp_loader.py
+++ b/src/sportstradamus/stats/nfl_fp_loader.py
@@ -66,9 +66,7 @@ _TEAM_COVERAGE_PREFIX = "tm_cov_off_"
 
 # FP CSV "key" columns that must NOT be prefixed -- they're either join
 # keys or filterable identifiers shared across files.
-_FP_KEY_COLUMNS: frozenset[str] = frozenset(
-    {"Name", "Team", "POS", "G", "Season", "Rank"}
-)
+_FP_KEY_COLUMNS: frozenset[str] = frozenset({"Name", "Team", "POS", "G", "Season", "Rank"})
 
 # coverageMatrixOffense uses full team names (``Cleveland Browns``);
 # every other FP per-player file uses an abbreviation that does NOT match
@@ -261,9 +259,7 @@ def derive_comp_metrics(profile: pd.DataFrame) -> pd.DataFrame:
     # WIN_RATE column for some bins, so SEP SCORE is the only metric
     # guaranteed across every route. The per-route mean uses every
     # ``SEP SCORE`` column (canonicalized + auto-suffixed).
-    route_sep_cols = [
-        c for c in profile.columns if c.startswith("rec_sep_route_SEP_SCORE")
-    ]
+    route_sep_cols = [c for c in profile.columns if c.startswith("rec_sep_route_SEP_SCORE")]
     qb_man = profile.get("qb_cov_QB_MAN_pct")
     tm_man = profile.get("tm_cov_off_MAN_pct")
     rush_success = profile.get("rush_adv_Success_pct")
@@ -392,9 +388,7 @@ def apply_rolling_transforms(
     for feature in features:
         if feature not in out.columns:
             continue
-        out[feature] = grouped[feature].transform(
-            lambda s: s.rolling(window, min_periods=1).mean()
-        )
+        out[feature] = grouped[feature].transform(lambda s: s.rolling(window, min_periods=1).mean())
     return out
 
 
@@ -408,9 +402,7 @@ def _join_nfl_players(profile: pd.DataFrame) -> pd.DataFrame:
 
     nfl_players = nfl_players.loc[nfl_players["position"].isin(_COMP_POSITIONS)]
     nfl_players.index = nfl_players["name"].apply(remove_accents)
-    nfl_players["bmi"] = (
-        nfl_players["weight"] / nfl_players["height"] / nfl_players["height"]
-    )
+    nfl_players["bmi"] = nfl_players["weight"] / nfl_players["height"] / nfl_players["height"]
     nfl_players = nfl_players[["age", "height", "bmi"]].dropna()
     nfl_players = nfl_players[~nfl_players.index.duplicated(keep="last")]
     return profile.join(nfl_players, how="left")
@@ -476,9 +468,7 @@ def _load_qb_coverage_file(fp_dir: object) -> pd.DataFrame | None:
     # Drop ``G`` / ``Season`` / ``Rank`` -- the per-player FP files already
     # carry these as join-key columns, and re-emitting them under the
     # qb-coverage frame would force ``G_x`` / ``G_y`` splits at combine.
-    grouped = grouped.drop(
-        columns=[c for c in ("G", "Season", "Rank") if c in grouped.columns]
-    )
+    grouped = grouped.drop(columns=[c for c in ("G", "Season", "Rank") if c in grouped.columns])
     grouped = _prefix_columns(grouped.reset_index(), _QB_COVERAGE_PREFIX)
     grouped.index = grouped["Name"].apply(remove_accents)
     grouped.index.name = None
@@ -512,16 +502,12 @@ def _load_team_coverage_file(fp_dir: object) -> pd.DataFrame | None:
     return df
 
 
-def _broadcast_team_columns(
-    per_year: pd.DataFrame, team_cov: pd.DataFrame
-) -> pd.DataFrame:
+def _broadcast_team_columns(per_year: pd.DataFrame, team_cov: pd.DataFrame) -> pd.DataFrame:
     """Broadcast team-grain coverage columns to every player on that team."""
     if "Team" not in per_year.columns:
         return per_year
 
-    joined = per_year.merge(
-        team_cov, how="left", left_on="Team", right_index=True
-    )
+    joined = per_year.merge(team_cov, how="left", left_on="Team", right_index=True)
     joined.index = per_year.index
     return joined
 
@@ -542,9 +528,7 @@ def _load_pbp_named_by_player(year: int) -> pd.DataFrame | None:
         logger.warning("import_ids() failed: %s", exc)
         return None
 
-    ids = ids.loc[
-        ids["position"].isin(_COMP_POSITIONS), ["name", "gsis_id"]
-    ].copy()
+    ids = ids.loc[ids["position"].isin(_COMP_POSITIONS), ["name", "gsis_id"]].copy()
     ids = ids.dropna(subset=["gsis_id"])
     ids["key"] = ids["name"].apply(remove_accents)
     # Multiple historical players can share a normalized name; mirror the

--- a/src/sportstradamus/strategies/_pickem_emit.py
+++ b/src/sportstradamus/strategies/_pickem_emit.py
@@ -93,6 +93,5 @@ def _lazy_import(name: str) -> Any:
         return __import__(name)
     except ImportError as exc:
         raise ImportError(
-            f"`{name}` is required for pickem-build. Install with "
-            f"`poetry install --with strategy`."
+            f"`{name}` is required for pickem-build. Install with `poetry install --with strategy`."
         ) from exc

--- a/src/sportstradamus/strategies/profit_sim.py
+++ b/src/sportstradamus/strategies/profit_sim.py
@@ -189,10 +189,12 @@ def extract_sim_returns(sim_df: pd.DataFrame, initial_bankroll: float) -> np.nda
     if sim_df.empty:
         return np.array([], dtype=float)
     series = sim_df.groupby("run", group_keys=False)[["daily_pnl", "bankroll"]].apply(
-        lambda x: x["daily_pnl"].values
-        / np.maximum(
-            x["bankroll"].shift(1).fillna(initial_bankroll).values,
-            1,
+        lambda x: (
+            x["daily_pnl"].values
+            / np.maximum(
+                x["bankroll"].shift(1).fillna(initial_bankroll).values,
+                1,
+            )
         )
     )
     return np.concatenate(series.values)
@@ -232,8 +234,10 @@ def summarize_runs(result: pd.DataFrame, initial_bankroll: float) -> dict[str, f
     max_drawdown = float(np.mean(drawdowns)) if drawdowns else 0.0
 
     daily_returns = result.groupby("run", group_keys=False)[["daily_pnl", "bankroll"]].apply(
-        lambda x: x["daily_pnl"].values
-        / np.maximum(x["bankroll"].shift(1).fillna(initial_bankroll).values, 1)
+        lambda x: (
+            x["daily_pnl"].values
+            / np.maximum(x["bankroll"].shift(1).fillna(initial_bankroll).values, 1)
+        )
     )
     all_returns = np.concatenate(daily_returns.values)
     sharpe = float(np.mean(all_returns) / np.std(all_returns)) if np.std(all_returns) > 0 else 0.0

--- a/src/sportstradamus/training/config.py
+++ b/src/sportstradamus/training/config.py
@@ -82,7 +82,9 @@ def save_zi_config(config: dict) -> None:
     cal = _load(_STAT_CAL_PATH)
     for league, markets in config.items():
         for market, zi in markets.items():
-            cell = cal.setdefault(league, {}).setdefault(market, {"cv": 1.0, "std": None, "zi": None})
+            cell = cal.setdefault(league, {}).setdefault(
+                market, {"cv": 1.0, "std": None, "zi": None}
+            )
             cell["zi"] = zi
     _write(_STAT_CAL_PATH, cal)
 
@@ -96,10 +98,14 @@ def save_cv_std_config(cv_config: dict, std_config: dict) -> None:
     cal = _load(_STAT_CAL_PATH)
     for league, markets in cv_config.items():
         for market, cv in markets.items():
-            cell = cal.setdefault(league, {}).setdefault(market, {"cv": 1.0, "std": None, "zi": None})
+            cell = cal.setdefault(league, {}).setdefault(
+                market, {"cv": 1.0, "std": None, "zi": None}
+            )
             cell["cv"] = cv
     for league, markets in std_config.items():
         for market, std in markets.items():
-            cell = cal.setdefault(league, {}).setdefault(market, {"cv": 1.0, "std": None, "zi": None})
+            cell = cal.setdefault(league, {}).setdefault(
+                market, {"cv": 1.0, "std": None, "zi": None}
+            )
             cell["std"] = std
     _write(_STAT_CAL_PATH, cal)

--- a/src/sportstradamus/training/report.py
+++ b/src/sportstradamus/training/report.py
@@ -73,10 +73,10 @@ def report() -> None:
             _cal = json.load(f)
     else:
         _cal = {}
-    stat_cv = {lg: {m: cell.get("cv", 1.0) for m, cell in mkts.items()} for lg, mkts in _cal.items()}
-    stat_std = {
-        lg: {m: cell.get("std") for m, cell in mkts.items()} for lg, mkts in _cal.items()
+    stat_cv = {
+        lg: {m: cell.get("cv", 1.0) for m, cell in mkts.items()} for lg, mkts in _cal.items()
     }
+    stat_std = {lg: {m: cell.get("std") for m, cell in mkts.items()} for lg, mkts in _cal.items()}
 
     with open(pkg_resources.files(data) / "training" / "training_report.txt", "w") as f:
         league_models = {}

--- a/src/sportstradamus/training/ship_config.py
+++ b/src/sportstradamus/training/ship_config.py
@@ -111,9 +111,7 @@ def _validate_cell(league: str, market: str, cell: dict) -> None:
         )
 
 
-def load_ship_config(
-    branch: str = "devel", path: Path | None = None
-) -> ShipConfig:
+def load_ship_config(branch: str = "devel", path: Path | None = None) -> ShipConfig:
     """Project ``stat_meta.json`` into the legacy ship-config shape.
 
     Args:
@@ -137,9 +135,7 @@ def load_ship_config(
             :func:`_validate_cell`).
     """
     if branch not in _ALLOWED_FOR_BRANCH:
-        raise ValueError(
-            f"Unknown branch {branch!r}; valid: {sorted(_ALLOWED_FOR_BRANCH)}"
-        )
+        raise ValueError(f"Unknown branch {branch!r}; valid: {sorted(_ALLOWED_FOR_BRANCH)}")
     path = Path(str(STAT_META_PATH)) if path is None else Path(path)
     meta = _load_stat_meta(path)
     allowed = _ALLOWED_FOR_BRANCH[branch]

--- a/tests/golden/test_archive_wal_recovery.py
+++ b/tests/golden/test_archive_wal_recovery.py
@@ -93,16 +93,16 @@ def test_archive_recovers_from_stale_wal(tmp_path, monkeypatch):
             archive = Archive()
 
         recovery_warnings = [w for w in caught if "Discarded stale DuckDB WAL" in str(w.message)]
-        assert (
-            len(recovery_warnings) == 1
-        ), f"expected exactly one recovery warning, got {[str(w.message) for w in caught]}"
+        assert len(recovery_warnings) == 1, (
+            f"expected exactly one recovery warning, got {[str(w.message) for w in caught]}"
+        )
 
         quarantined = [
             p for p in tmp_path.iterdir() if p.name.startswith("archive.duckdb.wal.corrupt-")
         ]
-        assert (
-            len(quarantined) == 1
-        ), f"expected one quarantined WAL, got {sorted(p.name for p in tmp_path.iterdir())}"
+        assert len(quarantined) == 1, (
+            f"expected one quarantined WAL, got {sorted(p.name for p in tmp_path.iterdir())}"
+        )
 
         assert archive._connection.execute("SELECT COUNT(*) FROM odds").fetchone() == (0,)
     finally:

--- a/tests/golden/test_archive_wal_recovery.py
+++ b/tests/golden/test_archive_wal_recovery.py
@@ -42,14 +42,14 @@ def _build_corrupt_wal(tmp_path: Path) -> Path:
         "entity TEXT, book TEXT, ev DOUBLE, sample_ts TIMESTAMP)"
     )
     con.execute(
-        "CREATE TABLE lines (league TEXT, market TEXT, game_date DATE, " "entity TEXT, line DOUBLE)"
+        "CREATE TABLE lines (league TEXT, market TEXT, game_date DATE, entity TEXT, line DOUBLE)"
     )
     con.execute("CHECKPOINT")
     con.close()
 
     victim_script = (
         "import duckdb, os\n"
-        f'con = duckdb.connect({str(tmp_path / "victim.duckdb")!r})\n'
+        f"con = duckdb.connect({str(tmp_path / 'victim.duckdb')!r})\n"
         'con.execute("CREATE TABLE odds (league TEXT, market TEXT, '
         "game_date DATE, entity TEXT, book TEXT, ev DOUBLE, "
         'sample_ts TIMESTAMP)")\n'
@@ -93,16 +93,16 @@ def test_archive_recovers_from_stale_wal(tmp_path, monkeypatch):
             archive = Archive()
 
         recovery_warnings = [w for w in caught if "Discarded stale DuckDB WAL" in str(w.message)]
-        assert (
-            len(recovery_warnings) == 1
-        ), f"expected exactly one recovery warning, got {[str(w.message) for w in caught]}"
+        assert len(recovery_warnings) == 1, (
+            f"expected exactly one recovery warning, got {[str(w.message) for w in caught]}"
+        )
 
         quarantined = [
             p for p in tmp_path.iterdir() if p.name.startswith("archive.duckdb.wal.corrupt-")
         ]
-        assert (
-            len(quarantined) == 1
-        ), f"expected one quarantined WAL, got {sorted(p.name for p in tmp_path.iterdir())}"
+        assert len(quarantined) == 1, (
+            f"expected one quarantined WAL, got {sorted(p.name for p in tmp_path.iterdir())}"
+        )
 
         assert archive._connection.execute("SELECT COUNT(*) FROM odds").fetchone() == (0,)
     finally:

--- a/tests/golden/test_archive_wal_recovery.py
+++ b/tests/golden/test_archive_wal_recovery.py
@@ -93,16 +93,16 @@ def test_archive_recovers_from_stale_wal(tmp_path, monkeypatch):
             archive = Archive()
 
         recovery_warnings = [w for w in caught if "Discarded stale DuckDB WAL" in str(w.message)]
-        assert len(recovery_warnings) == 1, (
-            f"expected exactly one recovery warning, got {[str(w.message) for w in caught]}"
-        )
+        assert (
+            len(recovery_warnings) == 1
+        ), f"expected exactly one recovery warning, got {[str(w.message) for w in caught]}"
 
         quarantined = [
             p for p in tmp_path.iterdir() if p.name.startswith("archive.duckdb.wal.corrupt-")
         ]
-        assert len(quarantined) == 1, (
-            f"expected one quarantined WAL, got {sorted(p.name for p in tmp_path.iterdir())}"
-        )
+        assert (
+            len(quarantined) == 1
+        ), f"expected one quarantined WAL, got {sorted(p.name for p in tmp_path.iterdir())}"
 
         assert archive._connection.execute("SELECT COUNT(*) FROM odds").fetchone() == (0,)
     finally:

--- a/tests/golden/test_compression_eval.py
+++ b/tests/golden/test_compression_eval.py
@@ -174,7 +174,7 @@ def test_gate1_ci_below_zero_when_model_beats_book():
     y = (rng.uniform(size=4000) < 0.5).astype(float)
     p_model = np.where(y == 1, 0.9, 0.1)  # close to truth
     p_book = np.full_like(y, 0.5)  # near-random
-    mean, lo, hi = _gate1_brier_ci(p_model, p_book, y, rng)
+    mean, _lo, hi = _gate1_brier_ci(p_model, p_book, y, rng)
     assert mean < 0  # model Brier lower than book
     assert hi < 0  # 95% CI entirely below 0
 
@@ -184,7 +184,7 @@ def test_gate1_ci_above_zero_when_book_beats_model():
     y = (rng.uniform(size=4000) < 0.5).astype(float)
     p_model = np.where(y == 1, 0.1, 0.9)  # anti-correlated
     p_book = np.where(y == 1, 0.9, 0.1)  # nails it
-    mean, lo, hi = _gate1_brier_ci(p_model, p_book, y, rng)
+    mean, lo, _hi = _gate1_brier_ci(p_model, p_book, y, rng)
     assert mean > 0
     assert lo > 0  # CI excludes 0 on the book's side
 
@@ -195,7 +195,7 @@ def test_gate1_oracle_equals_negative_book_brier():
     rng = np.random.default_rng(2)
     y = (rng.uniform(size=3000) < 0.5).astype(float)
     p_book = rng.uniform(0.2, 0.8, size=3000)
-    mean, lo, hi = _gate1_brier_ci(y, p_book, y, rng)
+    mean, _lo, hi = _gate1_brier_ci(y, p_book, y, rng)
     assert mean == pytest.approx(-float(np.mean((p_book - y) ** 2)))
     assert hi < 0
 
@@ -211,7 +211,7 @@ def test_gate23_segment_match_z_matches_known_bias():
     mask[:30] = True
     pred = actual.copy()
     pred[:30] += 2.0  # over-predict the segment by a constant +2.0
-    pred_mean, true_mean, abs_diff, sigma, z = _gate23_segment_match(pred, actual, mask)
+    _pred_mean, _true_mean, abs_diff, sigma, z = _gate23_segment_match(pred, actual, mask)
     expected_sigma = float(np.std(actual[:30], ddof=1))
     assert abs_diff == pytest.approx(2.0)
     assert sigma == pytest.approx(expected_sigma)
@@ -1344,7 +1344,7 @@ def test_live_window_cli_smoke_with_mock_stats(monkeypatch):
     monkeypatch.setattr("sportstradamus.scripts.compression_eval.read_history", lambda: history)
     monkeypatch.setattr(
         "sportstradamus.scripts.compression_eval._load_league_stats_lookup",
-        lambda league: (lambda player, market, date: 20.0),
+        lambda league: lambda player, market, date: 20.0,
     )
     runner = CliRunner()
     result = runner.invoke(

--- a/tests/golden/test_correlate.py
+++ b/tests/golden/test_correlate.py
@@ -59,9 +59,9 @@ def test_residualization_breaks_shared_trends() -> None:
     assert valid.sum() >= n_games - ROLLING_WINDOW_GAMES, "too many residuals are NaN"
 
     resid_corr = float(np.corrcoef(a_resid[valid], b_resid[valid])[0, 1])
-    assert abs(resid_corr) < 0.4, (
-        f"residual correlation should be much smaller than raw ({raw_corr:.2f}), got {resid_corr:.2f}"
-    )
+    assert (
+        abs(resid_corr) < 0.4
+    ), f"residual correlation should be much smaller than raw ({raw_corr:.2f}), got {resid_corr:.2f}"
 
 
 def test_low_overlap_pairs_shrink_toward_zero() -> None:

--- a/tests/golden/test_correlate.py
+++ b/tests/golden/test_correlate.py
@@ -59,9 +59,9 @@ def test_residualization_breaks_shared_trends() -> None:
     assert valid.sum() >= n_games - ROLLING_WINDOW_GAMES, "too many residuals are NaN"
 
     resid_corr = float(np.corrcoef(a_resid[valid], b_resid[valid])[0, 1])
-    assert (
-        abs(resid_corr) < 0.4
-    ), f"residual correlation should be much smaller than raw ({raw_corr:.2f}), got {resid_corr:.2f}"
+    assert abs(resid_corr) < 0.4, (
+        f"residual correlation should be much smaller than raw ({raw_corr:.2f}), got {resid_corr:.2f}"
+    )
 
 
 def test_low_overlap_pairs_shrink_toward_zero() -> None:

--- a/tests/golden/test_parlay_search.py
+++ b/tests/golden/test_parlay_search.py
@@ -172,9 +172,9 @@ def test_push_aware_payout_independent_two_leg_power() -> None:
     # No-loss outcomes other than both-win: WIN-PUSH, PUSH-WIN, PUSH-PUSH.
     refund_prob = p_win[0] * p_push[1] + p_push[0] * p_win[1] + p_push[0] * p_push[1]
     expected = 3.0 * p_win[0] * p_win[1] + 1.0 * refund_prob
-    assert ev == pytest.approx(expected, rel=0.02), (
-        f"expected ~{expected:.4f}, got {ev:.4f}; p_lose={p_lose}"
-    )
+    assert ev == pytest.approx(
+        expected, rel=0.02
+    ), f"expected ~{expected:.4f}, got {ev:.4f}; p_lose={p_lose}"
 
 
 def test_push_aware_payout_one_leg_pushes_promotes_to_refund() -> None:

--- a/tests/golden/test_parlay_search.py
+++ b/tests/golden/test_parlay_search.py
@@ -172,9 +172,9 @@ def test_push_aware_payout_independent_two_leg_power() -> None:
     # No-loss outcomes other than both-win: WIN-PUSH, PUSH-WIN, PUSH-PUSH.
     refund_prob = p_win[0] * p_push[1] + p_push[0] * p_win[1] + p_push[0] * p_push[1]
     expected = 3.0 * p_win[0] * p_win[1] + 1.0 * refund_prob
-    assert ev == pytest.approx(
-        expected, rel=0.02
-    ), f"expected ~{expected:.4f}, got {ev:.4f}; p_lose={p_lose}"
+    assert ev == pytest.approx(expected, rel=0.02), (
+        f"expected ~{expected:.4f}, got {ev:.4f}; p_lose={p_lose}"
+    )
 
 
 def test_push_aware_payout_one_leg_pushes_promotes_to_refund() -> None:

--- a/tests/integration/test_centered_target_live_path.py
+++ b/tests/integration/test_centered_target_live_path.py
@@ -119,9 +119,9 @@ def test_centered_additive_skewnormal_decodes_with_finite_alpha_and_no_compressi
         "Model Skew (alpha) must be finite under the centered strategy -- "
         "NaN here is the FGA dead end from OVERCONFIDENCE_INVESTIGATION.md 3.4."
     )
-    assert np.isfinite(decoded["Model Skew"].to_numpy()).all(), (
-        "Model Skew must be finite (no inf) for every row."
-    )
+    assert np.isfinite(
+        decoded["Model Skew"].to_numpy()
+    ).all(), "Model Skew must be finite (no inf) for every row."
 
     # Assertion 2: Model EV matches EB_prior + loc + scale*delta*sqrt(2/pi).
     eb = compute_eb_prior(

--- a/tests/integration/test_centered_target_live_path.py
+++ b/tests/integration/test_centered_target_live_path.py
@@ -119,9 +119,9 @@ def test_centered_additive_skewnormal_decodes_with_finite_alpha_and_no_compressi
         "Model Skew (alpha) must be finite under the centered strategy -- "
         "NaN here is the FGA dead end from OVERCONFIDENCE_INVESTIGATION.md 3.4."
     )
-    assert np.isfinite(
-        decoded["Model Skew"].to_numpy()
-    ).all(), "Model Skew must be finite (no inf) for every row."
+    assert np.isfinite(decoded["Model Skew"].to_numpy()).all(), (
+        "Model Skew must be finite (no inf) for every row."
+    )
 
     # Assertion 2: Model EV matches EB_prior + loc + scale*delta*sqrt(2/pi).
     eb = compute_eb_prior(
@@ -136,7 +136,7 @@ def test_centered_additive_skewnormal_decodes_with_finite_alpha_and_no_compressi
         decoded["Model EV"].to_numpy(),
         expected_ev,
         atol=1e-9,
-        err_msg=("Live decode formula does not match the train-side " "EB-additive transform."),
+        err_msg=("Live decode formula does not match the train-side EB-additive transform."),
     )
 
     # Assertion 3: top-quintile EV not collapsed (anti-amplification guard).

--- a/tests/integration/test_centered_target_live_path.py
+++ b/tests/integration/test_centered_target_live_path.py
@@ -119,9 +119,9 @@ def test_centered_additive_skewnormal_decodes_with_finite_alpha_and_no_compressi
         "Model Skew (alpha) must be finite under the centered strategy -- "
         "NaN here is the FGA dead end from OVERCONFIDENCE_INVESTIGATION.md 3.4."
     )
-    assert np.isfinite(
-        decoded["Model Skew"].to_numpy()
-    ).all(), "Model Skew must be finite (no inf) for every row."
+    assert np.isfinite(decoded["Model Skew"].to_numpy()).all(), (
+        "Model Skew must be finite (no inf) for every row."
+    )
 
     # Assertion 2: Model EV matches EB_prior + loc + scale*delta*sqrt(2/pi).
     eb = compute_eb_prior(

--- a/tests/integration/test_end_to_end.py
+++ b/tests/integration/test_end_to_end.py
@@ -102,16 +102,16 @@ def test_pipeline_smoke(
         archive_obj._connection.execute("SELECT COUNT(*) FROM odds").fetchone()[0]
     )
     assert second_poll_rows > first_poll_rows, (
-        f"second confer poll did not append new rows: " f"{first_poll_rows} -> {second_poll_rows}"
+        f"second confer poll did not append new rows: {first_poll_rows} -> {second_poll_rows}"
     )
 
     sample_player = next(iter(pts_df.index))[1] if not pts_df.empty else None
     if sample_player is not None:
         history = archive_obj.get_ev_history("WNBA", "PTS", "2026-05-08", sample_player)
         if not history.empty:
-            assert history[
-                "observed_at"
-            ].is_monotonic_increasing, "get_ev_history must return rows ordered by observed_at"
+            assert history["observed_at"].is_monotonic_increasing, (
+                "get_ev_history must return rows ordered by observed_at"
+            )
 
     # ----- Phase 2: meditate (CLI invoked; ML stubbed; no writes) -----
     from sportstradamus.training import cli as training_cli
@@ -144,9 +144,9 @@ def test_pipeline_smoke(
 
     result = runner.invoke(meditate, ["--league", "WNBA"], catch_exceptions=False)
     assert result.exit_code == 0, f"meditate failed: {result.output}"
-    assert (
-        ("WNBA", "PTS") in train_market_calls
-    ), f"train_market was not invoked for WNBA:PTS. calls={train_market_calls}"
+    assert ("WNBA", "PTS") in train_market_calls, (
+        f"train_market was not invoked for WNBA:PTS. calls={train_market_calls}"
+    )
 
     # ----- Phase 3: prophecize (CLI invoked; parquet snapshot + scrapers mocked) -----
     from sportstradamus.prediction import cli as prediction_cli
@@ -208,9 +208,9 @@ def test_pipeline_smoke(
     assert captured, "process_offers was never invoked"
     underdog_offers, _ = captured.get("Underdog", (pd.DataFrame(), pd.DataFrame()))
     assert len(underdog_offers) >= 10, f"expected >= 10 offers with EV, got {len(underdog_offers)}"
-    assert (
-        underdog_offers["Model EV"].notna().sum() >= 10
-    ), "fewer than 10 offers had a populated Model EV column"
+    assert underdog_offers["Model EV"].notna().sum() >= 10, (
+        "fewer than 10 offers had a populated Model EV column"
+    )
     parlay_total = sum(len(p) for _, p in captured.values())
     assert parlay_total >= 1, "no parlay candidates were returned"
 

--- a/tests/integration/test_end_to_end.py
+++ b/tests/integration/test_end_to_end.py
@@ -101,17 +101,17 @@ def test_pipeline_smoke(
     second_poll_rows = int(
         archive_obj._connection.execute("SELECT COUNT(*) FROM odds").fetchone()[0]
     )
-    assert second_poll_rows > first_poll_rows, (
-        f"second confer poll did not append new rows: {first_poll_rows} -> {second_poll_rows}"
-    )
+    assert (
+        second_poll_rows > first_poll_rows
+    ), f"second confer poll did not append new rows: {first_poll_rows} -> {second_poll_rows}"
 
     sample_player = next(iter(pts_df.index))[1] if not pts_df.empty else None
     if sample_player is not None:
         history = archive_obj.get_ev_history("WNBA", "PTS", "2026-05-08", sample_player)
         if not history.empty:
-            assert history["observed_at"].is_monotonic_increasing, (
-                "get_ev_history must return rows ordered by observed_at"
-            )
+            assert history[
+                "observed_at"
+            ].is_monotonic_increasing, "get_ev_history must return rows ordered by observed_at"
 
     # ----- Phase 2: meditate (CLI invoked; ML stubbed; no writes) -----
     from sportstradamus.training import cli as training_cli
@@ -144,9 +144,9 @@ def test_pipeline_smoke(
 
     result = runner.invoke(meditate, ["--league", "WNBA"], catch_exceptions=False)
     assert result.exit_code == 0, f"meditate failed: {result.output}"
-    assert ("WNBA", "PTS") in train_market_calls, (
-        f"train_market was not invoked for WNBA:PTS. calls={train_market_calls}"
-    )
+    assert (
+        ("WNBA", "PTS") in train_market_calls
+    ), f"train_market was not invoked for WNBA:PTS. calls={train_market_calls}"
 
     # ----- Phase 3: prophecize (CLI invoked; parquet snapshot + scrapers mocked) -----
     from sportstradamus.prediction import cli as prediction_cli
@@ -208,9 +208,9 @@ def test_pipeline_smoke(
     assert captured, "process_offers was never invoked"
     underdog_offers, _ = captured.get("Underdog", (pd.DataFrame(), pd.DataFrame()))
     assert len(underdog_offers) >= 10, f"expected >= 10 offers with EV, got {len(underdog_offers)}"
-    assert underdog_offers["Model EV"].notna().sum() >= 10, (
-        "fewer than 10 offers had a populated Model EV column"
-    )
+    assert (
+        underdog_offers["Model EV"].notna().sum() >= 10
+    ), "fewer than 10 offers had a populated Model EV column"
     parlay_total = sum(len(p) for _, p in captured.values())
     assert parlay_total >= 1, "no parlay candidates were returned"
 

--- a/tests/integration/test_end_to_end.py
+++ b/tests/integration/test_end_to_end.py
@@ -101,17 +101,17 @@ def test_pipeline_smoke(
     second_poll_rows = int(
         archive_obj._connection.execute("SELECT COUNT(*) FROM odds").fetchone()[0]
     )
-    assert (
-        second_poll_rows > first_poll_rows
-    ), f"second confer poll did not append new rows: {first_poll_rows} -> {second_poll_rows}"
+    assert second_poll_rows > first_poll_rows, (
+        f"second confer poll did not append new rows: {first_poll_rows} -> {second_poll_rows}"
+    )
 
     sample_player = next(iter(pts_df.index))[1] if not pts_df.empty else None
     if sample_player is not None:
         history = archive_obj.get_ev_history("WNBA", "PTS", "2026-05-08", sample_player)
         if not history.empty:
-            assert history[
-                "observed_at"
-            ].is_monotonic_increasing, "get_ev_history must return rows ordered by observed_at"
+            assert history["observed_at"].is_monotonic_increasing, (
+                "get_ev_history must return rows ordered by observed_at"
+            )
 
     # ----- Phase 2: meditate (CLI invoked; ML stubbed; no writes) -----
     from sportstradamus.training import cli as training_cli
@@ -144,9 +144,9 @@ def test_pipeline_smoke(
 
     result = runner.invoke(meditate, ["--league", "WNBA"], catch_exceptions=False)
     assert result.exit_code == 0, f"meditate failed: {result.output}"
-    assert (
-        ("WNBA", "PTS") in train_market_calls
-    ), f"train_market was not invoked for WNBA:PTS. calls={train_market_calls}"
+    assert ("WNBA", "PTS") in train_market_calls, (
+        f"train_market was not invoked for WNBA:PTS. calls={train_market_calls}"
+    )
 
     # ----- Phase 3: prophecize (CLI invoked; parquet snapshot + scrapers mocked) -----
     from sportstradamus.prediction import cli as prediction_cli
@@ -208,9 +208,9 @@ def test_pipeline_smoke(
     assert captured, "process_offers was never invoked"
     underdog_offers, _ = captured.get("Underdog", (pd.DataFrame(), pd.DataFrame()))
     assert len(underdog_offers) >= 10, f"expected >= 10 offers with EV, got {len(underdog_offers)}"
-    assert (
-        underdog_offers["Model EV"].notna().sum() >= 10
-    ), "fewer than 10 offers had a populated Model EV column"
+    assert underdog_offers["Model EV"].notna().sum() >= 10, (
+        "fewer than 10 offers had a populated Model EV column"
+    )
     parlay_total = sum(len(p) for _, p in captured.values())
     assert parlay_total >= 1, "no parlay candidates were returned"
 

--- a/tests/integration/test_pipeline_target_strategy.py
+++ b/tests/integration/test_pipeline_target_strategy.py
@@ -163,6 +163,6 @@ def test_centered_loc_meanyr_correlation_differs_from_ratio_loc():
     # Different correlations to MeanYr is the load-bearing signal — the
     # ratio target builds in division by MeanYr, the centered target does
     # not, so the GBDT learns a structurally different mapping.
-    assert abs(corr_ratio - corr_centered) > 0.05, (
-        f"corr(loc, MeanYr) barely moved: ratio={corr_ratio:.3f}, centered={corr_centered:.3f}"
-    )
+    assert (
+        abs(corr_ratio - corr_centered) > 0.05
+    ), f"corr(loc, MeanYr) barely moved: ratio={corr_ratio:.3f}, centered={corr_centered:.3f}"

--- a/tests/integration/test_pipeline_target_strategy.py
+++ b/tests/integration/test_pipeline_target_strategy.py
@@ -163,6 +163,6 @@ def test_centered_loc_meanyr_correlation_differs_from_ratio_loc():
     # Different correlations to MeanYr is the load-bearing signal — the
     # ratio target builds in division by MeanYr, the centered target does
     # not, so the GBDT learns a structurally different mapping.
-    assert (
-        abs(corr_ratio - corr_centered) > 0.05
-    ), f"corr(loc, MeanYr) barely moved: ratio={corr_ratio:.3f}, centered={corr_centered:.3f}"
+    assert abs(corr_ratio - corr_centered) > 0.05, (
+        f"corr(loc, MeanYr) barely moved: ratio={corr_ratio:.3f}, centered={corr_centered:.3f}"
+    )

--- a/tests/integration/test_pipeline_target_strategy.py
+++ b/tests/integration/test_pipeline_target_strategy.py
@@ -164,5 +164,5 @@ def test_centered_loc_meanyr_correlation_differs_from_ratio_loc():
     # ratio target builds in division by MeanYr, the centered target does
     # not, so the GBDT learns a structurally different mapping.
     assert abs(corr_ratio - corr_centered) > 0.05, (
-        f"corr(loc, MeanYr) barely moved: ratio={corr_ratio:.3f}, " f"centered={corr_centered:.3f}"
+        f"corr(loc, MeanYr) barely moved: ratio={corr_ratio:.3f}, centered={corr_centered:.3f}"
     )

--- a/tests/test_backfill_live_metrics.py
+++ b/tests/test_backfill_live_metrics.py
@@ -112,9 +112,7 @@ def test_backfill_merges_with_existing_parquet(monkeypatch, tmp_path):
 
 
 def test_backfill_empty_history_exits_zero(monkeypatch, tmp_path):
-    monkeypatch.setattr(
-        "sportstradamus.scripts.backfill_live_metrics.read_history", lambda: pd.DataFrame()
-    )
+    monkeypatch.setattr("sportstradamus.scripts.backfill_live_metrics.read_history", pd.DataFrame)
     runner = CliRunner()
     out = tmp_path / "out.parquet"
     result = runner.invoke(main, ["--days", "30", "--output", str(out)])
@@ -123,9 +121,7 @@ def test_backfill_empty_history_exits_zero(monkeypatch, tmp_path):
 
 
 def test_backfill_rejects_step_zero(monkeypatch, tmp_path):
-    monkeypatch.setattr(
-        "sportstradamus.scripts.backfill_live_metrics.read_history", lambda: pd.DataFrame()
-    )
+    monkeypatch.setattr("sportstradamus.scripts.backfill_live_metrics.read_history", pd.DataFrame)
     runner = CliRunner()
     out = tmp_path / "out.parquet"
     result = runner.invoke(main, ["--days", "30", "--step", "0", "--output", str(out)])

--- a/tests/test_hurdle_zinb.py
+++ b/tests/test_hurdle_zinb.py
@@ -71,9 +71,9 @@ def test_hurdle_gate_recovers_true_zero_rate() -> None:
     # ZINB identity reconstruction of P(Y=0)
     reconstructed_pzero = gate + (1 - gate) * nb0
 
-    assert abs(reconstructed_pzero.mean() - 0.35) < 0.10, (
-        f"Reconstructed P(Y=0)={reconstructed_pzero.mean():.3f} deviates >0.10 from 0.35"
-    )
+    assert (
+        abs(reconstructed_pzero.mean() - 0.35) < 0.10
+    ), f"Reconstructed P(Y=0)={reconstructed_pzero.mean():.3f} deviates >0.10 from 0.35"
     # Gate should be well above the ~0.18 the joint ZINB produces.
     assert gate.mean() > 0.20, f"gate.mean()={gate.mean():.3f} unexpectedly low"
 

--- a/tests/test_hurdle_zinb.py
+++ b/tests/test_hurdle_zinb.py
@@ -71,9 +71,9 @@ def test_hurdle_gate_recovers_true_zero_rate() -> None:
     # ZINB identity reconstruction of P(Y=0)
     reconstructed_pzero = gate + (1 - gate) * nb0
 
-    assert (
-        abs(reconstructed_pzero.mean() - 0.35) < 0.10
-    ), f"Reconstructed P(Y=0)={reconstructed_pzero.mean():.3f} deviates >0.10 from 0.35"
+    assert abs(reconstructed_pzero.mean() - 0.35) < 0.10, (
+        f"Reconstructed P(Y=0)={reconstructed_pzero.mean():.3f} deviates >0.10 from 0.35"
+    )
     # Gate should be well above the ~0.18 the joint ZINB produces.
     assert gate.mean() > 0.20, f"gate.mean()={gate.mean():.3f} unexpectedly low"
 


### PR DESCRIPTION
## Summary
- `match_offers` in `prediction/scoring.py` documents that it returns an empty DataFrame "when the market is not in the gamelog or no model file exists", but only the first half was implemented. The model pickle was opened unconditionally, so any market present in the gamelog but missing a trained model file (`NBA_fantasy-points-prizepicks.mdl` in the reported trace) crashes `process_offers` with `FileNotFoundError`.
- Dev passed because the pickle was sitting on the dev host; the production server didn't have it, so the exact same code path blew up there.

## Fix
Check `filepath.is_file()` before opening and return `pd.DataFrame()` when the model isn't on disk — matching the docstring contract.

## Test plan
- [ ] `poetry run prophecize` on prod no longer aborts on the first untrained market; offers for trained markets still score normally.
- [ ] Confirm the previously failing NBA fantasy-points pull now skips silently and Underdog/Sleeper matching completes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LtJGxLKxUuYJxeuRgiuEPc)_