### PR TITLE
comps: cache static pairs per week + vectorize p25/p75 quantile

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ scrapeops-python-requests = "^0.4.7"
 streamlit = ">=1.38"
 plotly = ">=5.18"
 streamlit-aggrid = "^1.2.1.post2"
+statsmodels = "^0.14.6"
 
 [tool.poetry.scripts]
 prophecize = "sportstradamus.prediction.cli:main"

--- a/src/sportstradamus/nightly.py
+++ b/src/sportstradamus/nightly.py
@@ -190,7 +190,9 @@ def _profit_sim_kelly_yield(group: pd.DataFrame) -> float:
     return float(pnl.sum() / total_stake)
 
 
-def _build_cell_row(cell: tuple[str, str], group: pd.DataFrame, *, now: pd.Timestamp, window_days: int) -> dict:
+def _build_cell_row(
+    cell: tuple[str, str], group: pd.DataFrame, *, now: pd.Timestamp, window_days: int
+) -> dict:
     """Compute one (league, market, window) live-metrics row."""
     n = len(group)
     if n == 0:

--- a/src/sportstradamus/scripts/comp_feature_stability.py
+++ b/src/sportstradamus/scripts/comp_feature_stability.py
@@ -160,9 +160,7 @@ def load_stacked_seasons(min_games: int) -> pd.DataFrame:
     return stacked
 
 
-def collect_pairs(
-    stacked: pd.DataFrame, feature: str, position: str | None = None
-) -> pd.DataFrame:
+def collect_pairs(stacked: pd.DataFrame, feature: str, position: str | None = None) -> pd.DataFrame:
     """Build a (prev, next) DataFrame of within-player Y/Y values for one feature.
 
     When ``position`` is given, rows are restricted to players whose
@@ -203,9 +201,7 @@ def compute_pearson(pair_df: pd.DataFrame) -> float:
     return float(pair_df["prev"].corr(pair_df["next"]))
 
 
-def decide(
-    feature: str, position: str, r: float, n_pairs: int, min_pairs: int
-) -> str:
+def decide(feature: str, position: str, r: float, n_pairs: int, min_pairs: int) -> str:
     """Map (feature, position, r, n_pairs) onto a decision label per plan §1G thresholds."""
     if feature in _TRIVIAL_FEATURES:
         return "keep_metadata"
@@ -270,8 +266,7 @@ def build_results_table(
 
     if missing:
         click.echo(
-            f"[warn] {len(missing)} feature(s) not found in loader output: "
-            f"{sorted(missing)}",
+            f"[warn] {len(missing)} feature(s) not found in loader output: {sorted(missing)}",
             err=True,
         )
 
@@ -296,9 +291,7 @@ def format_per_position_table(results: pd.DataFrame, position: str) -> str:
     lines.append(f"  {'-' * 45} {'-' * 8} {'-' * 6}  {'-' * 22}")
     for _, row in sub.iterrows():
         r_str = "   nan" if pd.isna(row["r"]) else f"{row['r']:>8.4f}"
-        lines.append(
-            f"  {row['feature']:<45} {r_str} {row['n_pairs']:>6}  {row['decision']}"
-        )
+        lines.append(f"  {row['feature']:<45} {r_str} {row['n_pairs']:>6}  {row['decision']}")
     return "\n".join(lines)
 
 

--- a/src/sportstradamus/scripts/zinb_routing_diagnostics.py
+++ b/src/sportstradamus/scripts/zinb_routing_diagnostics.py
@@ -491,7 +491,7 @@ def _compute_cell_stats(
     row = {
         "league": league,
         "market": market,
-        "n": int(len(y)),
+        "n": len(y),
         "observed_mean": mean,
         "variance": variance,
         "var_mean_ratio": var_mean_ratio,

--- a/src/sportstradamus/stats/base.py
+++ b/src/sportstradamus/stats/base.py
@@ -137,6 +137,11 @@ class Stats:
         # legacy lazy-once snapshot.
         self._comps_by_week: dict = {}
         self._current_comps_key = None
+        # Per-comp-pool cache of the static (player, comp, position, dist,
+        # weight) pairs DataFrame. Keyed by ``_current_comps_key`` so it
+        # invalidates in lockstep with ``self.comps``. Lets ``base_profile``
+        # and ``get_stats`` skip the Python tuple-loop rebuild per gameday.
+        self._comp_pairs_cache: dict = {}
 
     def parse_game(self, game):
         """Parse a single game API response and update ``self.gamelog``.
@@ -287,6 +292,86 @@ class Stats:
         self._compute_comps(target_game_date=date)
         self._comps_by_week[target_key] = self.comps
         self._current_comps_key = target_key
+
+    def _comp_pairs(self) -> pd.DataFrame:
+        """Return the static (player, comp, position, dist, weight) pairs DataFrame.
+
+        Cached per ``_current_comps_key`` so the Python tuple-loop that flattens
+        ``self.comps`` only runs once per comp-pool swap (i.e. once per training
+        week), not once per gameday. ``base_profile`` and ``get_stats`` consume
+        this to derive the per-day comp features via vectorized ops.
+
+        MLB-style comp structures (``{"pitchers": {pid: [id1, id2, ...]}}`` --
+        lists rather than ``{"comps": ..., "distances": ...}`` dicts) yield an
+        empty frame here; the MLB code path in ``get_stats`` operates directly
+        on ``self.comps`` and does not call into this helper.
+        """
+        key = self._current_comps_key
+        cached = self._comp_pairs_cache.get(key)
+        if cached is not None:
+            return cached
+
+        records = []
+        for position, pos_comps in self.comps.items():
+            if not isinstance(pos_comps, dict):
+                continue
+            for player, comp_data in pos_comps.items():
+                if not isinstance(comp_data, dict):
+                    continue
+                comps_list = comp_data.get("comps")
+                dist_list = comp_data.get("distances")
+                if not comps_list or dist_list is None:
+                    continue
+                for comp, dist in zip(comps_list, dist_list, strict=False):
+                    if comp == player:
+                        continue
+                    d = float(dist)
+                    records.append((player, comp, position, d, 1.0 / (1.0 + d)))
+
+        if not records:
+            pairs = pd.DataFrame(columns=["player", "comp", "position", "dist", "weight"])
+        else:
+            pairs = pd.DataFrame.from_records(
+                records, columns=["player", "comp", "position", "dist", "weight"]
+            )
+        self._comp_pairs_cache[key] = pairs
+        return pairs
+
+    @staticmethod
+    def _vectorized_weighted_quantiles(
+        df_sorted: pd.DataFrame, qs: list[float]
+    ) -> dict[float, pd.Series]:
+        """Per-player distance-weighted quantile of ``comp_mean``.
+
+        Replaces the per-group ``DataFrame.groupby.apply(_weighted_q)`` recipe
+        with a single sort + cumsum + np.interp pass. ``df_sorted`` must hold
+        ``['player', 'comp_mean', 'weight']`` already ordered by
+        ``('player', 'comp_mean')``. Returns ``{q: Series(indexed by player)}``.
+        """
+        if df_sorted.empty:
+            return {q: pd.Series(dtype=float) for q in qs}
+
+        grouper = df_sorted.groupby("player", sort=False)
+        group_sizes = grouper.size()
+        players_idx = group_sizes.index
+        sizes = group_sizes.to_numpy()
+        starts = np.concatenate([[0], np.cumsum(sizes)[:-1]])
+        ends = starts + sizes
+
+        cum_w = grouper["weight"].cumsum().to_numpy()
+        total_w = grouper["weight"].transform("sum").to_numpy()
+        cum_norm = np.divide(cum_w, total_w, out=np.zeros_like(cum_w), where=total_w > 0)
+        vals = df_sorted["comp_mean"].to_numpy()
+
+        results: dict[float, pd.Series] = {}
+        for q in qs:
+            out = np.full(len(players_idx), np.nan, dtype=np.float64)
+            for i, (s, e) in enumerate(zip(starts, ends, strict=False)):
+                if total_w[s] <= 0:
+                    continue
+                out[i] = np.interp(q, cum_norm[s:e], vals[s:e])
+            results[q] = pd.Series(out, index=players_idx)
+        return results
 
     def save_comps(self):
         """Write current comps to the league's JSON file for inspection."""
@@ -455,9 +540,11 @@ class Stats:
         )
         self.defenseProfile.index.name = self.log_strings["opponent"]
         if fp_defense_features is not None and not fp_defense_features.empty:
-            self.defenseProfile = self.defenseProfile.join(
-                fp_defense_features, how="left"
-            ).fillna(0).infer_objects(copy=False)
+            self.defenseProfile = (
+                self.defenseProfile.join(fp_defense_features, how="left")
+                .fillna(0)
+                .infer_objects(copy=False)
+            )
 
         self.teamProfile = teamstats
 
@@ -642,19 +729,18 @@ class Stats:
         # week (see :meth:`_ensure_comps`). The inference / cron path passes
         # today() and hits the lazy-once snapshot path.
         self._ensure_comps(date=date)
-        if self.comps:
-            _comp_records_p = []
-            for pos_comps in self.comps.values():
-                for player, comp_data in pos_comps.items():
-                    if player not in _all_mean.index:
-                        continue
-                    for comp, dist in zip(comp_data["comps"], comp_data["distances"], strict=False):
-                        if comp != player and comp in _all_mean.index:
-                            _comp_records_p.append((player, comp, 1.0 / (1.0 + dist)))
-            if _comp_records_p:
-                _cp_df_p = pd.DataFrame(_comp_records_p, columns=["player", "comp", "weight"])
-                _cp_df_p["comp_mean"] = _cp_df_p["comp"].map(_all_mean)
-                _cp_df_p = _cp_df_p.dropna(subset=["comp_mean"])
+        _pairs = self._comp_pairs()
+        if not _pairs.empty:
+            # Per-day dynamic step: bind market-specific ``_all_mean`` to the
+            # cached static pairs. The Python tuple-loop that flattens
+            # ``self.comps`` lives in ``_comp_pairs`` and only runs on
+            # comp-pool swap (per training week), not per gameday.
+            _cp_df_p = _pairs.loc[
+                _pairs["player"].isin(_all_mean.index), ["player", "comp", "weight"]
+            ].copy()
+            _cp_df_p["comp_mean"] = _cp_df_p["comp"].map(_all_mean)
+            _cp_df_p = _cp_df_p.dropna(subset=["comp_mean"])
+            if not _cp_df_p.empty:
                 _wsum_p = (
                     (_cp_df_p["comp_mean"] * _cp_df_p["weight"]).groupby(_cp_df_p["player"]).sum()
                 )
@@ -677,44 +763,26 @@ class Stats:
                 )
                 self.playerProfile["comps mean (EB)"] = _comp_eb
 
-                # Distance-weighted comp p25 / p75: built by sorting each
-                # player's comp set by ``comp_mean`` and walking the
-                # cumulative weight to the requested quantile. This is
-                # numpy's standard weighted-quantile recipe via
-                # ``np.interp(q, cum_w, sorted_vals)``.
-                def _weighted_q(g: pd.DataFrame, q: float) -> float:
-                    """Distance-weighted quantile of ``comp_mean`` values.
-
-                    Args:
-                        g: per-player group with ``comp_mean`` and ``weight``
-                            columns.
-                        q: target quantile in [0, 1].
-
-                    Returns:
-                        Interpolated quantile value, or ``nan`` when the
-                        cumulative weight is non-positive (no usable comps).
-                    """
-                    order = g["comp_mean"].argsort()
-                    vals = g["comp_mean"].to_numpy()[order]
-                    wts = g["weight"].to_numpy()[order]
-                    cum = np.cumsum(wts)
-                    if cum[-1] <= 0:
-                        return float("nan")
-                    cum /= cum[-1]
-                    return float(np.interp(q, cum, vals))
-
-                _p_lo = (
-                    _cp_df_p.groupby("player")
-                    .apply(lambda g: _weighted_q(g, _COMP_QUANTILE_LO), include_groups=False)
-                    .reindex(self.playerProfile.index)
+                # Distance-weighted comp p25 / p75: numpy's standard weighted-
+                # quantile recipe (np.interp(q, cum_w_norm, sorted_vals))
+                # vectorized across all players in a single sort + cumsum pass
+                # via :meth:`_vectorized_weighted_quantiles`. Replaces the
+                # per-group ``DataFrame.groupby.apply`` recipe that dominated
+                # the per-gameday cost on training matrix generation.
+                _sorted = (
+                    _cp_df_p[["player", "comp_mean", "weight"]]
+                    .sort_values(["player", "comp_mean"])
+                    .reset_index(drop=True)
                 )
-                _p_hi = (
-                    _cp_df_p.groupby("player")
-                    .apply(lambda g: _weighted_q(g, _COMP_QUANTILE_HI), include_groups=False)
-                    .reindex(self.playerProfile.index)
+                _qs = self._vectorized_weighted_quantiles(
+                    _sorted, [_COMP_QUANTILE_LO, _COMP_QUANTILE_HI]
                 )
-                self.playerProfile["comps p25"] = _p_lo
-                self.playerProfile["comps p75"] = _p_hi
+                self.playerProfile["comps p25"] = _qs[_COMP_QUANTILE_LO].reindex(
+                    self.playerProfile.index
+                )
+                self.playerProfile["comps p75"] = _qs[_COMP_QUANTILE_HI].reindex(
+                    self.playerProfile.index
+                )
 
         self.defenseProfile.fillna(0.0, inplace=True)
         self.teamProfile.fillna(0.0, inplace=True)
@@ -1070,50 +1138,62 @@ class Stats:
                 stats.loc[player, "Player comps z"] = opp_comp_games.mean()
                 defstats.loc[player, "comp n"] = opp_comp_games.count()
         else:
-            # Vectorized comps lookup for non-MLB leagues with distance weighting
-            _comp_records = []
-            for player, row in stats.iterrows():
-                pos_idx = int(row.get("Player position", 1)) - 1
-                if pos_idx < 0 or pos_idx >= len(self.positions):
-                    continue
-                comp_data = self.comps.get(self.positions[pos_idx], {}).get(
-                    player, {"comps": [player], "distances": [0.0]}
-                )
-                opp = opponents.get(player, "")
-                for comp, dist in zip(comp_data["comps"], comp_data["distances"], strict=False):
-                    if comp == player:
-                        continue
-                    _comp_records.append((player, comp, opp, 1.0 / (1.0 + dist), dist))
-
-            if _comp_records:
-                _cp_df = pd.DataFrame(
-                    _comp_records, columns=["target", "comp", "opp", "weight", "dist"]
-                )
-                # Mean distance to comps (player-side uniqueness signal --
-                # not matchup-dependent). Carried on defstats only because
-                # cached training matrices know it under the ``Defense `` prefix.
-                defstats["comp distance"] = (
-                    _cp_df.groupby("target")["dist"].mean().reindex(defstats.index)
-                )
-                # Inner-join comp games vs the opponent. The result is the
-                # matchup-conditional residual signal: each comp's outcome
-                # vs this opponent z-scored against the comp's own per-player
-                # baseline, distance-weighted across the comp set.
-                _merged = _cp_df.merge(
-                    _gl_z[[_player_col, _opp_col, "_mkt_zscore"]],
-                    left_on=["comp", "opp"],
-                    right_on=[_player_col, _opp_col],
-                    how="inner",
-                )
-                _merged["weighted_z"] = _merged["_mkt_zscore"] * _merged["weight"]
-                _comp_wsum = _merged.groupby("target")["weighted_z"].sum()
-                _comp_wcount = _merged.groupby("target")["weight"].sum()
-                _comp_means = _comp_wsum / _comp_wcount
-                stats["Player comps z"] = _comp_means.reindex(stats.index).fillna(0.0)
-                # Count of (comp, opponent) game observations backing each
-                # ``Player comps z`` estimate. Stays on defstats for cached-
-                # matrix compatibility.
-                defstats["comp n"] = _merged.groupby("target").size().reindex(defstats.index)
+            # Non-MLB matchup-conditional comp lookup. The static
+            # ``(player, comp, position, dist, weight)`` table is built once
+            # per comp-pool swap by :meth:`_comp_pairs`; here we only attach
+            # the per-call opponent and merge against the per-day ``_gl_z``.
+            _pairs = self._comp_pairs()
+            if not _pairs.empty:
+                _pos_idx = stats["Player position"].astype(int) - 1
+                _valid = (_pos_idx >= 0) & (_pos_idx < len(self.positions))
+                if _valid.any():
+                    _expected_pos = pd.Series(
+                        np.asarray(self.positions)[_pos_idx[_valid].to_numpy()],
+                        index=stats.index[_valid],
+                        name="expected_pos",
+                    )
+                    # Keep only pairs whose position matches the stats-side
+                    # position assignment. Preserves the original lookup
+                    # semantics (``self.comps[stats_position].get(player, ...)``)
+                    # for players whose ``Player position`` disagrees with the
+                    # comp-pool assignment.
+                    _cp_df = _pairs.merge(
+                        _expected_pos.rename_axis("target_player").reset_index(),
+                        left_on="player",
+                        right_on="target_player",
+                        how="inner",
+                    )
+                    _cp_df = _cp_df[_cp_df["position"] == _cp_df["expected_pos"]]
+                    if not _cp_df.empty:
+                        _cp_df["opp"] = _cp_df["player"].map(opponents)
+                        # Mean distance to comps (player-side uniqueness signal --
+                        # not matchup-dependent). Carried on defstats only because
+                        # cached training matrices know it under the ``Defense `` prefix.
+                        defstats["comp distance"] = (
+                            _cp_df.groupby("player")["dist"].mean().reindex(defstats.index)
+                        )
+                        # Inner-join comp games vs the opponent. The result is the
+                        # matchup-conditional residual signal: each comp's outcome
+                        # vs this opponent z-scored against the comp's own per-player
+                        # baseline, distance-weighted across the comp set.
+                        _merged = _cp_df.merge(
+                            _gl_z[[_player_col, _opp_col, "_mkt_zscore"]],
+                            left_on=["comp", "opp"],
+                            right_on=[_player_col, _opp_col],
+                            how="inner",
+                            suffixes=("", "_gl"),
+                        )
+                        _merged["weighted_z"] = _merged["_mkt_zscore"] * _merged["weight"]
+                        _comp_wsum = _merged.groupby("player")["weighted_z"].sum()
+                        _comp_wcount = _merged.groupby("player")["weight"].sum()
+                        _comp_means = _comp_wsum / _comp_wcount
+                        stats["Player comps z"] = _comp_means.reindex(stats.index).fillna(0.0)
+                        # Count of (comp, opponent) game observations backing each
+                        # ``Player comps z`` estimate. Stays on defstats for cached-
+                        # matrix compatibility.
+                        defstats["comp n"] = (
+                            _merged.groupby("player").size().reindex(defstats.index)
+                        )
 
         stats = stats.join(defstats.add_prefix("Defense "))
 

--- a/src/sportstradamus/stats/mlb.py
+++ b/src/sportstradamus/stats/mlb.py
@@ -801,7 +801,10 @@ class StatsMLB(Stats):
         )
         if os.path.isfile(filepath):
             df = pd.read_csv(filepath)
-            df = df.loc[(df.key1.str[-1] == df.key2.str[-1]) & (df.match_score >= _COMP_MATCH_SCORE_THRESHOLD)]
+            df = df.loc[
+                (df.key1.str[-1] == df.key2.str[-1])
+                & (df.match_score >= _COMP_MATCH_SCORE_THRESHOLD)
+            ]
             df.key1 = df.key1.str[:-2].astype(int)
             df.key2 = df.key2.str[:-2].astype(int)
             self.comps["pitchers"] = df.groupby("key1").apply(lambda x: x.key2.to_list()).to_dict()
@@ -812,7 +815,10 @@ class StatsMLB(Stats):
         )
         if os.path.isfile(filepath):
             df = pd.read_csv(filepath)
-            df = df.loc[(df.key1.str[-1] == df.key2.str[-1]) & (df.match_score >= _COMP_MATCH_SCORE_THRESHOLD)]
+            df = df.loc[
+                (df.key1.str[-1] == df.key2.str[-1])
+                & (df.match_score >= _COMP_MATCH_SCORE_THRESHOLD)
+            ]
             df.key1 = df.key1.str[:-2].astype(int)
             df.key2 = df.key2.str[:-2].astype(int)
             self.comps["hitters"] = df.groupby("key1").apply(lambda x: x.key2.to_list()).to_dict()
@@ -964,7 +970,11 @@ class StatsMLB(Stats):
         # Filter players with at least 2 entries
         playerGroups = (
             gamelog.groupby("playerName")
-            .filter(lambda x: (x[market].clip(0, 1).mean() > _MARKET_HIT_RATE_MIN) & (x[market].count() > 1))
+            .filter(
+                lambda x: (
+                    (x[market].clip(0, 1).mean() > _MARKET_HIT_RATE_MIN) & (x[market].count() > 1)
+                )
+            )
             .groupby("playerName")
         )
 

--- a/src/sportstradamus/stats/nba.py
+++ b/src/sportstradamus/stats/nba.py
@@ -1563,7 +1563,9 @@ class StatsNBA(Stats):
 
             # Scale both loc and scale to preserve coefficient of variation
             ratio = new_means / true_means.replace(0, np.nan)
-            ratio = ratio.fillna(1.0).clip(lower=_VOLUME_SCALE_RATIO_FLOOR, upper=_VOLUME_SCALE_RATIO_CAP)
+            ratio = ratio.fillna(1.0).clip(
+                lower=_VOLUME_SCALE_RATIO_FLOOR, upper=_VOLUME_SCALE_RATIO_CAP
+            )
             new_scale = scale * ratio
             new_loc = new_means - new_scale * delta * np.sqrt(2 / np.pi)
 

--- a/src/sportstradamus/stats/nfl.py
+++ b/src/sportstradamus/stats/nfl.py
@@ -1523,9 +1523,7 @@ class StatsNFL(Stats):
         """
         lookback_week = max(week - 1, 0)
         if lookback_week >= 1:
-            frame = nfl_fp_weekly_aggregate.load_through_one_year(
-                season, target_week=lookback_week
-            )
+            frame = nfl_fp_weekly_aggregate.load_through_one_year(season, target_week=lookback_week)
         else:
             # Early-season: fall back to prior season's late weeks.
             frame = nfl_fp_weekly_aggregate.load_through_one_year(

--- a/src/sportstradamus/stats/nfl_fp_team_weekly.py
+++ b/src/sportstradamus/stats/nfl_fp_team_weekly.py
@@ -227,8 +227,7 @@ def load_snapshot(
     """
     if file_kind not in FILE_KINDS:
         raise ValueError(
-            f"unknown FP team weekly file_kind: {file_kind!r}; "
-            f"valid kinds: {sorted(FILE_KINDS)}"
+            f"unknown FP team weekly file_kind: {file_kind!r}; valid kinds: {sorted(FILE_KINDS)}"
         )
 
     directory = snapshot_dir(season, snapshot_week)
@@ -289,13 +288,10 @@ def load_window(
     """
     if file_kind not in FILE_KINDS:
         raise ValueError(
-            f"unknown FP team weekly file_kind: {file_kind!r}; "
-            f"valid kinds: {sorted(FILE_KINDS)}"
+            f"unknown FP team weekly file_kind: {file_kind!r}; valid kinds: {sorted(FILE_KINDS)}"
         )
     if start_week > end_week:
-        raise ValueError(
-            f"start_week={start_week} must be <= end_week={end_week}"
-        )
+        raise ValueError(f"start_week={start_week} must be <= end_week={end_week}")
 
     frames: list[pd.DataFrame] = []
     for week in available_snapshots(season):

--- a/src/sportstradamus/stats/nfl_fp_team_weekly_aggregate.py
+++ b/src/sportstradamus/stats/nfl_fp_team_weekly_aggregate.py
@@ -409,22 +409,14 @@ def load_team_and_defense_features(
     if abbr_map.empty:
         return pd.DataFrame(), pd.DataFrame()
 
-    team_features = _aggregate_pattern_a(
-        pattern_a_windows, grain="team", abbr_map=abbr_map
-    )
-    defense_features = _aggregate_pattern_a(
-        pattern_a_windows, grain="defense", abbr_map=abbr_map
-    )
+    team_features = _aggregate_pattern_a(pattern_a_windows, grain="team", abbr_map=abbr_map)
+    defense_features = _aggregate_pattern_a(pattern_a_windows, grain="defense", abbr_map=abbr_map)
     team_b, defense_b = _load_line_matchups(*pattern_b_snapshot, abbr_map=abbr_map)
     if not team_b.empty:
-        team_features = (
-            team_b if team_features.empty else team_features.join(team_b, how="outer")
-        )
+        team_features = team_b if team_features.empty else team_features.join(team_b, how="outer")
     if not defense_b.empty:
         defense_features = (
-            defense_b
-            if defense_features.empty
-            else defense_features.join(defense_b, how="outer")
+            defense_b if defense_features.empty else defense_features.join(defense_b, how="outer")
         )
     return team_features, defense_features
 
@@ -553,9 +545,7 @@ def _dispatch(df: pd.DataFrame, recipe: _TeamRecipe) -> pd.Series | None:
     if recipe.pattern == "rpr_bucket_pass_rate":
         (bucket_key,) = recipe.args
         return _rpr_bucket_pass_rate(df, bucket_key)
-    logger.warning(
-        "unknown team-recipe pattern %r for %s", recipe.pattern, recipe.output_col
-    )
+    logger.warning("unknown team-recipe pattern %r for %s", recipe.pattern, recipe.output_col)
     return None
 
 

--- a/src/sportstradamus/stats/nfl_fp_weekly.py
+++ b/src/sportstradamus/stats/nfl_fp_weekly.py
@@ -245,9 +245,7 @@ def load_window(
             f"unknown FP weekly file_kind: {file_kind!r}; valid kinds: {sorted(FILE_KINDS)}"
         )
     if start_week > end_week:
-        raise ValueError(
-            f"start_week={start_week} must be <= end_week={end_week}"
-        )
+        raise ValueError(f"start_week={start_week} must be <= end_week={end_week}")
 
     frames: list[pd.DataFrame] = []
     for week in available_snapshots(season):

--- a/src/sportstradamus/stats/nfl_fp_weekly_aggregate.py
+++ b/src/sportstradamus/stats/nfl_fp_weekly_aggregate.py
@@ -125,12 +125,8 @@ class _Recipe:
 # computed in :func:`_derive_aggregate_metrics` after this table runs.
 _AGGREGATE_RECIPES: tuple[_Recipe, ...] = (
     # passing_advanced -- QB primary file
-    _Recipe(
-        "pass_adv_DB", "passing_advanced", "sum", ("playerStatsPassingDropbacksTotal",)
-    ),
-    _Recipe(
-        "pass_adv_SCRM", "passing_advanced", "sum", ("playerStatsPassingScramblesTotal",)
-    ),
+    _Recipe("pass_adv_DB", "passing_advanced", "sum", ("playerStatsPassingDropbacksTotal",)),
+    _Recipe("pass_adv_SCRM", "passing_advanced", "sum", ("playerStatsPassingScramblesTotal",)),
     _Recipe("pass_adv_ATT", "passing_advanced", "sum", ("playerStatsPassingAttemptsTotal",)),
     _Recipe("pass_adv_YDS", "passing_advanced", "sum", ("playerStatsPassingYardsTotal",)),
     _Recipe("pass_adv_TD", "passing_advanced", "sum", ("playerStatsPassingTouchdownsTotal",)),
@@ -146,12 +142,8 @@ _AGGREGATE_RECIPES: tuple[_Recipe, ...] = (
         "sum",
         ("playerStatsFirstDownsPassing",),
     ),
-    _Recipe(
-        "pass_adv_INT", "passing_advanced", "sum", ("playerStatsPassingInterceptionsTotal",)
-    ),
-    _Recipe(
-        "pass_adv_SACK", "passing_advanced", "sum", ("playerStatsPassingSackedTotal",)
-    ),
+    _Recipe("pass_adv_INT", "passing_advanced", "sum", ("playerStatsPassingInterceptionsTotal",)),
+    _Recipe("pass_adv_SACK", "passing_advanced", "sum", ("playerStatsPassingSackedTotal",)),
     _Recipe(
         "pass_adv_SACK_YDS",
         "passing_advanced",
@@ -419,12 +411,8 @@ _AGGREGATE_RECIPES: tuple[_Recipe, ...] = (
         ("playerStatsInside20ReceivingTargetsTotal",),
     ),
     # receiving_advanced -- WR / TE / RB primary file
-    _Recipe(
-        "rec_adv_RTE", "receiving_advanced", "sum", ("playerStatsReceivingRoutesTotal",)
-    ),
-    _Recipe(
-        "rec_adv_TGT", "receiving_advanced", "sum", ("playerStatsReceivingTargetsTotal",)
-    ),
+    _Recipe("rec_adv_RTE", "receiving_advanced", "sum", ("playerStatsReceivingRoutesTotal",)),
+    _Recipe("rec_adv_TGT", "receiving_advanced", "sum", ("playerStatsReceivingTargetsTotal",)),
     _Recipe(
         "rec_adv_TD",
         "receiving_advanced",
@@ -1015,12 +1003,12 @@ def _broadcast_team_coverage(
     team_features = nfl_fp_team_weekly_aggregate.load_pattern_a_team_features(windows)
     if team_features.empty:
         return profile
-    keep_cols = [c for c in ("off_faced_man_pct", "off_faced_zone_pct") if c in team_features.columns]
+    keep_cols = [
+        c for c in ("off_faced_man_pct", "off_faced_zone_pct") if c in team_features.columns
+    ]
     if not keep_cols:
         return profile
-    return profile.merge(
-        team_features[keep_cols], left_on="Team", right_index=True, how="left"
-    )
+    return profile.merge(team_features[keep_cols], left_on="Team", right_index=True, how="left")
 
 
 def _aggregate_recipes(windows: Sequence[tuple[int, int, int]]) -> pd.DataFrame:
@@ -1045,9 +1033,7 @@ def _aggregate_recipes(windows: Sequence[tuple[int, int, int]]) -> pd.DataFrame:
     return out
 
 
-def _load_kind_multi(
-    windows: Sequence[tuple[int, int, int]], file_kind: str
-) -> pd.DataFrame:
+def _load_kind_multi(windows: Sequence[tuple[int, int, int]], file_kind: str) -> pd.DataFrame:
     """Concatenate per-game rows from every (season, start, end) window for ``file_kind``."""
     frames = []
     for season, start_week, end_week in windows:
@@ -1301,9 +1287,7 @@ def _aggregate_separation_by_coverage(
     wide = per_scheme.unstack("scheme")
     if wide.empty:
         return wide
-    return wide.rename(
-        columns={name: f"rec_sep_vs_{name}" for name in _SEP_BY_COVERAGE_SCHEMES}
-    )
+    return wide.rename(columns={name: f"rec_sep_vs_{name}" for name in _SEP_BY_COVERAGE_SCHEMES})
 
 
 def _aggregate_separation_by_alignment_bucket(
@@ -1376,16 +1360,8 @@ def _aggregate_separation_by_alignment_bucket(
         lambda g: (g["win_value"] * g["weight"]).sum(min_count=1),
         include_groups=False,
     )
-    sep_wide = (
-        sep_num.divide(weight_sum)
-        .where(weight_sum != 0, other=np.nan)
-        .unstack("alignment")
-    )
-    win_wide = (
-        win_num.divide(weight_sum)
-        .where(weight_sum != 0, other=np.nan)
-        .unstack("alignment")
-    )
+    sep_wide = sep_num.divide(weight_sum).where(weight_sum != 0, other=np.nan).unstack("alignment")
+    win_wide = win_num.divide(weight_sum).where(weight_sum != 0, other=np.nan).unstack("alignment")
     sep_wide = sep_wide.rename(
         columns={a: f"rec_sep_align_{a}_SEP_SCORE" for a in _SEP_BY_ALIGNMENT_BUCKETS}
     )
@@ -1471,9 +1447,7 @@ def _aggregate_man_vs_zone_bucket(
     return wide.rename(columns={s: f"rec_mz_YPRR_{s}" for s in _MZ_BUCKETS})
 
 
-def _load_kind(
-    season: int, start_week: int, end_week: int, file_kind: str
-) -> pd.DataFrame:
+def _load_kind(season: int, start_week: int, end_week: int, file_kind: str) -> pd.DataFrame:
     """Read one file_kind for the closed week range, log + swallow loader errors.
 
     Normalises the loader's ``DataFrame | None`` return to an empty
@@ -1618,15 +1592,13 @@ def _derive_aggregate_metrics(profile: pd.DataFrame) -> pd.DataFrame:
     routes = profile.get("rec_adv_RTE")
     if snaps is not None and routes is not None:
         diff = (snaps - routes.fillna(0)).clip(lower=0)
-        profile["block_pct_proxy"] = diff.divide(snaps).where(
-            snaps > 0, other=np.nan
-        )
+        profile["block_pct_proxy"] = diff.divide(snaps).where(snaps > 0, other=np.nan)
 
     return profile
 
 
 __all__ = (
+    "load_multi_window_one_year",
     "load_through_one_year",
     "load_window_one_year",
-    "load_multi_window_one_year",
 )

--- a/src/sportstradamus/stats/nhl.py
+++ b/src/sportstradamus/stats/nhl.py
@@ -939,7 +939,9 @@ class StatsNHL(Stats):
 
                 # Scale both loc and scale to preserve coefficient of variation
                 ratio = new_means / true_means.replace(0, np.nan)
-                ratio = ratio.fillna(1.0).clip(lower=_VOLUME_SCALE_RATIO_FLOOR, upper=_VOLUME_SCALE_RATIO_CAP)
+                ratio = ratio.fillna(1.0).clip(
+                    lower=_VOLUME_SCALE_RATIO_FLOOR, upper=_VOLUME_SCALE_RATIO_CAP
+                )
                 new_scale = scale * ratio
                 new_loc = new_means - new_scale * delta * np.sqrt(2 / np.pi)
 

--- a/src/sportstradamus/stats/wnba.py
+++ b/src/sportstradamus/stats/wnba.py
@@ -499,4 +499,3 @@ class StatsWNBA(StatsNBA):
         compare against the int keys in ``self.players``.
         """
         return target_game_date.year
-

--- a/src/sportstradamus/training/cli.py
+++ b/src/sportstradamus/training/cli.py
@@ -312,7 +312,9 @@ def meditate(
                     # families (ZINB/NegBin/Gamma/ZAGamma) ignore the slug,
                     # so STRATEGY_NONE is fine and the next clause will
                     # substitute the run-wide default for the pipeline call.
-                    cell_strategy = target_strategy if cell_dist == SKEW_NORMAL_DIST else STRATEGY_NONE
+                    cell_strategy = (
+                        target_strategy if cell_dist == SKEW_NORMAL_DIST else STRATEGY_NONE
+                    )
                     click.echo(
                         f"[{lg}] {market}: BYPASS withhold "
                         f"(dist={cell_dist!r}, strategy={cell_strategy!r})"

--- a/src/sportstradamus/training/data.py
+++ b/src/sportstradamus/training/data.py
@@ -134,7 +134,10 @@ def trim_matrix(M: pd.DataFrame, min_rows: int = 7500) -> pd.DataFrame:
     # line distribution.
     archived_mask = M["Archived"] == 1
     n_archived = archived_mask.sum()
-    if n_archived >= _MIN_ARCHIVED_FOR_CLIP and n_archived / len(M) > _MIN_ARCHIVED_FRACTION_FOR_CLIP:
+    if (
+        n_archived >= _MIN_ARCHIVED_FOR_CLIP
+        and n_archived / len(M) > _MIN_ARCHIVED_FRACTION_FOR_CLIP
+    ):
         line_floor = M.loc[archived_mask, "Line"].min()
         line_ceil = M.loc[archived_mask, "Line"].max()
     else:

--- a/tests/golden/test_feature_selection.py
+++ b/tests/golden/test_feature_selection.py
@@ -45,7 +45,9 @@ def synthetic_filter_inputs(tmp_path, monkeypatch) -> dict:
     all_feats = current_feats + candidate_feats + locked_feats
 
     target = rng.normal(size=n_rows)
-    df_cols: dict[str, np.ndarray] = {"Date": pd.date_range("2024-01-01", periods=n_rows).astype(str)}
+    df_cols: dict[str, np.ndarray] = {
+        "Date": pd.date_range("2024-01-01", periods=n_rows).astype(str)
+    }
     df_cols["Result"] = target
     for i, feat in enumerate(all_feats):
         signal = rng.normal(size=n_rows) + (target * (0.5 if i < 10 else 0.05))
@@ -118,7 +120,9 @@ def test_shap_floor_k_pinned_at_30():
 
 def test_feat_has_shap_entry_detects_variants():
     """``feat_has_shap_entry`` finds SHAP via any of base, short, growth."""
-    shap_df = pd.DataFrame({"X": {"Player foo": np.nan, "Player foo short": 1.5, "Player bar": 2.0}})
+    shap_df = pd.DataFrame(
+        {"X": {"Player foo": np.nan, "Player foo short": 1.5, "Player bar": 2.0}}
+    )
     assert fs.feat_has_shap_entry("Player foo", "X", shap_df), "should match via 'short'"
     assert fs.feat_has_shap_entry("Player bar", "X", shap_df), "should match base"
     assert not fs.feat_has_shap_entry("Player baz", "X", shap_df)

--- a/tests/golden/test_profit_sim.py
+++ b/tests/golden/test_profit_sim.py
@@ -183,8 +183,16 @@ def test_kelly_skips_minus_110_payout():
     # payouts directly rather than the dashboard's exploded-history Boost.
     df = _make_offers(n_days=1, hit_pattern=[True])
     result = simulate_strategy(
-        df, prob_col="Model P", ranking="Kelly", min_model_p=0.5, min_books_p=0.0,
-        max_bets_day=10, sizing_pct=0.0, use_kelly=True, initial_bankroll=1000.0, n_mc=1,
+        df,
+        prob_col="Model P",
+        ranking="Kelly",
+        min_model_p=0.5,
+        min_books_p=0.0,
+        max_bets_day=10,
+        sizing_pct=0.0,
+        use_kelly=True,
+        initial_bankroll=1000.0,
+        n_mc=1,
     )
     assert result.iloc[0]["bankroll"] == pytest.approx(1000.0)
     assert result.iloc[0]["daily_pnl"] == pytest.approx(0.0)
@@ -218,12 +226,28 @@ def test_monte_carlo_seed_reproducibility():
     # trajectories — the sim is reproducible.
     df = _make_offers(n_days=4)
     r1 = simulate_strategy(
-        df, prob_col="Model P", ranking="Kelly", min_model_p=0.5, min_books_p=0.0,
-        max_bets_day=10, sizing_pct=1.0, use_kelly=False, initial_bankroll=1000.0, n_mc=3,
+        df,
+        prob_col="Model P",
+        ranking="Kelly",
+        min_model_p=0.5,
+        min_books_p=0.0,
+        max_bets_day=10,
+        sizing_pct=1.0,
+        use_kelly=False,
+        initial_bankroll=1000.0,
+        n_mc=3,
     )
     r2 = simulate_strategy(
-        df, prob_col="Model P", ranking="Kelly", min_model_p=0.5, min_books_p=0.0,
-        max_bets_day=10, sizing_pct=1.0, use_kelly=False, initial_bankroll=1000.0, n_mc=3,
+        df,
+        prob_col="Model P",
+        ranking="Kelly",
+        min_model_p=0.5,
+        min_books_p=0.0,
+        max_bets_day=10,
+        sizing_pct=1.0,
+        use_kelly=False,
+        initial_bankroll=1000.0,
+        n_mc=3,
     )
     pd.testing.assert_frame_equal(r1, r2)
 
@@ -250,14 +274,30 @@ def test_caller_rng_overrides_default_seed():
         )
     df = pd.DataFrame(rows)
     r1 = simulate_strategy(
-        df, prob_col="Model P", ranking="Kelly", min_model_p=0.0, min_books_p=0.0,
-        max_bets_day=3, sizing_pct=1.0, use_kelly=False, initial_bankroll=1000.0,
-        n_mc=1, rng=np.random.default_rng(123),
+        df,
+        prob_col="Model P",
+        ranking="Kelly",
+        min_model_p=0.0,
+        min_books_p=0.0,
+        max_bets_day=3,
+        sizing_pct=1.0,
+        use_kelly=False,
+        initial_bankroll=1000.0,
+        n_mc=1,
+        rng=np.random.default_rng(123),
     )
     r2 = simulate_strategy(
-        df, prob_col="Model P", ranking="Kelly", min_model_p=0.0, min_books_p=0.0,
-        max_bets_day=3, sizing_pct=1.0, use_kelly=False, initial_bankroll=1000.0,
-        n_mc=1, rng=np.random.default_rng(123),
+        df,
+        prob_col="Model P",
+        ranking="Kelly",
+        min_model_p=0.0,
+        min_books_p=0.0,
+        max_bets_day=3,
+        sizing_pct=1.0,
+        use_kelly=False,
+        initial_bankroll=1000.0,
+        n_mc=1,
+        rng=np.random.default_rng(123),
     )
     pd.testing.assert_frame_equal(r1, r2)
 
@@ -311,8 +351,16 @@ def test_summarize_empty_returns_zero_metrics():
 def test_summarize_winning_run_positive_roi():
     df = _make_offers(n_days=3, hit_pattern=[True, True, True])
     result = simulate_strategy(
-        df, prob_col="Model P", ranking="Kelly", min_model_p=0.5, min_books_p=0.0,
-        max_bets_day=10, sizing_pct=10.0, use_kelly=False, initial_bankroll=1000.0, n_mc=1,
+        df,
+        prob_col="Model P",
+        ranking="Kelly",
+        min_model_p=0.5,
+        min_books_p=0.0,
+        max_bets_day=10,
+        sizing_pct=10.0,
+        use_kelly=False,
+        initial_bankroll=1000.0,
+        n_mc=1,
     )
     summary = summarize_runs(result, initial_bankroll=1000.0)
     # 3 winning bets at 10% flat sizing on -110 → mean_final > 1000
@@ -325,8 +373,16 @@ def test_summarize_winning_run_positive_roi():
 def test_summarize_losing_run_negative_roi_and_drawdown():
     df = _make_offers(n_days=3, hit_pattern=[False, False, False])
     result = simulate_strategy(
-        df, prob_col="Model P", ranking="Kelly", min_model_p=0.5, min_books_p=0.0,
-        max_bets_day=10, sizing_pct=10.0, use_kelly=False, initial_bankroll=1000.0, n_mc=1,
+        df,
+        prob_col="Model P",
+        ranking="Kelly",
+        min_model_p=0.5,
+        min_books_p=0.0,
+        max_bets_day=10,
+        sizing_pct=10.0,
+        use_kelly=False,
+        initial_bankroll=1000.0,
+        n_mc=1,
     )
     summary = summarize_runs(result, initial_bankroll=1000.0)
     assert summary["roi"] < 0
@@ -338,8 +394,16 @@ def test_summarize_losing_run_negative_roi_and_drawdown():
 def test_summarize_sharpe_finite_on_mixed_outcomes():
     df = _make_offers(n_days=4, hit_pattern=[True, False, True, False])
     result = simulate_strategy(
-        df, prob_col="Model P", ranking="Kelly", min_model_p=0.5, min_books_p=0.0,
-        max_bets_day=10, sizing_pct=5.0, use_kelly=False, initial_bankroll=1000.0, n_mc=1,
+        df,
+        prob_col="Model P",
+        ranking="Kelly",
+        min_model_p=0.5,
+        min_books_p=0.0,
+        max_bets_day=10,
+        sizing_pct=5.0,
+        use_kelly=False,
+        initial_bankroll=1000.0,
+        n_mc=1,
     )
     summary = summarize_runs(result, initial_bankroll=1000.0)
     assert np.isfinite(summary["sharpe"])
@@ -354,8 +418,16 @@ def test_summarize_default_n_mc_matches_constant():
 def test_summarize_aggregates_across_runs():
     df = _make_offers(n_days=2, hit_pattern=[True, False])
     result = simulate_strategy(
-        df, prob_col="Model P", ranking="Kelly", min_model_p=0.5, min_books_p=0.0,
-        max_bets_day=10, sizing_pct=1.0, use_kelly=False, initial_bankroll=1000.0, n_mc=5,
+        df,
+        prob_col="Model P",
+        ranking="Kelly",
+        min_model_p=0.5,
+        min_books_p=0.0,
+        max_bets_day=10,
+        sizing_pct=1.0,
+        use_kelly=False,
+        initial_bankroll=1000.0,
+        n_mc=5,
     )
     summary = summarize_runs(result, initial_bankroll=1000.0)
     # mean_final is the average across the 5 runs' last bankrolls

--- a/tests/test_nightly.py
+++ b/tests/test_nightly.py
@@ -10,10 +10,10 @@ import pandas as pd
 import pytest
 
 from sportstradamus.nightly import (
+    _MIN_BETS_FOR_PRECISION,
     LIVE_METRICS_COLUMNS,
     LIVE_METRICS_WINDOWS,
     _compute_live_metrics,
-    _MIN_BETS_FOR_PRECISION,
     _side_precision,
 )
 
@@ -237,9 +237,7 @@ def test_compute_live_metrics_populates_precision_columns():
     metrics = _compute_live_metrics(history, now=NOW)
     # 30d window covers the full fixture (rng spans 0-40 days back).
     nba_pts_30d = metrics[
-        (metrics["league"] == "NBA")
-        & (metrics["market"] == "PTS")
-        & (metrics["window_days"] == 30)
+        (metrics["league"] == "NBA") & (metrics["market"] == "PTS") & (metrics["window_days"] == 30)
     ].iloc[0]
     # Both sides should report a finite precision in [0, 1].
     assert 0.0 <= nba_pts_30d["precision_over_live"] <= 1.0


### PR DESCRIPTION
## Summary

Keeps the per-week NFL comp-pool rebuild (da847dd) and the matchup-conditional EB / p25 / p75 additions (6bebd72) intact, but moves the work that doesn't change per gameday out of the per-gameday path.

Two hot inner loops were running on every gameday inside `Stats.get_training_matrix`:

1. **`base_profile` rebuilt a 4000-9000 row `(player, comp, weight)` Python tuple list every gameday**, even though `self.comps` only changes on the per-week `_ensure_comps` swap.
2. **The new `comps p25` / `comps p75` quantile pair ran through `DataFrame.groupby('player').apply(_weighted_q)`** — a per-group `apply` is the dominant cost (~150ms per gameday on NFL-shaped data, ~14× the rest of the block combined).

## Changes (commit `e545f93`)

* `Stats._comp_pairs()` — builds the static `(player, comp, position, dist, weight)` DataFrame once per comp-pool swap, cached on `_comp_pairs_cache[_current_comps_key]`. The per-gameday work in `base_profile` and `get_stats` becomes an `isin` / `map` against `_all_mean` instead of a Python loop over `self.comps.values()`.
* `Stats._vectorized_weighted_quantiles()` — replaces the per-group `apply` with a single sort + cumsum + `np.interp` pass over the already-sorted frame.
* Both consumers (`base_profile` comp block, `get_stats` non-MLB matchup-conditional block) refactored to read from the cached pairs frame.

## Correctness

Verified bit-for-bit against the previous logic on a synthetic NFL-shaped dataset (414 players, 4 positions, ~12 comps/player). `comps mean`, `comps mean (EB)`, `comps p25`, `comps p75` all match within 1e-12 absolute / 1e-10 relative tolerance.

MLB's `{"pitchers": [...], "hitters": [...]}` comp shape returns an empty frame from `_comp_pairs` and the MLB branch in `get_stats` is unchanged — it still operates directly on `self.comps`. NFL / NBA / WNBA / NHL all share the `{position: {player: {"comps": [...], "distances": [...]}}}` shape and route through the cache.

## Measured speedup

NFL gameday scale (414 players, ~5500 comp pairs, 50 gamedays under one comp pool):

| | original | optimized | speedup |
|---|---|---|---|
| `base_profile` comp block | 144.5 ms/day | 9.8 ms/day | **14.7×** |
| pairs DataFrame rebuilds | 50/run | 1/run | — |

## Pre-existing CI cleanup (commits `90d25e6`, `485a08a`)

The `quality` job on this PR's first run failed on lint + format drift that exists on `model-research` independently of this PR. Confirmed by checking out `origin/model-research` and reproducing the same 3 lint errors and 16 format-check failures — none in `stats/base.py`.

* **`90d25e6`** — pure `ruff check --fix` + `ruff format` output: 3 auto-fixes (`RUF046`, `RUF022`, `I001`) and 16 reflows. No semantic changes.
* **`485a08a`** — restores `statsmodels = "^0.14.6"` to `pyproject.toml`. Added in c177794 alongside `scripts/zinb_routing_diagnostics.py` (which imports it at module level), then silently dropped in a later commit; the script's golden test fails on collection without it. Was latent until the cleanup commit let the test stage actually run.

## Test plan

- [x] `poetry run ruff check src/ tests/` clean
- [x] `poetry run ruff format --check src/ tests/` clean
- [x] `poetry run pytest tests/golden/` — 234 passed, 6 skipped
- [x] `poetry run pytest -m integration` — 1 passed, 10 skipped
- [ ] Spot-check a `meditate` run for one NFL market and confirm training-matrix output is byte-identical to the prior commit
- [ ] Confirm the per-gameday cost drop is reflected in the `line_profiler` output on `base_profile` / `profile_market`