### PR TITLE
dashboard: key data caches on parquet mtime + quiet source-file watcher

### DIFF
--- a/src/sportstradamus/dashboard.py
+++ b/src/sportstradamus/dashboard.py
@@ -25,9 +25,15 @@ def run() -> None:
     app_path = Path(__file__).parent / "dashboard_app.py"
     subprocess.run(
         [
-            sys.executable, "-m", "streamlit", "run", str(app_path),
-            "--server.fileWatcherType", "none",
-            "--server.runOnSave", "false",
+            sys.executable,
+            "-m",
+            "streamlit",
+            "run",
+            str(app_path),
+            "--server.fileWatcherType",
+            "none",
+            "--server.runOnSave",
+            "false",
         ],
         check=False,
     )

--- a/src/sportstradamus/dashboard.py
+++ b/src/sportstradamus/dashboard.py
@@ -13,9 +13,21 @@ import click
 
 @click.command()
 def run():
-    """Launch the Sportstradamus Streamlit dashboard."""
+    """Launch the Sportstradamus Streamlit dashboard.
+
+    Production runs unattended under systemd, so the source-file watcher is
+    disabled. The watcher's only effect is the "Source file changed, rerun?"
+    popup, which misleads users — clicking "Rerun" only re-executes the
+    script, it does not invalidate the data cache, so the displayed data
+    looks unchanged. Data freshness is handled by mtime-keyed caches in
+    ``dashboard_data.py``.
+    """
     app_path = Path(__file__).parent / "dashboard_app.py"
     subprocess.run(
-        [sys.executable, "-m", "streamlit", "run", str(app_path)],
+        [
+            sys.executable, "-m", "streamlit", "run", str(app_path),
+            "--server.fileWatcherType", "none",
+            "--server.runOnSave", "false",
+        ],
         check=False,
     )

--- a/src/sportstradamus/dashboard.py
+++ b/src/sportstradamus/dashboard.py
@@ -12,7 +12,7 @@ import click
 
 
 @click.command()
-def run():
+def run() -> None:
     """Launch the Sportstradamus Streamlit dashboard.
 
     Production runs unattended under systemd, so the source-file watcher is

--- a/src/sportstradamus/dashboard_data.py
+++ b/src/sportstradamus/dashboard_data.py
@@ -407,7 +407,11 @@ def _extract_platforms(history):
     return sorted(platforms)
 
 
-def sidebar_filters(history, parlays=None, key_prefix=""):
+def sidebar_filters(
+    history: pd.DataFrame,
+    parlays: pd.DataFrame | None = None,
+    key_prefix: str = "",
+) -> dict:
     """Render sidebar filters and return filter values."""
     if st.sidebar.button(
         "Refresh data",

--- a/src/sportstradamus/dashboard_data.py
+++ b/src/sportstradamus/dashboard_data.py
@@ -6,6 +6,7 @@ All pages import from here to get cached DataFrames and filters.
 import importlib.resources as pkg_resources
 import json
 from datetime import datetime, timedelta
+from pathlib import Path
 from typing import Literal
 
 import numpy as np
@@ -23,7 +24,9 @@ from sportstradamus.helpers.io import (
     CURRENT_META_PATH,
     CURRENT_OFFERS_PATH,
     CURRENT_PARLAYS_PATH,
+    HISTORY_PATH,
     MODEL_STATS_PATH,
+    PARLAY_HIST_PATH,
     read_history,
     read_parlay_hist,
     read_parquet_safe,
@@ -84,6 +87,26 @@ GAMELOG_SCHEMA = {
 PRED_BANNER_COLOR = "#1f4e79"  # deep teal
 STATS_BANNER_COLOR = "#2d6a4f"  # forest green
 
+# Cache TTL for parquet/JSON loaders. mtime is the primary invalidation signal;
+# this is a safety net so a cache entry can't outlive 10 min even if the host
+# filesystem ever misreports mtime.
+_CACHE_TTL_SECONDS = 600
+
+# TTL for static config loaders (stat_map.json). No mtime key — these files
+# change only on deploy, so a 1-hour TTL is sufficient.
+_STATIC_CONFIG_TTL_SECONDS = 3600
+
+
+def _mtime(path) -> float:
+    """Return the parquet/JSON file's mtime, or 0.0 if absent.
+
+    Used as a cache key so Streamlit re-reads when cron rewrites a snapshot.
+    Passed by value into private ``_load_*_cached`` helpers; the function
+    body never touches the value, but Streamlit hashes it for the key.
+    """
+    p = Path(str(path))
+    return p.stat().st_mtime if p.is_file() else 0.0
+
 
 def format_ts(ts: str) -> str:
     """Convert a raw timestamp string to a friendly local-time label.
@@ -105,13 +128,12 @@ def format_ts(ts: str) -> str:
     return local_dt.strftime("%b %-d at %-I:%M %p")
 
 
-@st.cache_data(ttl=3600, show_spinner="Loading prediction history...")
-def load_history():
-    """Load prediction history from parquet.
+@st.cache_data(ttl=_CACHE_TTL_SECONDS, show_spinner="Loading prediction history...")
+def _load_history_cached(mtime: float) -> pd.DataFrame:
+    """Cached read of the prediction-history parquet.
 
-    Migrates old flat schema (no Offers column) to the normalized one-row-per-
-    prediction shape with an Offers list, then writes the migrated frame back.
-    Offers round-trip as list[tuple] (CLV-aware 9-tuples; 6-tuples padded).
+    ``mtime`` is the file modification time; Streamlit hashes it as part of
+    the cache key so a fresh cron write invalidates the entry.
     """
     history = read_history()
     if history.empty:
@@ -129,9 +151,18 @@ def load_history():
     return history
 
 
-@st.cache_data(ttl=3600, show_spinner="Loading parlay history...")
-def load_parlays():
-    """Load parlay history from parquet."""
+def load_history() -> pd.DataFrame:
+    """Load prediction history from parquet (mtime-keyed cache).
+
+    Migrates old flat schema (no Offers column) to the normalized one-row-per-
+    prediction shape with an Offers list, then writes the migrated frame back.
+    Offers round-trip as list[tuple] (CLV-aware 9-tuples; 6-tuples padded).
+    """
+    return _load_history_cached(_mtime(HISTORY_PATH))
+
+
+@st.cache_data(ttl=_CACHE_TTL_SECONDS, show_spinner="Loading parlay history...")
+def _load_parlays_cached(mtime: float) -> pd.DataFrame:
     parlays = read_parlay_hist()
     if parlays.empty:
         return parlays
@@ -143,35 +174,53 @@ def load_parlays():
     return parlays
 
 
-@st.cache_data(ttl=3600, show_spinner="Loading current offers...")
-def load_current_offers() -> pd.DataFrame:
-    """Today's scored offers, written by `prophecize`."""
+def load_parlays() -> pd.DataFrame:
+    """Load parlay history from parquet (mtime-keyed cache)."""
+    return _load_parlays_cached(_mtime(PARLAY_HIST_PATH))
+
+
+@st.cache_data(ttl=_CACHE_TTL_SECONDS, show_spinner="Loading current offers...")
+def _load_current_offers_cached(mtime: float) -> pd.DataFrame:
     return read_parquet_safe(CURRENT_OFFERS_PATH)
 
 
-@st.cache_data(ttl=3600, show_spinner="Loading current parlays...")
-def load_current_parlays() -> pd.DataFrame:
-    """Today's parlay candidates, written by `prophecize`."""
+def load_current_offers() -> pd.DataFrame:
+    """Today's scored offers, written by ``prophecize`` (mtime-keyed cache)."""
+    return _load_current_offers_cached(_mtime(CURRENT_OFFERS_PATH))
+
+
+@st.cache_data(ttl=_CACHE_TTL_SECONDS, show_spinner="Loading current parlays...")
+def _load_current_parlays_cached(mtime: float) -> pd.DataFrame:
     return read_parquet_safe(CURRENT_PARLAYS_PATH)
 
 
-@st.cache_data(ttl=3600, show_spinner=False)
-def load_gamelog(league: str) -> pd.DataFrame:
-    """Load the full season gamelog parquet for a league.
+def load_current_parlays() -> pd.DataFrame:
+    """Today's parlay candidates, written by ``prophecize`` (mtime-keyed cache)."""
+    return _load_current_parlays_cached(_mtime(CURRENT_PARLAYS_PATH))
 
-    Returns an empty DataFrame if the league is unrecognised or the file is
-    missing.  Callers are responsible for filtering to the relevant player and
-    stat column.
-    """
+
+@st.cache_data(ttl=_CACHE_TTL_SECONDS, show_spinner=False)
+def _load_gamelog_cached(league: str, mtime: float) -> pd.DataFrame:
     schema = GAMELOG_SCHEMA.get(league)
     if schema is None:
         return pd.DataFrame()
     return read_parquet_safe(pkg_resources.files(data) / schema["file"])
 
 
-@st.cache_data(ttl=3600)
-def load_current_meta() -> dict:
-    """Snapshot metadata (timestamp, leagues, platforms, row counts)."""
+def load_gamelog(league: str) -> pd.DataFrame:
+    """Load the full season gamelog parquet for a league (mtime-keyed cache).
+
+    Returns an empty DataFrame if the league is unrecognised or the file is
+    missing.  Callers are responsible for filtering to the relevant player and
+    stat column.
+    """
+    schema = GAMELOG_SCHEMA.get(league)
+    gamelog_path = pkg_resources.files(data) / schema["file"] if schema else None
+    return _load_gamelog_cached(league, _mtime(gamelog_path) if gamelog_path else 0.0)
+
+
+@st.cache_data(ttl=_CACHE_TTL_SECONDS)
+def _load_current_meta_cached(mtime: float) -> dict:
     if not CURRENT_META_PATH.is_file():
         return {}
     try:
@@ -181,10 +230,19 @@ def load_current_meta() -> dict:
         return {}
 
 
-@st.cache_data(ttl=3600, show_spinner="Loading model training stats...")
-def load_model_stats() -> pd.DataFrame:
-    """Per-(league, market, metric_row) training diagnostics from `meditate`."""
+def load_current_meta() -> dict:
+    """Snapshot metadata (timestamp, leagues, platforms, row counts; mtime-keyed)."""
+    return _load_current_meta_cached(_mtime(CURRENT_META_PATH))
+
+
+@st.cache_data(ttl=_CACHE_TTL_SECONDS, show_spinner="Loading model training stats...")
+def _load_model_stats_cached(mtime: float) -> pd.DataFrame:
     return read_parquet_safe(MODEL_STATS_PATH)
+
+
+def load_model_stats() -> pd.DataFrame:
+    """Per-(league, market, metric_row) training diagnostics from ``meditate``."""
+    return _load_model_stats_cached(_mtime(MODEL_STATS_PATH))
 
 
 def render_banner(kind: Literal["predictions", "stats"], subtitle: str = "") -> None:
@@ -221,7 +279,7 @@ def load_stats():
     return stats
 
 
-@st.cache_data(ttl=3600, show_spinner="Loading stat map...")
+@st.cache_data(ttl=_STATIC_CONFIG_TTL_SECONDS, show_spinner="Loading stat map...")
 def load_stat_map():
     with open(pkg_resources.files(data) / "config" / "stat_map.json") as f:
         return json.load(f)
@@ -340,6 +398,13 @@ def _extract_platforms(history):
 
 def sidebar_filters(history, parlays=None, key_prefix=""):
     """Render sidebar filters and return filter values."""
+    if st.sidebar.button(
+        "Refresh data",
+        key=f"{key_prefix}refresh_data",
+        help="Force-reload all parquet snapshots, bypassing the data cache.",
+    ):
+        st.cache_data.clear()
+        st.rerun()
     st.sidebar.header("Filters")
 
     # Date range

--- a/src/sportstradamus/dashboard_data.py
+++ b/src/sportstradamus/dashboard_data.py
@@ -163,6 +163,7 @@ def load_history() -> pd.DataFrame:
 
 @st.cache_data(ttl=_CACHE_TTL_SECONDS, show_spinner="Loading parlay history...")
 def _load_parlays_cached(mtime: float) -> pd.DataFrame:
+    """Cached read of the parlay-history parquet; ``mtime`` is the cache key."""
     parlays = read_parlay_hist()
     if parlays.empty:
         return parlays
@@ -261,7 +262,7 @@ def render_banner(kind: Literal["predictions", "stats"], subtitle: str = "") -> 
 
 
 @st.cache_resource(show_spinner="Loading league stats...")
-def load_stats():
+def load_stats() -> dict:
     """Load Stats objects from cached pickle files (no API calls).
 
     API updates are handled by the nightly script (poetry run reflect),
@@ -280,12 +281,13 @@ def load_stats():
 
 
 @st.cache_data(ttl=_STATIC_CONFIG_TTL_SECONDS, show_spinner="Loading stat map...")
-def load_stat_map():
+def load_stat_map() -> dict:
+    """Load the stat name mapping config (static, long-lived cache)."""
     with open(pkg_resources.files(data) / "config" / "stat_map.json") as f:
         return json.load(f)
 
 
-def load_resolve_meta():
+def load_resolve_meta() -> dict:
     """Load nightly resolution metadata (last run time, counts).
 
     Returns a dict with keys: last_run, history_resolved, parlays_resolved.
@@ -299,7 +301,7 @@ def load_resolve_meta():
         return {}
 
 
-def resolve_and_save(history, stats):
+def resolve_and_save(history: pd.DataFrame, stats: dict) -> pd.DataFrame:
     """Resolve pending predictions (fill Actual) and save back to parquet."""
     if "Actual" not in history.columns:
         history["Actual"] = np.nan
@@ -313,7 +315,7 @@ def resolve_and_save(history, stats):
     return history
 
 
-def resolve_parlays_and_save(parlays, stats, stat_map):
+def resolve_parlays_and_save(parlays: pd.DataFrame, stats: dict, stat_map: dict) -> pd.DataFrame:
     """Resolve pending parlays and save back to parquet."""
     if parlays.empty or "Legs" not in parlays.columns:
         return parlays
@@ -334,8 +336,13 @@ def resolve_parlays_and_save(parlays, stats, stat_map):
 
 
 def get_filtered_history(
-    history, leagues=None, platforms=None, markets=None, date_range=None, min_model_p=None
-):
+    history: pd.DataFrame,
+    leagues: list | None = None,
+    platforms: list | None = None,
+    markets: list | None = None,
+    date_range: tuple | None = None,
+    min_model_p: float | None = None,
+) -> pd.DataFrame:
     """Explode offers and apply sidebar filters.
 
     Returns a per-offer DataFrame with columns: all prediction-level cols +
@@ -366,7 +373,11 @@ def get_filtered_history(
     return df
 
 
-def get_prediction_history(history, leagues=None, date_range=None):
+def get_prediction_history(
+    history: pd.DataFrame,
+    leagues: list | None = None,
+    date_range: tuple | None = None,
+) -> pd.DataFrame:
     """Return prediction-level rows (no explosion) for CRPS/coverage analysis.
 
     Filters by league and date range but does NOT explode offers.

--- a/tests/golden/fixtures/dashboard_help.txt
+++ b/tests/golden/fixtures/dashboard_help.txt
@@ -2,5 +2,11 @@ Usage: run [OPTIONS]
 
   Launch the Sportstradamus Streamlit dashboard.
 
+  Production runs unattended under systemd, so the source-file watcher is
+  disabled. The watcher's only effect is the "Source file changed, rerun?"
+  popup, which misleads users — clicking "Rerun" only re-executes the script, it
+  does not invalidate the data cache, so the displayed data looks unchanged.
+  Data freshness is handled by mtime-keyed caches in ``dashboard_data.py``.
+
 Options:
   --help  Show this message and exit.


### PR DESCRIPTION
## Summary

- `src/sportstradamus/dashboard_data.py` — every cached parquet/JSON loader now passes the snapshot file's mtime as a hashed cache argument (`_mtime(path)` helper), so cron rewrites invalidate the cache immediately instead of waiting up to an hour for TTL. TTL drops to a 10-min safety net (`_CACHE_TTL_SECONDS = 600`). `load_stat_map` keeps a longer TTL via `_STATIC_CONFIG_TTL_SECONDS = 3600` (static config). New "Refresh data" sidebar button in `sidebar_filters` calls `st.cache_data.clear() + st.rerun()` as a manual escape hatch.
- `src/sportstradamus/dashboard.py` — `streamlit run` argv extended with `--server.fileWatcherType none --server.runOnSave false` to stop the misleading "Source file changed, rerun?" popup. Production runs under systemd; clicking "Rerun" only re-executed the script — it never cleared the data cache, which was the underlying lag bug.
- `load_stats` stays `@st.cache_resource` (pickle-backed `Stats` objects on a nightly cadence — not worth rehydrating per parquet write).

## Why

User reported the dashboard lagged the hourly cron and that the "files changed" popup, when accepted, flashed the screen black without refreshing data. Both symptoms had a single root cause: `@st.cache_data(ttl=3600)` on every loader keyed only on (empty) args, so reruns hit the same cached frames. mtime-as-cache-key is Streamlit's documented pattern for "reload when file changes."

## Test plan

- [ ] `poetry run ruff check src/sportstradamus/` (clean — verified)
- [ ] `poetry run pytest tests/golden/` on a machine with full deps (sandbox lacks torch/duckdb)
- [ ] `poetry run pytest -m integration`
- [ ] Local smoke: `poetry run dashboard`, then in another shell rerun `prophecize` and confirm the page picks up the new data on next refresh without manual rerun
- [ ] Verify popup gone: `touch src/sportstradamus/pages/1_🎯_Predictions_Today.py` while dashboard is running — no popup
- [ ] Sidebar "Refresh data" button clears caches and reloads

---
_Generated by [Claude Code](https://claude.ai/code/session_01KMhWm1uWUUCshR1jK2oBvp)_