### PR TITLE
archive: retry DuckDB connect on transient peer-lock conflicts

### DIFF
--- a/src/sportstradamus/helpers/archive.py
+++ b/src/sportstradamus/helpers/archive.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 import dataclasses
 import datetime
 import os
+import time
 import warnings
 from datetime import timedelta
 from pathlib import Path
@@ -67,6 +68,16 @@ TRAINING_LOOKBACK = timedelta(hours=TRAINING_LOOKBACK_HOURS)
 
 # Sharp books that anchor the movement-direction diagnostic in CLV.
 SHARP_BOOKS: tuple[str, ...] = ("pinnacle", "circa", "bookmaker")
+
+# Total seconds to wait for a conflicting writer (e.g. a confer pass that's
+# still flushing) to release the DuckDB file lock before giving up. DuckDB
+# holds the lock for the lifetime of the connection, so this is sized to
+# absorb a typical concurrent job wrapping up while the next one starts.
+# Override via ``SPORTSTRADAMUS_ARCHIVE_LOCK_WAIT_SECONDS`` for tuning;
+# set to 0 to disable retries (the legacy behaviour).
+_LOCK_WAIT_SECONDS_DEFAULT: float = 120.0
+_LOCK_BACKOFF_INITIAL: float = 2.0
+_LOCK_BACKOFF_MAX: float = 16.0
 
 # No PRIMARY KEY: DuckDB's PK creates an ART index that bloats the DB ~10x for
 # this row count. Lookups don't need the index — zone-map pruning on naturally
@@ -137,7 +148,7 @@ class Archive:
     _instance: Archive | None = None
 
     @staticmethod
-    def _connect_with_wal_recovery(db_path: Path) -> duckdb.DuckDBPyConnection:
+    def _connect_once(db_path: Path) -> duckdb.DuckDBPyConnection:
         # DuckDB <=1.1.x can leave a .wal that replays a bare CREATE TABLE
         # against an already-checkpointed catalog after a hard kill — the
         # connection then refuses to open at all. Quarantine the stale WAL
@@ -160,6 +171,37 @@ class Archive:
                 stacklevel=2,
             )
             return duckdb.connect(str(db_path))
+
+    @staticmethod
+    def _connect_with_wal_recovery(db_path: Path) -> duckdb.DuckDBPyConnection:
+        # DuckDB's file lock is held for the entire lifetime of a peer
+        # connection (not just during writes), so two production jobs that
+        # overlap by a few seconds will collide. Retry with bounded
+        # exponential backoff before giving up so a confer pass wrapping up
+        # while prophecize starts no longer crashes the cron entry.
+        wait_budget = float(
+            os.environ.get("SPORTSTRADAMUS_ARCHIVE_LOCK_WAIT_SECONDS", _LOCK_WAIT_SECONDS_DEFAULT)
+        )
+        deadline = time.monotonic() + wait_budget
+        backoff = _LOCK_BACKOFF_INITIAL
+        while True:
+            try:
+                return Archive._connect_once(db_path)
+            except duckdb.IOException as exc:
+                if "Could not set lock on file" not in str(exc):
+                    raise
+                remaining = deadline - time.monotonic()
+                if remaining <= 0 or wait_budget <= 0:
+                    raise
+                sleep_for = min(backoff, remaining)
+                warnings.warn(
+                    f"DuckDB archive {db_path} is locked by another process; "
+                    f"retrying in {sleep_for:.1f}s ({remaining:.0f}s remaining "
+                    f"of {wait_budget:.0f}s budget): {exc}",
+                    stacklevel=2,
+                )
+                time.sleep(sleep_for)
+                backoff = min(backoff * 2, _LOCK_BACKOFF_MAX)
 
     def __new__(cls):
         if cls._instance is None:

--- a/tests/golden/test_archive_wal_recovery.py
+++ b/tests/golden/test_archive_wal_recovery.py
@@ -13,6 +13,7 @@ import contextlib
 import shutil
 import subprocess
 import sys
+import time
 import warnings
 from pathlib import Path
 
@@ -126,4 +127,103 @@ def test_unrelated_catalog_exception_propagates(tmp_path, monkeypatch):
         assert "Failure while replaying WAL" not in str(excinfo.value)
     finally:
         _reset_archive_singleton()
+        monkeypatch.delenv("SPORTSTRADAMUS_ARCHIVE_DB", raising=False)
+
+
+def test_archive_retries_when_another_process_holds_lock(tmp_path, monkeypatch):
+    """A peer holding the DuckDB lock must trigger bounded retry, not immediate failure."""
+
+    archive_db = tmp_path / "archive.duckdb"
+    ready_file = tmp_path / "peer.ready"
+    release_file = tmp_path / "peer.release"
+
+    peer_script = (
+        "import duckdb, pathlib, time\n"
+        f"con = duckdb.connect({str(archive_db)!r})\n"
+        f"pathlib.Path({str(ready_file)!r}).touch()\n"
+        f"release = pathlib.Path({str(release_file)!r})\n"
+        "while not release.exists():\n"
+        "    time.sleep(0.05)\n"
+        "con.close()\n"
+    )
+    peer = subprocess.Popen([sys.executable, "-c", peer_script])
+    try:
+        deadline = time.monotonic() + 10
+        while not ready_file.exists() and time.monotonic() < deadline:
+            time.sleep(0.05)
+        assert ready_file.exists(), "peer process never acquired the lock"
+
+        monkeypatch.setenv("SPORTSTRADAMUS_ARCHIVE_DB", str(archive_db))
+        monkeypatch.setenv("SPORTSTRADAMUS_ARCHIVE_LOCK_WAIT_SECONDS", "30")
+        _reset_archive_singleton()
+
+        import threading
+
+        from sportstradamus.helpers.archive import Archive
+
+        # Release the lock shortly after Archive() starts retrying.
+        def release_peer():
+            time.sleep(3.0)
+            release_file.touch()
+
+        releaser = threading.Thread(target=release_peer)
+        releaser.start()
+        try:
+            with warnings.catch_warnings(record=True) as caught:
+                warnings.simplefilter("always")
+                archive = Archive()
+            lock_warnings = [w for w in caught if "is locked by another process" in str(w.message)]
+            assert lock_warnings, (
+                f"expected at least one lock-retry warning, got {[str(w.message) for w in caught]}"
+            )
+            assert archive._connection.execute("SELECT COUNT(*) FROM odds").fetchone() == (0,)
+        finally:
+            releaser.join()
+            _reset_archive_singleton()
+            monkeypatch.delenv("SPORTSTRADAMUS_ARCHIVE_LOCK_WAIT_SECONDS", raising=False)
+            monkeypatch.delenv("SPORTSTRADAMUS_ARCHIVE_DB", raising=False)
+    finally:
+        release_file.touch()
+        peer.wait(timeout=10)
+
+
+def test_archive_lock_retry_gives_up_after_budget(tmp_path, monkeypatch):
+    """When the lock is never released, retry must surface the original IOException."""
+
+    archive_db = tmp_path / "archive.duckdb"
+    ready_file = tmp_path / "peer.ready"
+    release_file = tmp_path / "peer.release"
+
+    peer_script = (
+        "import duckdb, pathlib, time\n"
+        f"con = duckdb.connect({str(archive_db)!r})\n"
+        f"pathlib.Path({str(ready_file)!r}).touch()\n"
+        f"release = pathlib.Path({str(release_file)!r})\n"
+        "while not release.exists():\n"
+        "    time.sleep(0.05)\n"
+        "con.close()\n"
+    )
+    peer = subprocess.Popen([sys.executable, "-c", peer_script])
+    try:
+        deadline = time.monotonic() + 10
+        while not ready_file.exists() and time.monotonic() < deadline:
+            time.sleep(0.05)
+        assert ready_file.exists(), "peer process never acquired the lock"
+
+        monkeypatch.setenv("SPORTSTRADAMUS_ARCHIVE_DB", str(archive_db))
+        # 1s budget — peer won't release in time, so we must fail fast.
+        monkeypatch.setenv("SPORTSTRADAMUS_ARCHIVE_LOCK_WAIT_SECONDS", "1")
+        _reset_archive_singleton()
+
+        from sportstradamus.helpers.archive import Archive
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            with pytest.raises(duckdb.IOException, match="Could not set lock on file"):
+                Archive()
+    finally:
+        release_file.touch()
+        peer.wait(timeout=10)
+        _reset_archive_singleton()
+        monkeypatch.delenv("SPORTSTRADAMUS_ARCHIVE_LOCK_WAIT_SECONDS", raising=False)
         monkeypatch.delenv("SPORTSTRADAMUS_ARCHIVE_DB", raising=False)


### PR DESCRIPTION
## Problem

Production cron failed at import time when prophecize started while a sibling job (e.g. confer) still held the archive lock:

```
_duckdb.IOException: IO Error: Could not set lock on file ".../archive.duckdb":
Conflicting lock is held in /usr/bin/python3.11 (PID 1289).
```

DuckDB holds the file lock for the entire lifetime of any connection, not just during writes. Two cron entries that overlap by even a few seconds collide — there's no native wait, the second process just dies.

## Fix

Split `Archive._connect_with_wal_recovery` into two layers:
- `_connect_once` — the existing single attempt with WAL-quarantine recovery, untouched in behavior
- `_connect_with_wal_recovery` — wraps `_connect_once` with bounded exponential-backoff retry (2s → 4s → 8s → 16s, capped) when the failure is a peer-lock `IOException`

The wait budget defaults to **120s** and is overridable via `SPORTSTRADAMUS_ARCHIVE_LOCK_WAIT_SECONDS`. Set it to `0` to restore the legacy fail-fast behavior. Each retry emits a `warnings.warn(...)` so the wait is visible in ops logs — not a silent fallback (STYLE_GUIDE §2.7).

Only the "Could not set lock on file" `IOException` triggers retry. All other `IOException`s, the WAL `CatalogException`, and any other failure propagate immediately as before.

## Test plan

- [x] `tests/golden/test_archive_wal_recovery.py::test_archive_retries_when_another_process_holds_lock` — spawns a peer subprocess that actually holds the DuckDB lock, releases it after 3s, and asserts `Archive()` succeeds and emits at least one retry warning.
- [x] `tests/golden/test_archive_wal_recovery.py::test_archive_lock_retry_gives_up_after_budget` — same peer setup but with a 1s budget and the lock never released; asserts the original `duckdb.IOException` surfaces unchanged.
- [x] Existing `test_archive_recovers_from_stale_wal` + `test_unrelated_catalog_exception_propagates` still pass (refactor preserves the WAL-recovery path bit-for-bit).
- [x] `ruff check` + `ruff format --check` clean on both touched files.


---
_Generated by [Claude Code](https://claude.ai/code/session_011akwbhPN9yCYK2KRTeBr8W)_