### PR TITLE
docs: pin "dashboard never opens DuckDB archive" as a hard rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,20 @@ Do not undo that work:
   into the next refactor's surprise pile.
 * **No magic numbers.** Named constants at module level with a one-line reason comment.
   See STYLE_GUIDE.md §9.
+* **Dashboard never touches the DuckDB archive.** The Streamlit dashboard reads
+  pre-computed parquet snapshots only (`data/history.parquet`,
+  `data/parlay_hist.parquet`, `data/model_stats.parquet`). DuckDB holds an
+  exclusive file lock for the entire lifetime of any read-write connection;
+  the dashboard is the only long-lived process in the system, so any archive
+  connection it opens — even accidentally via a module-level `Archive()` in
+  a transitively-imported module — blocks every cron job (prophecize, confer,
+  close-lines) that needs to write odds. If a dashboard page ever needs
+  archive-derived data, export it to parquet from a cron job and read the
+  parquet from the dashboard; do not query DuckDB directly. New dashboard
+  pages must not import any module whose top-level code constructs
+  `Archive()` — use `LazyArchive` from `sportstradamus.helpers` if a module
+  needs an `archive` binding shared with the prediction or training pipelines.
+  Pinned by `tests/golden/test_dashboard_no_archive_lock.py`.
 
 ## MANDATORY: run refactoring-specialist before any push, PR update, or review
 

--- a/tests/golden/test_dashboard_no_archive_lock.py
+++ b/tests/golden/test_dashboard_no_archive_lock.py
@@ -1,0 +1,130 @@
+"""Pin the CLAUDE.md hard rule: dashboard process must never hold the archive lock.
+
+The Streamlit dashboard is the only long-lived process in the system.
+DuckDB holds an exclusive file lock for the entire lifetime of any
+read-write connection, so any archive connection the dashboard opens —
+even accidentally via a module-level ``Archive()`` in a transitively-
+imported module — blocks every cron job that needs to write odds.
+
+This regression has bitten production twice already (first when
+``stats/base.py`` instantiated ``Archive`` at import, then again when
+the ``prediction/*`` modules did the same). The defensive proxy lives in
+``helpers/archive.py`` as ``LazyArchive``; this test pins the rule so a
+future refactor cannot silently regress.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import importlib
+import importlib.util
+import sys
+from pathlib import Path
+
+# Project source root: src/sportstradamus/
+_PROJECT_SRC = Path(__file__).resolve().parents[2] / "src" / "sportstradamus"
+
+# Dashboard entry surfaces. Add new top-level dashboard modules here when
+# they appear under src/sportstradamus/.
+_DASHBOARD_MODULES = (
+    "sportstradamus.dashboard",
+    "sportstradamus.dashboard_app",
+    "sportstradamus.dashboard_data",
+    "sportstradamus.dashboard_detail",
+)
+
+
+def _reset_archive_singleton() -> None:
+    """Clear the Archive singleton and close any open DuckDB connection.
+
+    Connection must be closed before nulling ``_instance``; leaving an open
+    handle on the ``tmp_path`` database would cause the OS to refuse deletion
+    of the temp directory on teardown on some platforms.
+    """
+    from sportstradamus.helpers.archive import Archive
+
+    inst = Archive._instance
+    if inst is None:
+        return
+    con = getattr(inst, "_connection", None)
+    if con is not None:
+        with contextlib.suppress(Exception):
+            con.close()
+    inst._initialized = False
+    Archive._instance = None
+
+
+def _clear_dashboard_imports() -> None:
+    """Drop dashboard + stats modules from sys.modules so re-import is fresh.
+
+    Other tests in the session may have already imported these modules, in
+    which case ``importlib.import_module`` is a no-op and would never trigger
+    the module-level code we want to observe. Clearing the cache forces a
+    fresh execution.
+    """
+    prefixes = (
+        "sportstradamus.dashboard",
+        "sportstradamus.pages",
+        "sportstradamus.stats",
+        "sportstradamus.prediction",
+    )
+    for name in [m for m in list(sys.modules) if m.startswith(prefixes)]:
+        del sys.modules[name]
+
+
+def _import_page_file(path: Path) -> None:
+    """Import a Streamlit page by filesystem path.
+
+    Pages use emoji in their filenames (``1_🎯_Predictions_Today.py``)
+    which are not valid Python identifiers, so they must be loaded via
+    ``importlib.util.spec_from_file_location`` rather than a normal import.
+
+    Streamlit-runtime side effects (``st.set_page_config`` outside a session,
+    ``@st.cache_data`` registration) may raise when executed without a
+    running Streamlit; we suppress those because the assertion we care about
+    is purely the Archive singleton, not whether the page renders.
+    """
+    spec = importlib.util.spec_from_file_location(f"_pinned_page_{path.stem}", path)
+    if spec is None or spec.loader is None:
+        return
+    module = importlib.util.module_from_spec(spec)
+    with contextlib.suppress(Exception):
+        spec.loader.exec_module(module)
+
+
+def test_dashboard_imports_do_not_construct_archive(tmp_path, monkeypatch) -> None:
+    """Importing every dashboard surface must leave ``Archive._instance`` is ``None``.
+
+    Codifies the CLAUDE.md "Hard rules" entry: the dashboard never opens
+    DuckDB. If this test fails, trace which module instantiates ``Archive()``
+    at top level and switch it to ``LazyArchive`` (see
+    ``sportstradamus.helpers.archive``).
+    """
+    monkeypatch.setenv("SPORTSTRADAMUS_ARCHIVE_DB", str(tmp_path / "archive.duckdb"))
+    _reset_archive_singleton()
+    _clear_dashboard_imports()
+    try:
+        from sportstradamus.helpers.archive import Archive
+
+        assert Archive._instance is None, "test fixture failed to reset singleton"
+
+        for name in _DASHBOARD_MODULES:
+            with contextlib.suppress(Exception):
+                importlib.import_module(name)
+
+        for page_path in sorted((_PROJECT_SRC / "pages").glob("*.py")):
+            if page_path.name == "__init__.py":
+                continue
+            _import_page_file(page_path)
+
+        assert Archive._instance is None, (
+            "Dashboard imports constructed the Archive singleton, which holds "
+            "DuckDB's exclusive file lock for the lifetime of the dashboard "
+            "process and blocks every cron job. Trace which module ran "
+            "Archive() at top level and switch it to LazyArchive — see the "
+            "Hard rules section of CLAUDE.md and the LazyArchive docstring "
+            "in helpers/archive.py."
+        )
+    finally:
+        _reset_archive_singleton()
+        monkeypatch.delenv("SPORTSTRADAMUS_ARCHIVE_DB", raising=False)


### PR DESCRIPTION
## Background

The two recent prod outages ([#58](https://github.com/tjjerome/Sportstradamus/pull/58), [#59](https://github.com/tjjerome/Sportstradamus/pull/59)) shared one root cause: the long-lived Streamlit dashboard transitively imported a module that did `archive = Archive()` at module top, which acquired DuckDB's exclusive file lock for the dashboard's lifetime and blocked every cron job (prophecize, confer, close-lines).

#59 introduced `LazyArchive` as the defensive proxy. This PR pins the rule so a future refactor can't silently regress.

## Changes

**`CLAUDE.md`** — adds a "Dashboard never touches the DuckDB archive" bullet to the Hard rules section, alongside the existing rules ("No new monoliths", "No back-compat shims", etc.). The new rule documents:

- Dashboard reads pre-computed parquet snapshots only (`data/history.parquet`, `data/parlay_hist.parquet`, `data/model_stats.parquet`).
- DuckDB's exclusive file lock semantics and why the dashboard's lifetime is the problem.
- The escape hatch — export to parquet from a cron job if archive data is ever needed in a page.
- The defensive helper — `LazyArchive` from `sportstradamus.helpers` if a module needs the binding shared with prediction/training.
- The test that pins it.

**`tests/golden/test_dashboard_no_archive_lock.py`** (new) — single test that:

1. Resets `Archive._instance` and clears `sportstradamus.{dashboard,pages,stats,prediction}.*` from `sys.modules` so re-imports run fresh.
2. Imports every dashboard surface: `dashboard`, `dashboard_app`, `dashboard_data`, `dashboard_detail`, and every `pages/*.py`.
3. Asserts `Archive._instance is None`.

Pages use emoji in their filenames (`1_🎯_Predictions_Today.py`), which are not valid Python identifiers, so they're loaded via `importlib.util.spec_from_file_location` rather than `importlib.import_module`. Streamlit-runtime side effects (`st.set_page_config` outside a session, `@st.cache_data` registration) are suppressed because the assertion we care about is purely the Archive singleton, not whether the page renders.

The failure message in the assertion points the next reader at LazyArchive and the CLAUDE.md rule, so a future regression doesn't require digging through the postmortem.

## Test plan

- [x] `poetry run pytest tests/golden/test_dashboard_no_archive_lock.py` — passes.
- [x] Sanity check: manually constructed `Archive()` and verified the assertion would catch it (`Archive._instance` becomes non-None).
- [x] `tests/golden/test_lazy_archive.py` + `test_archive_wal_recovery.py` still pass — 8/8 green across the archive-related suite.
- [x] `ruff check` + `ruff format --check` clean on both files.
- [x] refactoring-specialist audit: "Clean. One edit made [added `-> None` return annotation], all gates green on the in-scope files."


---
_Generated by [Claude Code](https://claude.ai/code/session_011akwbhPN9yCYK2KRTeBr8W)_