### PR TITLE
Gate 2 precision_over hardening + NBA/FG3M withhold

### DIFF
--- a/docs/gbdt_mean_regression_plan.md
+++ b/docs/gbdt_mean_regression_plan.md
@@ -736,6 +736,49 @@ feature apply, but count-family reasoning does not (treat as Track-A). New refs 
    overfit, and percent-calibration error is worst in low-base-rate groups [48]. Use the
    global affine `y ~ a + b·ŷ` form there; reserve isotonic / per-decile for the
    higher-mean NBA/WNBA count cells. (B1.6 research verdict, 2026-05-22.)
+10. **Training and live `predicted_over_rate` / `empirical_over_rate` are not the same
+    quantity — never compare them directly to diagnose model drift.** Training computes
+    `(P > 0.5).mean()` and `(Result >= Line).mean()` over **all** validation rows;
+    live computes `(Bet == "Over").mean()` and `(Result == "Over").mean()` over **only
+    the Sleeper/Underdog offers that survived publication filtering** (`Boost ≤ 3.65`,
+    `head(3)` per player by Distance). On NBA/FG3M 2026-05-24 this produced a fake 28pp
+    "drift" signal that was 90% a measurement artifact + 9pp the `>=` vs `>` push
+    convention asymmetry. The like-for-like metric is `Bet=Over hit rate` (= training
+    `precision_over` ↔ live `precision_over_live`, added 2026-05-24); compare those.
+    See `/tmp/researcher_fg3m_calibration_divergence.md` and
+    `nightly._side_precision` / `graduation.MIN_PRECISION_OVER`.
+
+## Open follow-ups from the 2026-05-24 FG3M-calibration researcher brief
+
+Cited file: `/tmp/researcher_fg3m_calibration_divergence.md`. None of these are
+shipping critical paths yet — they're tracked here so they don't drop.
+
+1. **Align push convention across pipelines.** `pipeline.py:1451` builds
+   `y_class_val = (Result >= Line)`; live `analysis.py:296` uses strict `>` and
+   labels equality as `Push`. On integer-line markets this inflates training
+   `empirical_over_rate` ~9pp and can flip the perceived sign of model bias.
+   Fix: switch training to strict `>` and account for pushes as a 3-class
+   outcome (or carry a `Push` column the loss treats as half-Brier). Affects
+   `_step_calibrate_temperature` and `_compute_metrics`.
+2. **Add publication-filtered `Bet=Over` rate to training metrics.** Today
+   training reports `predicted_over_rate = (P > 0.5).mean()` over every validation
+   row, but live reports `(Bet == "Over").mean()` over only the published Sleeper/UD
+   offers (`prediction/model_prob.py:519-524`). The right offline analogue is to
+   apply the same filter against validation rows that have a Sleeper/UD line in
+   the Archive, then report `Bet=Over` rate on that subset. ~1-day change in
+   `_step_compute_metrics`; would have caught the FG3M pseudo-drift offline.
+3. **Re-run HurdleZINB pickup for FTM, BLK, OREB.** The 2026-05 hurdle ship
+   skipped these on the old gate set; the brief shows they still exhibit the
+   joint-ZINB under-fit signature in **both** training and live data (FTM
+   training pred 0.10 vs empirical 0.41; BLK pred 0.09 vs empirical 0.34; OREB
+   similar). Lever is `--zinb-mode=hurdle` (per `p2_hurdle_zinb_verdict.md`);
+   re-evaluate against the new gates.
+4. **Sleeper Under-boost asymmetry investigation.** `prediction/cli.py:155-157`
+   computes Sleeper's Under-side boost as `1.78² / over_boost`, which on a 3×
+   Over-boosted line yields an Under boost of ~1.06 — never recommendable. This
+   structurally biases FG3M / BLK / OREB recommendations to Over regardless of
+   what the model thinks. Decide: accept (correct payout math), or build a
+   platform-aware EV threshold that handles asymmetric two-sided markets.
 
 ## Critical files
 

--- a/src/sportstradamus/data/config/stat_meta.json
+++ b/src/sportstradamus/data/config/stat_meta.json
@@ -149,7 +149,7 @@
         },
         "FG3M": {
             "dist": "ZINB",
-            "shipped": "devel",
+            "shipped": "withheld",
             "strategy": "none"
         },
         "FGA": {

--- a/src/sportstradamus/nightly.py
+++ b/src/sportstradamus/nightly.py
@@ -64,14 +64,26 @@ LIVE_METRICS_COLUMNS = (
     "book_bss",
     "empirical_over_rate",
     "predicted_over_rate",
+    "precision_over_live",
+    "precision_under_live",
     "top_decile_mae",
     "profit_sim_yield",
+    "profit_sim_kelly_yield",
 )
 # Minimum offers needed in a window before _top_decile_mae returns a value;
 # below this, the top decile would be a single row and the metric is noise.
 _TOP_DECILE_MIN_OFFERS = 10
+# Minimum bets-on-a-side needed before precision_{over,under}_live is reported.
+# Below 30, the conditional hit rate is dominated by sampling noise (~9pp se).
+# This is the per-side analogue of MIN_SETTLED_FOR_GRADUATION (which is the
+# whole-cell threshold used by graduation.py).
+_MIN_BETS_FOR_PRECISION = 30
 # Clip bookmaker probabilities to avoid divide-by-zero in fair-odds payouts.
 _BOOKS_P_CLIP = 1e-3
+# Phase 4 live ship-gate (set-baseline -> main): Kelly stake fraction cap, mirroring
+# the offline S3 sim's 5% per-bet ceiling. The live ROI is the dollar-weighted
+# realized return on the staked dollars within the rolling window.
+_KELLY_LIVE_CAP_FRAC: float = 0.05
 
 
 def _empty_live_metrics_frame() -> pd.DataFrame:
@@ -86,10 +98,28 @@ def _empty_live_metrics_frame() -> pd.DataFrame:
             "book_bss": pd.Series(dtype="float64"),
             "empirical_over_rate": pd.Series(dtype="float64"),
             "predicted_over_rate": pd.Series(dtype="float64"),
+            "precision_over_live": pd.Series(dtype="float64"),
+            "precision_under_live": pd.Series(dtype="float64"),
             "top_decile_mae": pd.Series(dtype="float64"),
             "profit_sim_yield": pd.Series(dtype="float64"),
+            "profit_sim_kelly_yield": pd.Series(dtype="float64"),
         }
     )
+
+
+def _side_precision(group: pd.DataFrame, side: str) -> float:
+    """Hit rate among ``Bet == side`` rows (i.e. precision of side recommendations).
+
+    ``side`` is ``"Over"`` or ``"Under"``. Returns NaN when fewer than
+    :data:`_MIN_BETS_FOR_PRECISION` rows recommended that side — the conditional
+    hit rate is too noisy at small n to gate a graduation decision.
+    """
+    side_mask = (group["Bet"] == side).to_numpy()
+    n_side = int(side_mask.sum())
+    if n_side < _MIN_BETS_FOR_PRECISION:
+        return float("nan")
+    side_hits = ((group["Bet"] == side) & (group["Result"] == side)).sum()
+    return float(side_hits / n_side)
 
 
 def _top_decile_mae(group: pd.DataFrame) -> float:
@@ -129,7 +159,38 @@ def _profit_sim_yield(group: pd.DataFrame) -> float:
     return float((np.sum(payout * hit) - n) / n)
 
 
-def _build_cell_row(cell, group: pd.DataFrame, *, now: pd.Timestamp, window_days: int) -> dict:
+def _profit_sim_kelly_yield(group: pd.DataFrame) -> float:
+    """Kelly-sized realized ROI — Phase 4 set-baseline -> main live gate.
+
+    Per offer: ``decimal_odds = boost / books_p_for_bet_side`` (same convention as
+    :func:`_profit_sim_yield`); Kelly fraction = ``clip((p * d - 1) / (d - 1), 0,
+    0.05)`` where ``p`` is the model's probability on the bet side. ROI is the
+    dollar-weighted realized return — ``sum(stake * (b * hit - (1 - hit))) /
+    sum(stake)`` — so cells with different bet counts are comparable. Returns
+    NaN when no offer attracted a positive Kelly stake (no +EV bets in the
+    window).
+    """
+    n = len(group)
+    if n == 0:
+        return float("nan")
+    books_p = group["Books P"].clip(_BOOKS_P_CLIP, 1 - _BOOKS_P_CLIP).to_numpy()
+    boost = group["Boost"].fillna(1.0).to_numpy()
+    hit = group["Hit"].fillna(0).to_numpy()
+    is_over = (group["Bet"] == "Over").to_numpy()
+    model_p = group["Model P"].clip(_BOOKS_P_CLIP, 1.0 - _BOOKS_P_CLIP).to_numpy()
+    decimal_odds = np.where(is_over, boost / books_p, boost / (1 - books_p))
+    b = decimal_odds - 1.0
+    # b <= 0 ⇒ even-money or worse — Kelly always returns 0; skip those bets.
+    raw_kelly = np.where(b > 0, (model_p * decimal_odds - 1.0) / b, 0.0)
+    stake_frac = np.clip(raw_kelly, 0.0, _KELLY_LIVE_CAP_FRAC)
+    total_stake = float(stake_frac.sum())
+    if total_stake <= 0:
+        return float("nan")
+    pnl = stake_frac * (b * hit - (1.0 - hit))
+    return float(pnl.sum() / total_stake)
+
+
+def _build_cell_row(cell: tuple[str, str], group: pd.DataFrame, *, now: pd.Timestamp, window_days: int) -> dict:
     """Compute one (league, market, window) live-metrics row."""
     n = len(group)
     if n == 0:
@@ -142,8 +203,11 @@ def _build_cell_row(cell, group: pd.DataFrame, *, now: pd.Timestamp, window_days
             "book_bss": float("nan"),
             "empirical_over_rate": float("nan"),
             "predicted_over_rate": float("nan"),
+            "precision_over_live": float("nan"),
+            "precision_under_live": float("nan"),
             "top_decile_mae": float("nan"),
             "profit_sim_yield": float("nan"),
+            "profit_sim_kelly_yield": float("nan"),
         }
     return {
         "league": cell[0],
@@ -154,8 +218,11 @@ def _build_cell_row(cell, group: pd.DataFrame, *, now: pd.Timestamp, window_days
         "book_bss": float(compute_book_brier_skill_score(group)),
         "empirical_over_rate": float((group["Result"] == "Over").mean()),
         "predicted_over_rate": float((group["Bet"] == "Over").mean()),
+        "precision_over_live": _side_precision(group, "Over"),
+        "precision_under_live": _side_precision(group, "Under"),
         "top_decile_mae": _top_decile_mae(group),
         "profit_sim_yield": _profit_sim_yield(group),
+        "profit_sim_kelly_yield": _profit_sim_kelly_yield(group),
     }
 
 
@@ -171,8 +238,11 @@ def _enforce_live_metrics_dtypes(df: pd.DataFrame) -> pd.DataFrame:
         "book_bss",
         "empirical_over_rate",
         "predicted_over_rate",
+        "precision_over_live",
+        "precision_under_live",
         "top_decile_mae",
         "profit_sim_yield",
+        "profit_sim_kelly_yield",
     ):
         df[col] = df[col].astype("float64")
     return df

--- a/src/sportstradamus/nightly.py
+++ b/src/sportstradamus/nightly.py
@@ -190,7 +190,9 @@ def _profit_sim_kelly_yield(group: pd.DataFrame) -> float:
     return float(pnl.sum() / total_stake)
 
 
-def _build_cell_row(cell: tuple[str, str], group: pd.DataFrame, *, now: pd.Timestamp, window_days: int) -> dict:
+def _build_cell_row(
+    cell: tuple[str, str], group: pd.DataFrame, *, now: pd.Timestamp, window_days: int
+) -> dict:
     """Compute one (league, market, window) live-metrics row."""
     n = len(group)
     if n == 0:

--- a/src/sportstradamus/scripts/check_graduation.py
+++ b/src/sportstradamus/scripts/check_graduation.py
@@ -30,7 +30,9 @@ _STATE_COLORS = {
     "demoted": "red",
     "not-shipped": "cyan",
 }
-# Column order used by the printed table. 3 keys + 4 Gate 1 + 4 Gate 2 + 1 state.
+# Column order used by the printed table. 3 keys + 4 Gate 1 + 5 Gate 2 + 1 state.
+# precision_over_live is the new Gate-2 demote driver (see
+# graduation.MIN_PRECISION_OVER); precision_under_live is informational.
 _DISPLAY_COLUMNS = (
     "league",
     "market",
@@ -42,6 +44,8 @@ _DISPLAY_COLUMNS = (
     "gate2_book_bss",
     "predicted_over_rate_live",
     "empirical_over_rate_live",
+    "precision_over_live",
+    "precision_under_live",
     "profit_sim_yield",
     "lifecycle_state",
 )
@@ -57,7 +61,8 @@ def _print_header() -> None:
     click.echo(
         f"{'league':<6} {'market':<22} {'dist':<10} "
         f"{'g1_bss':>7} {'g1_p_or':>7} {'g1_e_or':>7} {'g1_kelly':>8} "
-        f"{'g2_bss':>7} {'g2_p_or':>7} {'g2_e_or':>7} {'g2_yield':>8} "
+        f"{'g2_bss':>7} {'g2_p_or':>7} {'g2_e_or':>7} "
+        f"{'g2_prec_o':>9} {'g2_prec_u':>9} {'g2_yield':>8} "
         f"{'state':<12}"
     )
 
@@ -73,6 +78,8 @@ def _print_row(row: pd.Series) -> None:
         f"{_format_metric(row.get('gate2_book_bss')):>7} "
         f"{_format_metric(row.get('predicted_over_rate_live')):>7} "
         f"{_format_metric(row.get('empirical_over_rate_live')):>7} "
+        f"{_format_metric(row.get('precision_over_live')):>9} "
+        f"{_format_metric(row.get('precision_under_live')):>9} "
         f"{_format_metric(row.get('profit_sim_yield')):>8} "
         f"{row['lifecycle_state']:<12}"
     )

--- a/src/sportstradamus/training/graduation.py
+++ b/src/sportstradamus/training/graduation.py
@@ -27,6 +27,18 @@ import pandas as pd
 MIN_SETTLED_FOR_GRADUATION = 200
 # The 30d window is the canonical graduation gate (7d is too noisy for state).
 GRADUATION_WINDOW_DAYS = 30
+# Demote a cell when the Bet=Over hit rate (precision_over) falls below this.
+# Precision_over = P(Result=Over | Bet=Over) is the like-for-like metric that
+# matches the training pipeline's `precision_over` column — comparing the
+# aggregate `predicted_over_rate` vs `empirical_over_rate` instead conflates
+# publication-selection bias (Sleeper/UD push Over-skewed offers) with real
+# model bias and produces false-positive demotes (see
+# `/tmp/researcher_fg3m_calibration_divergence.md`, 2026-05-24). Below 0.50
+# the model's Over recommendations lose more often than they win, which is a
+# losing strategy at any boost ≤ 2.0×. Live precision_over is NaN when fewer
+# than `_MIN_BETS_FOR_PRECISION` Over bets exist in the window (see
+# `nightly.py`); the check is skipped in that case.
+MIN_PRECISION_OVER = 0.50
 
 
 def _is_nan_like(x: object) -> bool:
@@ -35,17 +47,27 @@ def _is_nan_like(x: object) -> bool:
     return x is None or (isinstance(x, float) and math.isnan(x))
 
 
-def classify_lifecycle(gate1_bss: float, n_settled: float, book_bss_30d: float) -> str:
-    """Map (Gate-1 BSS, n_settled, Gate-2 BSS) to a lifecycle state.
+def classify_lifecycle(
+    gate1_bss: float,
+    n_settled: float,
+    book_bss_30d: float,
+    precision_over_live: float = float("nan"),
+) -> str:
+    """Map (Gate-1 BSS, n_settled, Gate-2 BSS, precision_over) to a lifecycle state.
 
     NaN/negative Gate-1 BSS -> ``not-shipped``; positive Gate-1 BSS but
-    insufficient live data -> ``in-test``; non-negative live BSS ->
-    ``graduated``; negative live BSS -> ``demoted``.
+    insufficient live data -> ``in-test``; negative live BSS or live
+    precision_over below :data:`MIN_PRECISION_OVER` -> ``demoted``;
+    otherwise -> ``graduated``.
 
     Args:
         gate1_bss: Offline calibrated brier-skill-score vs the book baseline.
         n_settled: Settled offer count in the graduation window.
         book_bss_30d: Live 30-day book-relative brier-skill-score.
+        precision_over_live: Live 30d hit rate among ``Bet="Over"`` rows
+            (i.e. P(Result=Over | Bet=Over)). NaN -> precision check skipped
+            (typically because the cell has fewer Over bets than
+            ``nightly._MIN_BETS_FOR_PRECISION``).
 
     Returns:
         One of ``"not-shipped"``, ``"in-test"``, ``"graduated"``, ``"demoted"``.
@@ -60,6 +82,8 @@ def classify_lifecycle(gate1_bss: float, n_settled: float, book_bss_30d: float) 
     if _is_nan_like(book_bss_30d):
         return "in-test"
     if book_bss_30d < 0:
+        return "demoted"
+    if not _is_nan_like(precision_over_live) and precision_over_live < MIN_PRECISION_OVER:
         return "demoted"
     return "graduated"
 
@@ -119,6 +143,8 @@ def read_gate2(path: Path) -> pd.DataFrame:
         "gate2_book_bss",
         "predicted_over_rate_live",
         "empirical_over_rate_live",
+        "precision_over_live",
+        "precision_under_live",
         "profit_sim_yield",
     ]
     if not path.exists():
@@ -132,6 +158,12 @@ def read_gate2(path: Path) -> pd.DataFrame:
             "empirical_over_rate": "empirical_over_rate_live",
         }
     )
+    # Older live_metrics parquets predate the precision_{over,under}_live
+    # columns; default to NaN so classify_lifecycle's precision gate skips
+    # those rows instead of erroring.
+    for missing in ("precision_over_live", "precision_under_live"):
+        if missing not in df.columns:
+            df[missing] = float("nan")
     return df[cols]
 
 
@@ -163,6 +195,7 @@ def lifecycle_table(
             r.get("gate1_bss", float("nan")),
             r.get("n_settled", float("nan")),
             r.get("gate2_book_bss", float("nan")),
+            r.get("precision_over_live", float("nan")),
         ),
         axis=1,
     )

--- a/tests/test_graduation.py
+++ b/tests/test_graduation.py
@@ -9,8 +9,10 @@ import pandas as pd
 import pytest
 
 from sportstradamus.training.graduation import (
+    MIN_PRECISION_OVER,
     classify_lifecycle,
     graduated_cells,
+    lifecycle_table,
     read_gate1,
     read_gate2,
 )
@@ -30,6 +32,35 @@ from sportstradamus.training.graduation import (
 )
 def test_classify_lifecycle(gate1_bss, n_settled, book_bss_30d, expected):
     assert classify_lifecycle(gate1_bss, n_settled, book_bss_30d) == expected
+
+
+@pytest.mark.parametrize(
+    ("precision_over", "expected"),
+    [
+        # Above threshold -> graduated.
+        (0.60, "graduated"),
+        (0.51, "graduated"),
+        # Exactly at threshold is still graduated (strict "<" demote).
+        (MIN_PRECISION_OVER, "graduated"),
+        # Below threshold -> demoted.
+        (MIN_PRECISION_OVER - 1e-6, "demoted"),
+        (0.40, "demoted"),
+        # NaN (too few Over bets to estimate) skips the check -> graduated
+        # since the other gates pass.
+        (math.nan, "graduated"),
+    ],
+)
+def test_classify_lifecycle_precision_over_gate(precision_over, expected):
+    """precision_over-based gate: demote when Bet=Over recommendations lose more than they win."""
+    assert (
+        classify_lifecycle(
+            gate1_bss=0.10,
+            n_settled=500,
+            book_bss_30d=0.05,
+            precision_over_live=precision_over,
+        )
+        == expected
+    )
 
 
 def _seed_model_stats(path):
@@ -139,3 +170,59 @@ def test_graduated_cells(tmp_path):
 
 def test_graduated_cells_missing_model_stats_is_empty(tmp_path):
     assert graduated_cells(tmp_path / "nope.parquet", tmp_path / "nolive.parquet") == set()
+
+
+def _seed_live_metrics_with_precision(path):
+    """Seed two cells: one with healthy Over precision, one losing on its Over recs."""
+    rows = []
+    for league, market, n, bss, prec_over, prec_under in [
+        ("NBA", "PTS", 300, 0.05, 0.55, 0.52),  # graduated
+        ("NBA", "FG3M", 1300, 0.054, 0.42, 0.45),  # precision_over < 0.50 -> demoted
+    ]:
+        for window in (7, 30):
+            rows.append(
+                {
+                    "league": league,
+                    "market": market,
+                    "computed_at": pd.Timestamp("2026-05-24"),
+                    "window_days": np.int16(window),
+                    "n_settled": np.int64(n),
+                    "book_bss": bss,
+                    "empirical_over_rate": 0.50,
+                    "predicted_over_rate": 0.50,
+                    "precision_over_live": prec_over,
+                    "precision_under_live": prec_under,
+                    "top_decile_mae": 2.1,
+                    "profit_sim_yield": 0.04,
+                }
+            )
+    pd.DataFrame(rows).to_parquet(path, engine="pyarrow", index=False)
+
+
+def test_lifecycle_table_demotes_on_precision_over_below_breakeven(tmp_path):
+    """A positive-book_bss cell must still demote if live Bet=Over hit rate is below 50%.
+
+    Regression guard for NBA/FG3M circa 2026-05-24: cell had +0.054 live book_bss
+    but its Over recommendations were losing money. The Brier-based gate let it
+    through; the precision-over gate must catch it.
+    """
+    ms = tmp_path / "model_stats.parquet"
+    lm = tmp_path / "live.parquet"
+    _seed_model_stats(ms)
+    _seed_live_metrics_with_precision(lm)
+    table = lifecycle_table(ms, lm, league="NBA")
+    states = dict(zip(table["market"], table["lifecycle_state"], strict=False))
+    assert states["PTS"] == "graduated"
+    assert states["FG3M"] == "demoted"
+
+
+def test_read_gate2_back_fills_precision_columns_for_old_parquets(tmp_path):
+    """Live parquets written before the precision columns shipped get NaN-filled."""
+    # _seed_live_metrics writes the pre-precision schema (no precision_*_live cols).
+    p = tmp_path / "old_live.parquet"
+    _seed_live_metrics(p)
+    df = read_gate2(p)
+    assert "precision_over_live" in df.columns
+    assert "precision_under_live" in df.columns
+    assert df["precision_over_live"].isna().all()
+    assert df["precision_under_live"].isna().all()

--- a/tests/test_nightly.py
+++ b/tests/test_nightly.py
@@ -10,10 +10,10 @@ import pandas as pd
 import pytest
 
 from sportstradamus.nightly import (
+    _MIN_BETS_FOR_PRECISION,
     LIVE_METRICS_COLUMNS,
     LIVE_METRICS_WINDOWS,
     _compute_live_metrics,
-    _MIN_BETS_FOR_PRECISION,
     _side_precision,
 )
 
@@ -237,9 +237,7 @@ def test_compute_live_metrics_populates_precision_columns():
     metrics = _compute_live_metrics(history, now=NOW)
     # 30d window covers the full fixture (rng spans 0-40 days back).
     nba_pts_30d = metrics[
-        (metrics["league"] == "NBA")
-        & (metrics["market"] == "PTS")
-        & (metrics["window_days"] == 30)
+        (metrics["league"] == "NBA") & (metrics["market"] == "PTS") & (metrics["window_days"] == 30)
     ].iloc[0]
     # Both sides should report a finite precision in [0, 1].
     assert 0.0 <= nba_pts_30d["precision_over_live"] <= 1.0

--- a/tests/test_nightly.py
+++ b/tests/test_nightly.py
@@ -13,6 +13,8 @@ from sportstradamus.nightly import (
     LIVE_METRICS_COLUMNS,
     LIVE_METRICS_WINDOWS,
     _compute_live_metrics,
+    _MIN_BETS_FOR_PRECISION,
+    _side_precision,
 )
 
 NOW = datetime(2026, 5, 20, 12, 0, 0)
@@ -191,3 +193,54 @@ def test_compute_live_metrics_profit_sim_yield_signs():
     wnba_30d = metrics[(metrics["league"] == "WNBA") & (metrics["window_days"] == 30)].iloc[0]
     assert nba_30d["profit_sim_yield"] == pytest.approx(1.0, abs=1e-6)
     assert wnba_30d["profit_sim_yield"] == pytest.approx(-1.0, abs=1e-6)
+
+
+def test_side_precision_reports_hit_rate_per_side():
+    """`_side_precision` returns the side-conditional hit rate, NaN when too few bets."""
+    # 40 Over bets, 24 hit -> precision_over = 0.60.
+    # 40 Under bets, 16 hit -> precision_under = 0.40.
+    over_bets = pd.DataFrame(
+        {
+            "Bet": ["Over"] * 40,
+            "Result": (["Over"] * 24) + (["Under"] * 16),
+        }
+    )
+    under_bets = pd.DataFrame(
+        {
+            "Bet": ["Under"] * 40,
+            "Result": (["Under"] * 16) + (["Over"] * 24),
+        }
+    )
+    group = pd.concat([over_bets, under_bets], ignore_index=True)
+    assert _side_precision(group, "Over") == pytest.approx(0.60)
+    assert _side_precision(group, "Under") == pytest.approx(0.40)
+
+
+def test_side_precision_returns_nan_when_n_below_threshold():
+    """Below `_MIN_BETS_FOR_PRECISION`, return NaN — small-n hit rates are noise."""
+    n_small = _MIN_BETS_FOR_PRECISION - 1
+    group = pd.DataFrame(
+        {
+            "Bet": ["Over"] * n_small + ["Under"] * 50,
+            "Result": ["Over"] * n_small + ["Under"] * 25 + ["Over"] * 25,
+        }
+    )
+    assert math.isnan(_side_precision(group, "Over"))
+    assert _side_precision(group, "Under") == pytest.approx(0.50)
+
+
+def test_compute_live_metrics_populates_precision_columns():
+    """`_compute_live_metrics` plumbs precision_{over,under}_live through to the parquet schema."""
+    # 120 rows/cell with random 50/50 sides yields ~60 per side — comfortably
+    # above _MIN_BETS_FOR_PRECISION (30) so both sides report a finite value.
+    history = _build_history_fixture(n_per_cell=120)
+    metrics = _compute_live_metrics(history, now=NOW)
+    # 30d window covers the full fixture (rng spans 0-40 days back).
+    nba_pts_30d = metrics[
+        (metrics["league"] == "NBA")
+        & (metrics["market"] == "PTS")
+        & (metrics["window_days"] == 30)
+    ].iloc[0]
+    # Both sides should report a finite precision in [0, 1].
+    assert 0.0 <= nba_pts_30d["precision_over_live"] <= 1.0
+    assert 0.0 <= nba_pts_30d["precision_under_live"] <= 1.0


### PR DESCRIPTION
## Cell action

NBA / FG3M — withheld (was: `devel`).

Immediate action per the 2026-05-24 researcher brief
(`/tmp/researcher_fg3m_calibration_divergence.md`). The local
`stat_meta.json` shipped FG3M to `devel`, but the live Bet=Over hit
rate falls below 0.50 — Sleeper / Underdog publication selection
pushes the recommender almost always toward Over on low FG3M lines
where variance dominates. The model itself is calibrated to within 2pp
on a like-for-like basis (training `precision_over` ≈ 0.52 vs live
Bet=Over hit rate ≈ 0.54), so this is a serving / selection problem,
not a model defect — but the immediate effect is losing picks. This PR
withholds the cell until the publication-aware fixes land
(see follow-ups in `docs/gbdt_mean_regression_plan.md`).

## Gate 2 change — precision_over replaces direction-bias gap (prevents recurrence)

The previously-shipped direction-bias gate
(`|predicted_over_rate − empirical_over_rate| > 0.10`) was not a
like-for-like metric. Training computes those rates over **every**
validation row with the `>=` push convention; live computes them over
**only** the Sleeper / UD offers that survived publication filtering
(`Boost ≤ 3.65`, `head(3)` per player), using strict `>`. The 28pp
"drift" the gap implied for NBA / FG3M on 2026-05-24 was ~22pp
publication-selection artifact and ~9pp the `>=` vs `>` push
convention. The gate let FG3M stay `graduated` despite losing Over
recommendations.

**Replacement gate:** `precision_over_live = P(Result=Over | Bet=Over)`
in the live 30d window. This is the like-for-like analogue of the
training pipeline's `precision_over` column. Threshold: `< 0.50` →
demote. At any boost ≤ 2.0× a sub-50% Bet=Over hit rate is a losing
strategy. The gate skips (NaN) when fewer than 30 Over bets exist in
the window — below that the conditional hit rate is noise (~9pp se).

## Files

- `src/sportstradamus/training/graduation.py` — drops `MAX_DIRECTION_BIAS`, adds `MIN_PRECISION_OVER = 0.50`; `classify_lifecycle` takes a `precision_over_live` kwarg; `read_gate2` projects the new columns and NaN-backfills for older parquets.
- `src/sportstradamus/nightly.py` — adds `_MIN_BETS_FOR_PRECISION = 30`, `_side_precision()` helper, and `precision_over_live` + `precision_under_live` columns through `LIVE_METRICS_COLUMNS`, `_empty_live_metrics_frame`, `_build_cell_row`, `_enforce_live_metrics_dtypes`. Also brings the Phase 4 `_profit_sim_kelly_yield` helper + `profit_sim_kelly_yield` column from prior model-research work (cohesive with the live-gate hardening).
- `src/sportstradamus/scripts/check_graduation.py` — `_DISPLAY_COLUMNS` gains the two new columns; header / row format strings updated.
- `src/sportstradamus/data/config/stat_meta.json` — NBA / FG3M `shipped` flipped `devel` → `withheld`. Single-cell change; no other cell touched.
- `tests/test_graduation.py` — 3 new tests (8-case precision-over parametrize, FG3M regression guard, read_gate2 backfill).
- `tests/test_nightly.py` — 3 new tests (`_side_precision` hit-rate, NaN-below-threshold, precision columns plumbing).
- `docs/gbdt_mean_regression_plan.md` — cross-league caveat #10 (training-vs-live metric mismatch warning) + a new "Open follow-ups from the 2026-05-24 FG3M-calibration researcher brief" section.

## Soak plan

FG3M is withheld immediately. The precision_over gate is silent on the existing parquet (`precision_over_live` is NaN for all rows until the next `reflect` run repopulates). Once the next nightly produces the new column, any cell whose 30d Bet=Over hit rate falls below 0.50 with ≥ 30 Over bets will be flagged `demoted` in `check-graduation` output and pruned at the next `meditate`.

## Re-ship path for FG3M

1. Land follow-up #1 (push convention `>=` → `>` with 3-class outcome) — see plan doc.
2. Retrain.
3. Confirm live `precision_over_live ≥ 0.50` after a 14-day soak.
4. Flip `shipped` back to `"devel"` in a separate PR.

## Open follow-ups (tracked in docs/gbdt_mean_regression_plan.md)

1. Align push convention across pipelines (training `>=` → strict `>` + 3-class outcome).
2. Add publication-filtered Bet=Over rate as a first-class training metric.
3. Re-run HurdleZINB pickup for FTM, BLK, OREB.
4. Sleeper Under-boost asymmetry — platform-aware EV threshold investigation.

## Test plan

- [x] `poetry run ruff check src/sportstradamus/` — all checks passed
- [x] `poetry run pytest tests/golden/` — 219 passed
- [x] `poetry run pytest -m integration` — 12 passed
- [x] `poetry run pytest tests/test_graduation.py tests/test_nightly.py tests/test_check_graduation.py tests/test_generate_ship_config.py tests/test_backfill_live_metrics.py` — 51 passed