### PR TITLE
prediction: stop double-applying UD boost baseline to display Boost

### DIFF
--- a/src/sportstradamus/analysis.py
+++ b/src/sportstradamus/analysis.py
@@ -14,7 +14,7 @@ from scipy.stats import nbinom
 from sklearn.metrics import accuracy_score, brier_score_loss, log_loss
 from tqdm import tqdm
 
-from sportstradamus.helpers import get_odds
+from sportstradamus.helpers import UNDERDOG_BOOST_BASELINE, get_odds
 
 LEG_PATTERN = re.compile(r"^(.+?)\s+(Over|Under)\s+([\d.]+)\s+(.+?)\s+-\s+[\d.]+%")
 
@@ -324,11 +324,18 @@ def explode_offers(history):
             exploded.loc[resolved.index, "Hit"] = (resolved["Bet"] == resolved["Result"]).astype(
                 int
             )
-    # Derive Kelly-relevant columns
+    # Derive Kelly-relevant columns. ``Boost`` on persisted rows is the raw
+    # promo multiplier (1.00 = no promo). For Underdog the per-$1 payout
+    # multiplier is ``Boost * UNDERDOG_BOOST_BASELINE``; other platforms are
+    # treated as already payout-inclusive (back-compat with the pre-fix
+    # callers that read ``Model = Model P × Boost`` directly).
     if "Model P" in exploded.columns and "Boost" in exploded.columns:
-        exploded["Model"] = exploded["Model P"] * exploded["Boost"]
-        exploded["Books"] = exploded["Books P"].fillna(0.5) * exploded["Boost"]
-        exploded["K"] = (exploded["Model"] - 1) / (exploded["Boost"] - 1).replace(0, np.nan)
+        platform = exploded.get("Platform", pd.Series(dtype=str))
+        baseline = np.where(platform == "Underdog", UNDERDOG_BOOST_BASELINE, 1.0)
+        payout = exploded["Boost"] * baseline
+        exploded["Model"] = exploded["Model P"] * payout
+        exploded["Books"] = exploded["Books P"].fillna(0.5) * payout
+        exploded["K"] = (exploded["Model"] - 1) / (payout - 1).replace(0, np.nan)
     return exploded
 
 

--- a/src/sportstradamus/helpers/__init__.py
+++ b/src/sportstradamus/helpers/__init__.py
@@ -65,7 +65,16 @@ from sportstradamus.helpers.text import (
     remove_accents,
 )
 
+# Per-pick fair payout for an unboosted Underdog Power pick: power[4] ** (1/4)
+# = 10 ** 0.25 ≈ 1.778. Used by model_prob to convert the raw promo multiplier
+# from the Underdog API into a payout-inclusive value so ``Model = P × Boost``
+# yields true per-$1 expected return; consumers that want the raw modifier
+# (dashboard display, ``nightly.py`` profit-sim, parlay-search arithmetic in
+# ``correlation.py``) divide it back out.
+UNDERDOG_BOOST_BASELINE: float = 1.78
+
 __all__ = [
+    "UNDERDOG_BOOST_BASELINE",
     "Archive",
     "JsonFormatter",
     "LazyArchive",

--- a/src/sportstradamus/prediction/cli.py
+++ b/src/sportstradamus/prediction/cli.py
@@ -24,7 +24,7 @@ from tqdm import tqdm
 
 from sportstradamus import creds
 from sportstradamus.books import get_sleeper, get_ud
-from sportstradamus.helpers import LazyArchive, get_logger, stat_map
+from sportstradamus.helpers import UNDERDOG_BOOST_BASELINE, LazyArchive, get_logger, stat_map
 from sportstradamus.helpers.io import (
     read_history,
     read_parlay_hist,
@@ -128,12 +128,13 @@ def main(progress, legacy_correlation, contest_variant, log_level):
         ud_offers["Stat"] = ud_offers[
             "Market"
         ]  # preserve gamelog key for dashboard history lookups
-        ud_offers.loc[ud_offers["Bet"] == "Over", "Boost"] = (
-            1.78 * ud_offers.loc[ud_offers["Bet"] == "Over", "Boost"]
-        )
-        ud_offers.loc[ud_offers["Bet"] == "Under", "Boost"] = (
-            1.78 / ud_offers.loc[ud_offers["Bet"] == "Under", "Boost"]
-        )
+        # model_prob pre-multiplied Boost by UNDERDOG_BOOST_BASELINE so that
+        # ``Model = Model P * Boost`` is per-$1 EV. The persisted snapshot
+        # (current_offers.parquet, history.parquet) is consumed downstream
+        # (dashboard display, nightly profit-sim) as the raw UD promo
+        # multiplier, so divide the baseline back out here. Matches what the
+        # user sees on Underdog (1.00 = no promo, 1.05 = 5% promo).
+        ud_offers["Boost"] = ud_offers["Boost"] / UNDERDOG_BOOST_BASELINE
         ud_offers["Platform"] = "Underdog"
         all_offers.append(ud_offers)
         platforms_run.append("Underdog")
@@ -154,9 +155,10 @@ def main(progress, legacy_correlation, contest_variant, log_level):
         sl_offers["Stat"] = sl_offers[
             "Market"
         ]  # preserve gamelog key for dashboard history lookups
-        sl_offers.loc[sl_offers["Bet"] == "Under", "Boost"] = (
-            1.78 * 1.78 / sl_offers.loc[sl_offers["Bet"] == "Under", "Boost"]
-        )
+        # Sleeper Boost stays at the raw books.py value (model_prob only
+        # applies UNDERDOG_BOOST_BASELINE to platform == "Underdog"), so no
+        # division is needed here for display/storage to match the raw
+        # Sleeper promo multiplier.
         sl_offers["Platform"] = "Sleeper"
         all_offers.append(sl_offers)
         platforms_run.append("Sleeper")

--- a/src/sportstradamus/prediction/correlation.py
+++ b/src/sportstradamus/prediction/correlation.py
@@ -23,7 +23,7 @@ import pandas as pd
 from tqdm import tqdm
 
 from sportstradamus import data
-from sportstradamus.helpers import banned, stat_map
+from sportstradamus.helpers import UNDERDOG_BOOST_BASELINE, banned, stat_map
 from sportstradamus.prediction.parlay import (
     _PSD_EIG_TOLERANCE,
     _expected_payout_with_pushes,
@@ -55,10 +55,6 @@ _DEFENSIVE_PAIR_WEIGHT: float = 1.0 - _OFFENSIVE_PAIR_WEIGHT
 # via the ``max_boost`` arg). Underdog promo stacking is tighter than the rest.
 _MAX_BOOST_UNDERDOG: float = 2.5
 _MAX_BOOST_OTHER: float = 60.0
-
-# Underdog "Boost" column on raw offers is pre-multiplied by a 1.78 platform
-# baseline; divide it out so per-game boost arithmetic operates on a pure modifier.
-_UNDERDOG_BOOST_BASELINE: float = 1.78
 
 # Pre-filter gates for offers entering the per-game beam search. Hand-tuned to
 # keep only book-supported, model-favored legs out of the cartesian explosion.
@@ -267,7 +263,7 @@ def find_correlation(
         team_mod_map = banned[platform][league]["team"]
         opp_mod_map = banned[platform][league]["opponent"]
         if platform == "Underdog":
-            league_df["Boost"] = league_df["Boost"] / _UNDERDOG_BOOST_BASELINE
+            league_df["Boost"] = league_df["Boost"] / UNDERDOG_BOOST_BASELINE
 
         if league != "MLB":
             league_df["Player position"] = league_df["Player position"].apply(

--- a/src/sportstradamus/prediction/model_prob.py
+++ b/src/sportstradamus/prediction/model_prob.py
@@ -17,6 +17,7 @@ import pandas as pd
 from scipy.special import expit, logit
 
 from sportstradamus.helpers import (
+    UNDERDOG_BOOST_BASELINE,
     LazyArchive,
     fused_loc,
     get_ev,
@@ -497,7 +498,7 @@ def model_prob(
             offer_df.loc[offer_df["Boost"] == 1, ["Boost_Under", "Boost_Over"]] = 1
         offer_df[["Boost_Under", "Boost_Over"]] = offer_df[["Boost_Under", "Boost_Over"]].fillna(
             0
-        ).infer_objects(copy=False) * (1.78 if platform == "Underdog" else 1)
+        ).infer_objects(copy=False) * (UNDERDOG_BOOST_BASELINE if platform == "Underdog" else 1)
         offer_df["Boost"] = offer_df.apply(
             lambda x: (
                 (x["Boost_Over"] if x["Bet"] == "Over" else x["Boost_Under"])
@@ -514,7 +515,7 @@ def model_prob(
         offer_df["Books P"] = offer_df["Books"].fillna(0.5)
         offer_df["Books"] = offer_df["Books P"] * offer_df["Boost"]
         offer_df["K"] = (offer_df["Model"] - 1) / (offer_df["Boost"] - 1)
-        offer_df["Distance"] = offer_df["Boost"] / 1.78
+        offer_df["Distance"] = offer_df["Boost"] / UNDERDOG_BOOST_BASELINE
         offer_df.loc[offer_df["Distance"] < 1, "Distance"] = (
             1 / offer_df.loc[offer_df["Distance"] < 1, "Distance"]
         )


### PR DESCRIPTION
## Summary

Dashboard "Predictions Today" was showing wrong values in the `Boost` column for Underdog **Over** rows. Concrete examples the user hit today:

| Player | Bet | UD raw boost | Displayed Boost (before) | Model P | Displayed Model |
|--------|-----|--------------|--------------------------|---------|-----------------|
| Holmgren | Over 1.5 BLK  | 1.05 | **3.36** | 71.77 % | 1.35 |
| SGA      | Under 37.5 PA | 1.00 | 1.00     | 74.35 % | 1.32 |

## Root cause

`prediction/cli.py` mutated the `Boost` column on Underdog rows after `process_offers` returned, with arithmetic that double-applied the 1.78 Underdog per-pick baseline that `model_prob.py` had already mixed in:

```python
ud_offers.loc[Bet == "Over",  "Boost"] = 1.78 * Boost   # = 1.78² × raw
ud_offers.loc[Bet == "Under", "Boost"] = 1.78 / Boost   # = 1 / raw
```

For a raw UD promo of 1.05 the Over row displayed 3.36 instead of the 1.05 the user sees on Underdog. For an unboosted Under the inverse happened to land on 1.00 — looks right, but only by accident; any boosted Under would have displayed `1/raw`. The same broken pattern was duplicated for Sleeper Under (`1.78² / Boost`), producing ~3.17 for every vanilla Sleeper Under.

The displayed `Model` (EV) was **unaffected**: it is computed inside `process_offers` from the pre-mutation internal Boost, so parlay search, Kelly sizing, Pick'Em recommendations, and the EV column itself all stayed correct. The bug was confined to the persisted/displayed Boost column on `current_offers.parquet` (and the Boost slot in the offer tuples written to `history.parquet`).

## Changes

* Lifts `1.78` (per-pick fair payout for an unboosted UD Power pick: `power[4] ** (1/4) = 10 ** 0.25 ≈ 1.778`) from a module-private constant in `correlation.py` to a public top-level `UNDERDOG_BOOST_BASELINE` in `helpers/__init__.py`, so prediction-pipeline modules and `analysis.py` can share one definition.
* `prediction/cli.py`: replaces the broken six-line Over/Under mutation with a single divide that converts the internal payout-inclusive value back to the raw UD promo multiplier the user sees on the sportsbook. Deletes the parallel Sleeper-Under mutation entirely (Sleeper never went through the model_prob 1.78 multiplication, so its Boost was already raw).
* `prediction/model_prob.py`, `prediction/correlation.py`: replaces remaining literal `1.78`s with the shared constant.
* `analysis.py`: patches the Kelly recompute in `explode_offers` to rebuild `Model`, `Books`, and `K` using `Boost × baseline` for Underdog rows so the per-platform unit story stays consistent for downstream profit-sim and correlation pages reading history.

## Result

After this PR:

* Holmgren Over 1.5 BLK (raw=1.05): displayed Boost = **1.05**, Model EV unchanged at 1.34.
* SGA Under 37.5 PA (raw=1.00): displayed Boost = **1.00**, Model EV unchanged at 1.32.
* Any boosted UD Over/Under displays the actual UD promo modifier.
* Vanilla Sleeper Under no longer displays 3.17.

As a bonus, the dashboard's `BOOST_HOT_CEILING = 2.5` hot-row gate now actually gates: pre-fix every UD Over row had a stored Boost above 3, so the ceiling silently excluded all Overs from the highlight; post-fix the gate filters big-promo bets (Rivals 3x, etc.) as designed.

## History data

No on-disk migration of `history.parquet` is shipped; the corrupted Boost values in existing rows roll off the rolling window in the normal retention period. Recommendations were not affected and so no historical predictions need correction. If the user wants accurate historical `nightly.py` profit-sim/Kelly-yield cell metrics for the affected window, run a one-off migration as documented in the plan file:

```
over_mask  = (offers.bet == "Over")  & (offers.platform == "Underdog")
under_mask = (offers.bet == "Under") & (offers.platform == "Underdog")
offers.loc[over_mask, "boost"]  /= 1.78 ** 2   # was 1.78² × raw
offers.loc[under_mask, "boost"]  = 1 / offers.loc[under_mask, "boost"]
sl_under = (offers.bet == "Under") & (offers.platform == "Sleeper")
offers.loc[sl_under, "boost"] = 1.78 ** 2 / offers.loc[sl_under, "boost"]
```

## Test plan

- [x] `ruff check src/sportstradamus/` clean
- [x] `pytest tests/golden/` (177 passed, 6 skipped)
- [x] `pytest -m integration` (2 passed, 10 skipped on environment-limited paths)
- [x] `pytest tests/test_analysis.py tests/test_archive_history.py tests/golden/test_underdog_pickem.py tests/golden/test_parlay_search.py tests/golden/test_kelly.py` (47 passed, 3 skipped)
- [x] Manual math check: `Model P × (Boost × baseline) ≈ displayed Model EV` for both example rows
- [ ] Visual check on dashboard after next `prophecize` run: Boost column on `Predictions Today` matches what shows on Underdog

https://claude.ai/code/session_019iAVwiyUUbiqCRBfL9Nzae

---
_Generated by [Claude Code](https://claude.ai/code/session_019iAVwiyUUbiqCRBfL9Nzae)_