### PR TITLE
Harden stats.nba.com access in StatsNBA/StatsWNBA

### DIFF
--- a/src/sportstradamus/stats/nba.py
+++ b/src/sportstradamus/stats/nba.py
@@ -7,7 +7,6 @@ import pickle
 import warnings
 from datetime import datetime, timedelta
 from io import StringIO
-from time import sleep
 
 import line_profiler
 import nba_api.stats.endpoints as nba
@@ -35,19 +34,13 @@ from sportstradamus.helpers import (
 )
 from sportstradamus.helpers.io import read_gamelog, write_gamelog
 from sportstradamus.spiderLogger import logger
+from sportstradamus.stats import nba_client
 from sportstradamus.stats.base import Stats, archive, clean_data, scraper
+from sportstradamus.stats.nba_client import NBAStatsError
 
 
 class StatsNBA(Stats):
-    """A class for handling and analyzing NBA statistics.
-    Inherits from the Stats parent class.
-
-    Additional Attributes:
-        None
-
-    Additional Methods:
-        None
-    """
+    """NBA player statistics: game log loading, feature engineering, and prediction."""
 
     def __init__(self):
         """Initialize the StatsNBA class."""
@@ -376,7 +369,7 @@ class StatsNBA(Stats):
         self.tiebreaker_stat = "USG_PCT short"
         self._volume_model_cache = None
 
-    def load(self):
+    def load(self) -> None:
         """Load data from files."""
         nba_data = read_gamelog("nba")
         self.players = nba_data["players"]
@@ -510,7 +503,7 @@ class StatsNBA(Stats):
 
         self.comps = comps
 
-    def update(self):
+    def update(self) -> None:
         """Update data from the web API."""
         # Fix corrupted POS values (integer 0 or None) from prior fillna(0) bug
         # Step 1: Clean self.players — try to resolve from other seasons/teams
@@ -569,125 +562,70 @@ class StatsNBA(Stats):
             },
             inplace=True,
         )
-        i = 0
-        while i < 10:
-            try:
-                with tqdm(
-                    total=8, desc="NBA league endpoints", unit="endpoint", leave=False
-                ) as pbar:
-                    pbar.set_postfix_str("PlayerBioStats")
-                    playerBios = nba.leaguedashplayerbiostats.LeagueDashPlayerBioStats(
-                        season=self.season
-                    ).get_normalized_dict()["LeagueDashPlayerBioStats"]
-                    pbar.update(1)
 
-                    pbar.set_postfix_str("ShotLocations")
-                    shotData = nba.leaguedashplayershotlocations.LeagueDashPlayerShotLocations(
-                        **{
-                            "season": self.season,
-                            "season_type_all_star": "Regular Season",
-                            "distance_range": "By Zone",
-                            "per_mode_detailed": "PerGame",
-                        }
-                    ).get_dict()["resultSets"]
-                    pbar.update(1)
+        def _synergy(play_type: str) -> dict:
+            return nba_client.fetch(
+                nba.synergyplaytypes.SynergyPlayTypes,
+                league_id="00",
+                season=self.season,
+                season_type_all_star="Regular Season",
+                per_mode_simple="PerGame",
+                player_or_team_abbreviation="P",
+                type_grouping_nullable="offensive",
+                play_type_nullable=play_type,
+            ).get_dict()["resultSets"][0]
 
-                    pbar.set_postfix_str("Synergy:Postup")
-                    postup = nba.synergyplaytypes.SynergyPlayTypes(
-                        **{
-                            "league_id": "00",
-                            "season": self.season,
-                            "season_type_all_star": "Regular Season",
-                            "per_mode_simple": "PerGame",
-                            "player_or_team_abbreviation": "P",
-                            "type_grouping_nullable": "offensive",
-                            "play_type_nullable": "Postup",
-                        }
-                    ).get_dict()["resultSets"][0]
-                    pbar.update(1)
+        try:
+            with tqdm(total=8, desc="NBA league endpoints", unit="endpoint", leave=False) as pbar:
+                pbar.set_postfix_str("PlayerBioStats")
+                playerBios = nba_client.fetch(
+                    nba.leaguedashplayerbiostats.LeagueDashPlayerBioStats,
+                    season=self.season,
+                ).get_normalized_dict()["LeagueDashPlayerBioStats"]
+                pbar.update(1)
 
-                    pbar.set_postfix_str("Synergy:Handoff")
-                    handoff = nba.synergyplaytypes.SynergyPlayTypes(
-                        **{
-                            "league_id": "00",
-                            "season": self.season,
-                            "season_type_all_star": "Regular Season",
-                            "per_mode_simple": "PerGame",
-                            "player_or_team_abbreviation": "P",
-                            "type_grouping_nullable": "offensive",
-                            "play_type_nullable": "Handoff",
-                        }
-                    ).get_dict()["resultSets"][0]
-                    pbar.update(1)
+                pbar.set_postfix_str("ShotLocations")
+                shotData = nba_client.fetch(
+                    nba.leaguedashplayershotlocations.LeagueDashPlayerShotLocations,
+                    season=self.season,
+                    season_type_all_star="Regular Season",
+                    distance_range="By Zone",
+                    per_mode_detailed="PerGame",
+                ).get_dict()["resultSets"]
+                pbar.update(1)
 
-                    pbar.set_postfix_str("Synergy:Isolation")
-                    isolation = nba.synergyplaytypes.SynergyPlayTypes(
-                        **{
-                            "league_id": "00",
-                            "season": self.season,
-                            "season_type_all_star": "Regular Season",
-                            "per_mode_simple": "PerGame",
-                            "player_or_team_abbreviation": "P",
-                            "type_grouping_nullable": "offensive",
-                            "play_type_nullable": "Isolation",
-                        }
-                    ).get_dict()["resultSets"][0]
-                    pbar.update(1)
+                pbar.set_postfix_str("Synergy:Postup")
+                postup = _synergy("Postup")
+                pbar.update(1)
 
-                    pbar.set_postfix_str("Synergy:PRBallHandler")
-                    picknroll = nba.synergyplaytypes.SynergyPlayTypes(
-                        **{
-                            "league_id": "00",
-                            "season": self.season,
-                            "season_type_all_star": "Regular Season",
-                            "per_mode_simple": "PerGame",
-                            "player_or_team_abbreviation": "P",
-                            "type_grouping_nullable": "offensive",
-                            "play_type_nullable": "PRBallHandler",
-                        }
-                    ).get_dict()["resultSets"][0]
-                    pbar.update(1)
+                pbar.set_postfix_str("Synergy:Handoff")
+                handoff = _synergy("Handoff")
+                pbar.update(1)
 
-                    pbar.set_postfix_str("Synergy:Spotup")
-                    spotup = nba.synergyplaytypes.SynergyPlayTypes(
-                        **{
-                            "league_id": "00",
-                            "season": self.season,
-                            "season_type_all_star": "Regular Season",
-                            "per_mode_simple": "PerGame",
-                            "player_or_team_abbreviation": "P",
-                            "type_grouping_nullable": "offensive",
-                            "play_type_nullable": "Spotup",
-                        }
-                    ).get_dict()["resultSets"][0]
-                    pbar.update(1)
+                pbar.set_postfix_str("Synergy:Isolation")
+                isolation = _synergy("Isolation")
+                pbar.update(1)
 
-                    pbar.set_postfix_str("Synergy:OffRebound")
-                    putback = nba.synergyplaytypes.SynergyPlayTypes(
-                        **{
-                            "league_id": "00",
-                            "season": self.season,
-                            "season_type_all_star": "Regular Season",
-                            "per_mode_simple": "PerGame",
-                            "player_or_team_abbreviation": "P",
-                            "type_grouping_nullable": "offensive",
-                            "play_type_nullable": "OffRebound",
-                        }
-                    ).get_dict()["resultSets"][0]
-                    pbar.update(1)
-                break
-            except Exception as e:
-                logger.warning("NBA league endpoint fetch failed (attempt %d/10): %s", i + 1, e)
-                playerBios = []
-                shotData = {"rowSet": [], "headers": [{}, {"columnNames": []}]}
-                postup = {"rowSet": [], "headers": []}
-                handoff = {"rowSet": [], "headers": []}
-                isolation = {"rowSet": [], "headers": []}
-                picknroll = {"rowSet": [], "headers": []}
-                spotup = {"rowSet": [], "headers": []}
-                putback = {"rowSet": [], "headers": []}
-                sleep(0.1)
-                i = i + 1
+                pbar.set_postfix_str("Synergy:PRBallHandler")
+                picknroll = _synergy("PRBallHandler")
+                pbar.update(1)
+
+                pbar.set_postfix_str("Synergy:Spotup")
+                spotup = _synergy("Spotup")
+                pbar.update(1)
+
+                pbar.set_postfix_str("Synergy:OffRebound")
+                putback = _synergy("OffRebound")
+                pbar.update(1)
+        except NBAStatsError:
+            playerBios = []
+            shotData = {"rowSet": [], "headers": [{}, {"columnNames": []}]}
+            postup = {"rowSet": [], "headers": []}
+            handoff = {"rowSet": [], "headers": []}
+            isolation = {"rowSet": [], "headers": []}
+            picknroll = {"rowSet": [], "headers": []}
+            spotup = {"rowSet": [], "headers": []}
+            putback = {"rowSet": [], "headers": []}
 
         playerBios = pd.DataFrame(playerBios)
         shotData = pd.DataFrame(shotData["rowSet"], columns=shotData["headers"][1]["columnNames"])
@@ -893,7 +831,7 @@ class StatsNBA(Stats):
                         "Home": True,
                     }
 
-        except:
+        except Exception:
             pass
 
         params = {
@@ -909,150 +847,102 @@ class StatsNBA(Stats):
         teamlog = []
         sco_teamlog = []
         adv_teamlog = []
-        i = 0
         include_playin = (today.month == 4) or (today - latest_date).days > 150
         include_playoffs = (4 <= today.month <= 6) or (today - latest_date).days > 150
         total_gamelog_calls = 6 + (6 if include_playin else 0) + (6 if include_playoffs else 0)
 
-        while i < 10:
-            try:
-                with tqdm(
-                    total=total_gamelog_calls,
-                    desc="NBA player/team gamelogs",
-                    unit="endpoint",
-                    leave=False,
-                ) as pbar:
-                    pbar.set_postfix_str("PlayerGameLogs:Base")
-                    nba_gamelog = nba.playergamelogs.PlayerGameLogs(**params).get_normalized_dict()[
-                        "PlayerGameLogs"
-                    ]
+        def _player_logs(measure: str | None = None) -> list:
+            extra = {} if measure is None else {"measure_type_player_game_logs_nullable": measure}
+            return nba_client.fetch(
+                nba.playergamelogs.PlayerGameLogs, **(params | extra)
+            ).get_normalized_dict()["PlayerGameLogs"]
+
+        def _team_logs(measure: str | None = None) -> list:
+            extra = {} if measure is None else {"measure_type_player_game_logs_nullable": measure}
+            return nba_client.fetch(
+                nba.teamgamelogs.TeamGameLogs, **(params | extra)
+            ).get_normalized_dict()["TeamGameLogs"]
+
+        try:
+            with tqdm(
+                total=total_gamelog_calls,
+                desc="NBA player/team gamelogs",
+                unit="endpoint",
+                leave=False,
+            ) as pbar:
+                pbar.set_postfix_str("PlayerGameLogs:Base")
+                nba_gamelog = _player_logs()
+                pbar.update(1)
+
+                pbar.set_postfix_str("PlayerGameLogs:Advanced")
+                adv_gamelog = _player_logs("Advanced")
+                pbar.update(1)
+
+                pbar.set_postfix_str("PlayerGameLogs:Usage")
+                usg_gamelog = _player_logs("Usage")
+                pbar.update(1)
+
+                pbar.set_postfix_str("TeamGameLogs:Base")
+                teamlog = _team_logs()
+                pbar.update(1)
+
+                pbar.set_postfix_str("TeamGameLogs:Scoring")
+                sco_teamlog = _team_logs("Scoring")
+                pbar.update(1)
+
+                pbar.set_postfix_str("TeamGameLogs:Advanced")
+                adv_teamlog = _team_logs("Advanced")
+                pbar.update(1)
+
+                # Fetch playoffs game logs
+                if include_playin:
+                    params.update({"season_type_nullable": "PlayIn"})
+                    pbar.set_postfix_str("PlayIn:PlayerGameLogs:Base")
+                    nba_gamelog.extend(_player_logs())
                     pbar.update(1)
-
-                    pbar.set_postfix_str("PlayerGameLogs:Advanced")
-                    adv_gamelog = nba.playergamelogs.PlayerGameLogs(
-                        **(params | {"measure_type_player_game_logs_nullable": "Advanced"})
-                    ).get_normalized_dict()["PlayerGameLogs"]
+                    pbar.set_postfix_str("PlayIn:PlayerGameLogs:Advanced")
+                    adv_gamelog.extend(_player_logs("Advanced"))
                     pbar.update(1)
-
-                    pbar.set_postfix_str("PlayerGameLogs:Usage")
-                    usg_gamelog = nba.playergamelogs.PlayerGameLogs(
-                        **(params | {"measure_type_player_game_logs_nullable": "Usage"})
-                    ).get_normalized_dict()["PlayerGameLogs"]
+                    pbar.set_postfix_str("PlayIn:PlayerGameLogs:Usage")
+                    usg_gamelog.extend(_player_logs("Usage"))
                     pbar.update(1)
-
-                    pbar.set_postfix_str("TeamGameLogs:Base")
-                    teamlog = nba.teamgamelogs.TeamGameLogs(**(params)).get_normalized_dict()[
-                        "TeamGameLogs"
-                    ]
+                    pbar.set_postfix_str("PlayIn:TeamGameLogs:Base")
+                    teamlog.extend(_team_logs())
                     pbar.update(1)
-
-                    pbar.set_postfix_str("TeamGameLogs:Scoring")
-                    sco_teamlog = nba.teamgamelogs.TeamGameLogs(
-                        **(params | {"measure_type_player_game_logs_nullable": "Scoring"})
-                    ).get_normalized_dict()["TeamGameLogs"]
+                    pbar.set_postfix_str("PlayIn:TeamGameLogs:Scoring")
+                    sco_teamlog.extend(_team_logs("Scoring"))
                     pbar.update(1)
-
-                    pbar.set_postfix_str("TeamGameLogs:Advanced")
-                    adv_teamlog = nba.teamgamelogs.TeamGameLogs(
-                        **(params | {"measure_type_player_game_logs_nullable": "Advanced"})
-                    ).get_normalized_dict()["TeamGameLogs"]
+                    pbar.set_postfix_str("PlayIn:TeamGameLogs:Advanced")
+                    adv_teamlog.extend(_team_logs("Advanced"))
                     pbar.update(1)
-
-                    # Fetch playoffs game logs
-                    if include_playin:
-                        params.update({"season_type_nullable": "PlayIn"})
-                        pbar.set_postfix_str("PlayIn:PlayerGameLogs:Base")
-                        nba_gamelog.extend(
-                            nba.playergamelogs.PlayerGameLogs(**params).get_normalized_dict()[
-                                "PlayerGameLogs"
-                            ]
-                        )
-                        pbar.update(1)
-                        pbar.set_postfix_str("PlayIn:PlayerGameLogs:Advanced")
-                        adv_gamelog.extend(
-                            nba.playergamelogs.PlayerGameLogs(
-                                **(params | {"measure_type_player_game_logs_nullable": "Advanced"})
-                            ).get_normalized_dict()["PlayerGameLogs"]
-                        )
-                        pbar.update(1)
-                        pbar.set_postfix_str("PlayIn:PlayerGameLogs:Usage")
-                        usg_gamelog.extend(
-                            nba.playergamelogs.PlayerGameLogs(
-                                **(params | {"measure_type_player_game_logs_nullable": "Usage"})
-                            ).get_normalized_dict()["PlayerGameLogs"]
-                        )
-                        pbar.update(1)
-                        pbar.set_postfix_str("PlayIn:TeamGameLogs:Base")
-                        teamlog.extend(
-                            nba.teamgamelogs.TeamGameLogs(**(params)).get_normalized_dict()[
-                                "TeamGameLogs"
-                            ]
-                        )
-                        pbar.update(1)
-                        pbar.set_postfix_str("PlayIn:TeamGameLogs:Scoring")
-                        sco_teamlog.extend(
-                            nba.teamgamelogs.TeamGameLogs(
-                                **(params | {"measure_type_player_game_logs_nullable": "Scoring"})
-                            ).get_normalized_dict()["TeamGameLogs"]
-                        )
-                        pbar.update(1)
-                        pbar.set_postfix_str("PlayIn:TeamGameLogs:Advanced")
-                        adv_teamlog.extend(
-                            nba.teamgamelogs.TeamGameLogs(
-                                **(params | {"measure_type_player_game_logs_nullable": "Advanced"})
-                            ).get_normalized_dict()["TeamGameLogs"]
-                        )
-                        pbar.update(1)
-                    if include_playoffs:
-                        params.update({"season_type_nullable": "Playoffs"})
-                        pbar.set_postfix_str("Playoffs:PlayerGameLogs:Base")
-                        nba_gamelog.extend(
-                            nba.playergamelogs.PlayerGameLogs(**params).get_normalized_dict()[
-                                "PlayerGameLogs"
-                            ]
-                        )
-                        pbar.update(1)
-                        pbar.set_postfix_str("Playoffs:PlayerGameLogs:Advanced")
-                        adv_gamelog.extend(
-                            nba.playergamelogs.PlayerGameLogs(
-                                **(params | {"measure_type_player_game_logs_nullable": "Advanced"})
-                            ).get_normalized_dict()["PlayerGameLogs"]
-                        )
-                        pbar.update(1)
-                        pbar.set_postfix_str("Playoffs:PlayerGameLogs:Usage")
-                        usg_gamelog.extend(
-                            nba.playergamelogs.PlayerGameLogs(
-                                **(params | {"measure_type_player_game_logs_nullable": "Usage"})
-                            ).get_normalized_dict()["PlayerGameLogs"]
-                        )
-                        pbar.update(1)
-                        pbar.set_postfix_str("Playoffs:TeamGameLogs:Base")
-                        teamlog.extend(
-                            nba.teamgamelogs.TeamGameLogs(**(params)).get_normalized_dict()[
-                                "TeamGameLogs"
-                            ]
-                        )
-                        pbar.update(1)
-                        pbar.set_postfix_str("Playoffs:TeamGameLogs:Scoring")
-                        sco_teamlog.extend(
-                            nba.teamgamelogs.TeamGameLogs(
-                                **(params | {"measure_type_player_game_logs_nullable": "Scoring"})
-                            ).get_normalized_dict()["TeamGameLogs"]
-                        )
-                        pbar.update(1)
-                        pbar.set_postfix_str("Playoffs:TeamGameLogs:Advanced")
-                        adv_teamlog.extend(
-                            nba.teamgamelogs.TeamGameLogs(
-                                **(params | {"measure_type_player_game_logs_nullable": "Advanced"})
-                            ).get_normalized_dict()["TeamGameLogs"]
-                        )
-                        pbar.update(1)
-
-                break
-            except Exception as e:
-                logger.warning("NBA gamelog fetch failed (attempt %d/10): %s", i + 1, e)
-                sleep(0.2)
-                i += 1
+                if include_playoffs:
+                    params.update({"season_type_nullable": "Playoffs"})
+                    pbar.set_postfix_str("Playoffs:PlayerGameLogs:Base")
+                    nba_gamelog.extend(_player_logs())
+                    pbar.update(1)
+                    pbar.set_postfix_str("Playoffs:PlayerGameLogs:Advanced")
+                    adv_gamelog.extend(_player_logs("Advanced"))
+                    pbar.update(1)
+                    pbar.set_postfix_str("Playoffs:PlayerGameLogs:Usage")
+                    usg_gamelog.extend(_player_logs("Usage"))
+                    pbar.update(1)
+                    pbar.set_postfix_str("Playoffs:TeamGameLogs:Base")
+                    teamlog.extend(_team_logs())
+                    pbar.update(1)
+                    pbar.set_postfix_str("Playoffs:TeamGameLogs:Scoring")
+                    sco_teamlog.extend(_team_logs("Scoring"))
+                    pbar.update(1)
+                    pbar.set_postfix_str("Playoffs:TeamGameLogs:Advanced")
+                    adv_teamlog.extend(_team_logs("Advanced"))
+                    pbar.update(1)
+        except NBAStatsError:
+            # All-or-nothing: a partial pull would mix populated and empty logs.
+            nba_gamelog = []
+            adv_gamelog = []
+            usg_gamelog = []
+            teamlog = []
+            sco_teamlog = []
+            adv_teamlog = []
 
         adv_teamlog_idx = {(g["TEAM_ID"], g["GAME_ID"]): g for g in adv_teamlog}
         sco_teamlog_idx = {(g["TEAM_ID"], g["GAME_ID"]): g for g in sco_teamlog}
@@ -1159,11 +1049,13 @@ class StatsNBA(Stats):
                 if position is None:
                     try:
                         position = (
-                            nba.commonplayerinfo.CommonPlayerInfo(player_id=player_id)
+                            nba_client.fetch(
+                                nba.commonplayerinfo.CommonPlayerInfo, player_id=player_id
+                            )
                             .get_normalized_dict()["CommonPlayerInfo"][0]
                             .get("POSITION")
                         )
-                    except:
+                    except NBAStatsError:
                         position = "Forward-Guard"
                     position = position_map.get(position, "W")
 

--- a/src/sportstradamus/stats/nba_client.py
+++ b/src/sportstradamus/stats/nba_client.py
@@ -1,0 +1,94 @@
+"""Hardened transport wrapper for the stats.nba.com API.
+
+``stats.nba.com`` (reached through the ``nba_api`` library) is notoriously flaky
+from server and cloud hosts: it rejects or stalls requests that lack the right
+browser headers, and it hangs connections rather than refusing them. The library
+accepts per-request ``headers``, ``timeout``, and ``proxy`` arguments but applies
+none of them by default. This module centralizes the known-good header set, a
+real read timeout, and exponential-backoff retry logic so that ``StatsNBA`` and
+``StatsWNBA`` can make one flat call per endpoint instead of hand-rolling a
+silent ``while`` retry loop around every block.
+"""
+
+import random
+from time import sleep
+
+from sportstradamus.spiderLogger import logger
+
+# Header set documented by the nba_api project as the one stats.nba.com accepts;
+# requests without Referer/Origin/x-nba-stats-* are silently dropped or stalled.
+NBA_STATS_HEADERS: dict[str, str] = {
+    "Host": "stats.nba.com",
+    "User-Agent": (
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+        "(KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+    ),
+    "Accept": "application/json, text/plain, */*",
+    "Accept-Language": "en-US,en;q=0.9",
+    "Accept-Encoding": "gzip, deflate, br",
+    "Connection": "keep-alive",
+    "Referer": "https://www.nba.com/",
+    "Origin": "https://www.nba.com",
+    "x-nba-stats-origin": "stats",
+    "x-nba-stats-token": "true",
+}
+
+# Per-request read timeout (seconds). The endpoints are slow but should never
+# take a minute; a real timeout turns a hung connection into a fast retry
+# instead of blocking the whole update pipeline indefinitely.
+NBA_STATS_TIMEOUT: int = 60
+
+# Total tries per endpoint before giving up and raising NBAStatsError.
+NBA_MAX_ATTEMPTS: int = 5
+
+# Exponential backoff between retries: NBA_BACKOFF_BASE * 2**(attempt - 1),
+# capped at NBA_BACKOFF_CAP, plus jitter. Replaces the old flat 0.1s sleep that
+# hammered a rate-limiting server instead of backing off.
+NBA_BACKOFF_BASE: float = 1.0
+NBA_BACKOFF_CAP: float = 16.0
+
+
+class NBAStatsError(Exception):
+    """Raised when a stats.nba.com endpoint fails every retry attempt."""
+
+
+def fetch(endpoint_cls: type, **params: object) -> object:
+    """Construct an ``nba_api`` endpoint with hardened transport, retrying.
+
+    The HTTP request happens inside the endpoint constructor, so the constructed
+    instance is what the caller wants — call ``.get_normalized_dict()`` or
+    ``.get_dict()`` on the return value. Headers and a read timeout are injected
+    on every attempt; failures are logged and retried with exponential backoff.
+
+    Args:
+        endpoint_cls: An ``nba_api.stats.endpoints`` class (e.g.
+            ``PlayerGameLogs``). Not an instance — this function instantiates it.
+        **params: Endpoint-specific query parameters passed straight through.
+
+    Returns:
+        The constructed endpoint instance, with its HTTP request already made.
+
+    Raises:
+        NBAStatsError: If every one of ``NBA_MAX_ATTEMPTS`` tries fails.
+    """
+    name = endpoint_cls.__name__
+    for attempt in range(1, NBA_MAX_ATTEMPTS + 1):
+        try:
+            return endpoint_cls(
+                headers=NBA_STATS_HEADERS,
+                timeout=NBA_STATS_TIMEOUT,
+                **params,
+            )
+        except Exception as exc:
+            logger.warning(
+                "stats.nba.com %s failed (attempt %d/%d): %s",
+                name,
+                attempt,
+                NBA_MAX_ATTEMPTS,
+                exc,
+            )
+            if attempt < NBA_MAX_ATTEMPTS:
+                backoff = min(NBA_BACKOFF_BASE * 2 ** (attempt - 1), NBA_BACKOFF_CAP)
+                sleep(backoff + random.uniform(0, 1))
+
+    raise NBAStatsError(f"{name} failed after {NBA_MAX_ATTEMPTS} attempts")

--- a/src/sportstradamus/stats/wnba.py
+++ b/src/sportstradamus/stats/wnba.py
@@ -5,7 +5,6 @@ import json
 import warnings
 from datetime import datetime, timedelta
 from io import StringIO
-from time import sleep
 
 import line_profiler
 import nba_api.stats.endpoints as nba
@@ -33,8 +32,10 @@ from sportstradamus.helpers import (
 )
 from sportstradamus.helpers.io import read_gamelog, write_gamelog
 from sportstradamus.spiderLogger import logger
+from sportstradamus.stats import nba_client
 from sportstradamus.stats.base import Stats, archive, clean_data, scraper
 from sportstradamus.stats.nba import StatsNBA
+from sportstradamus.stats.nba_client import NBAStatsError
 
 
 class StatsWNBA(StatsNBA):
@@ -69,56 +70,49 @@ class StatsWNBA(StatsNBA):
 
         pos_map = {"G-F": "G", "F-G": "F", "F-C": "C"}
 
-        i = 0
-        while i < 10:
-            try:
-                player_df = nba.playerindex.PlayerIndex(
-                    season=self.season_start.year, league_id="10", historical_nullable=1
-                ).get_normalized_dict()["PlayerIndex"]
-                player_df = pd.DataFrame(player_df).rename(
-                    columns={"POSITION": "POS", "Position": "POS", "PERSON_ID": "PLAYER_ID"}
-                )
-                player_df.TEAM_ABBREVIATION = player_df.TEAM_ABBREVIATION.apply(
-                    lambda x: team_abbr_map.get(x, x)
-                )
-                player_df.POS = player_df.POS.apply(lambda x: pos_map.get(x, x))
-                break
-            except:
-                player_df = pd.DataFrame(
-                    columns=["PLAYER_ID", "PLAYER_NAME", "TEAM_ABBREVIATION", "POS"]
-                )
+        try:
+            player_df = nba_client.fetch(
+                nba.playerindex.PlayerIndex,
+                season=self.season_start.year,
+                league_id="10",
+                historical_nullable=1,
+            ).get_normalized_dict()["PlayerIndex"]
+            player_df = pd.DataFrame(player_df).rename(
+                columns={"POSITION": "POS", "Position": "POS", "PERSON_ID": "PLAYER_ID"}
+            )
+            player_df.TEAM_ABBREVIATION = player_df.TEAM_ABBREVIATION.apply(
+                lambda x: team_abbr_map.get(x, x)
+            )
+            player_df.POS = player_df.POS.apply(lambda x: pos_map.get(x, x))
+        except NBAStatsError:
+            player_df = pd.DataFrame(
+                columns=["PLAYER_ID", "PLAYER_NAME", "TEAM_ABBREVIATION", "POS"]
+            )
 
-            sleep(0.1)
-            i = i + 1
+        try:
+            playerBios = nba_client.fetch(
+                nba.leaguedashplayerbiostats.LeagueDashPlayerBioStats,
+                season=self.season_start.year,
+                league_id="10",
+            ).get_normalized_dict()["LeagueDashPlayerBioStats"]
 
-        i = 0
-        while i < 10:
-            try:
-                playerBios = nba.leaguedashplayerbiostats.LeagueDashPlayerBioStats(
-                    season=self.season_start.year, league_id="10"
-                ).get_normalized_dict()["LeagueDashPlayerBioStats"]
-
-                shotData = nba.leaguedashplayershotlocations.LeagueDashPlayerShotLocations(
-                    **{
-                        "season": self.season_start.year,
-                        "league_id_nullable": "10",
-                        "season_type_all_star": "Regular Season",
-                        "distance_range": "By Zone",
-                        "per_mode_detailed": "Per40",
-                    }
-                ).get_dict()["resultSets"]
-                break
-            except:
-                playerBios = {
-                    "PLAYER_NAME": [],
-                    "PLAYER_ID": [],
-                    "PLAYER_HEIGHT_INCHES": [],
-                    "PLAYER_WEIGHT": [],
-                    "TEAM_ABBREVIATION": [],
-                }
-                shotData = {"rowSet": []}
-                sleep(0.1)
-                i = i + 1
+            shotData = nba_client.fetch(
+                nba.leaguedashplayershotlocations.LeagueDashPlayerShotLocations,
+                season=self.season_start.year,
+                league_id_nullable="10",
+                season_type_all_star="Regular Season",
+                distance_range="By Zone",
+                per_mode_detailed="Per40",
+            ).get_dict()["resultSets"]
+        except NBAStatsError:
+            playerBios = {
+                "PLAYER_NAME": [],
+                "PLAYER_ID": [],
+                "PLAYER_HEIGHT_INCHES": [],
+                "PLAYER_WEIGHT": [],
+                "TEAM_ABBREVIATION": [],
+            }
+            shotData = {"rowSet": []}
 
         playerBios = pd.DataFrame(playerBios)
         if not playerBios.empty:
@@ -143,7 +137,6 @@ class StatsWNBA(StatsNBA):
                 on=["PLAYER_NAME", "TEAM_ABBREVIATION"],
                 suffixes=(None, "_y"),
             )
-            # list(player_df.loc[player_df.isna().any(axis=1)].index.unique()) TODO handle these names
             player_df.PLAYER_WEIGHT = player_df.PLAYER_WEIGHT.astype(float)
             player_df.POS = player_df.POS.str[0]
             player_df.index = player_df.PLAYER_NAME
@@ -231,9 +224,9 @@ class StatsWNBA(StatsNBA):
             "date_to_nullable": today.strftime("%m/%d/%Y"),
         }
 
-        # Pre-init so a fully-failed retry loop falls through to the empty-list
-        # guard at line 296 instead of raising UnboundLocalError. Mirrors the
-        # NBA pattern in stats/nba.py around the identical retry loop.
+        # Pre-init so the except-NBAStatsError branch and the empty-list guard
+        # below have defined names even if the first fetch raises. Mirrors the
+        # NBA pattern in stats/nba.py around the identical gamelog fetch.
         nba_gamelog: list = []
         adv_gamelog: list = []
         usg_gamelog: list = []
@@ -241,67 +234,43 @@ class StatsWNBA(StatsNBA):
         sco_teamlog: list = []
         adv_teamlog: list = []
 
-        i = 0
+        def _player_logs(measure: str | None = None) -> list:
+            extra = {} if measure is None else {"measure_type_player_game_logs_nullable": measure}
+            return nba_client.fetch(
+                nba.playergamelogs.PlayerGameLogs, **(params | extra)
+            ).get_normalized_dict()["PlayerGameLogs"]
 
-        while i < 10:
-            try:
-                nba_gamelog = nba.playergamelogs.PlayerGameLogs(**params).get_normalized_dict()[
-                    "PlayerGameLogs"
-                ]
-                adv_gamelog = nba.playergamelogs.PlayerGameLogs(
-                    **(params | {"measure_type_player_game_logs_nullable": "Advanced"})
-                ).get_normalized_dict()["PlayerGameLogs"]
-                usg_gamelog = nba.playergamelogs.PlayerGameLogs(
-                    **(params | {"measure_type_player_game_logs_nullable": "Usage"})
-                ).get_normalized_dict()["PlayerGameLogs"]
-                teamlog = nba.teamgamelogs.TeamGameLogs(**(params)).get_normalized_dict()[
-                    "TeamGameLogs"
-                ]
-                sco_teamlog = nba.teamgamelogs.TeamGameLogs(
-                    **(params | {"measure_type_player_game_logs_nullable": "Scoring"})
-                ).get_normalized_dict()["TeamGameLogs"]
-                adv_teamlog = nba.teamgamelogs.TeamGameLogs(
-                    **(params | {"measure_type_player_game_logs_nullable": "Advanced"})
-                ).get_normalized_dict()["TeamGameLogs"]
+        def _team_logs(measure: str | None = None) -> list:
+            extra = {} if measure is None else {"measure_type_player_game_logs_nullable": measure}
+            return nba_client.fetch(
+                nba.teamgamelogs.TeamGameLogs, **(params | extra)
+            ).get_normalized_dict()["TeamGameLogs"]
 
-                # Fetch playoffs game logs
-                if (today.month >= 9) or (today - latest_date).days > 150:
-                    params.update({"season_type_nullable": "Playoffs"})
-                    nba_gamelog.extend(
-                        nba.playergamelogs.PlayerGameLogs(**params).get_normalized_dict()[
-                            "PlayerGameLogs"
-                        ]
-                    )
-                    adv_gamelog.extend(
-                        nba.playergamelogs.PlayerGameLogs(
-                            **(params | {"measure_type_player_game_logs_nullable": "Advanced"})
-                        ).get_normalized_dict()["PlayerGameLogs"]
-                    )
-                    usg_gamelog.extend(
-                        nba.playergamelogs.PlayerGameLogs(
-                            **(params | {"measure_type_player_game_logs_nullable": "Usage"})
-                        ).get_normalized_dict()["PlayerGameLogs"]
-                    )
-                    teamlog.extend(
-                        nba.teamgamelogs.TeamGameLogs(**(params)).get_normalized_dict()[
-                            "TeamGameLogs"
-                        ]
-                    )
-                    sco_teamlog.extend(
-                        nba.teamgamelogs.TeamGameLogs(
-                            **(params | {"measure_type_player_game_logs_nullable": "Scoring"})
-                        ).get_normalized_dict()["TeamGameLogs"]
-                    )
-                    adv_teamlog.extend(
-                        nba.teamgamelogs.TeamGameLogs(
-                            **(params | {"measure_type_player_game_logs_nullable": "Advanced"})
-                        ).get_normalized_dict()["TeamGameLogs"]
-                    )
+        try:
+            nba_gamelog = _player_logs()
+            adv_gamelog = _player_logs("Advanced")
+            usg_gamelog = _player_logs("Usage")
+            teamlog = _team_logs()
+            sco_teamlog = _team_logs("Scoring")
+            adv_teamlog = _team_logs("Advanced")
 
-                break
-            except:
-                sleep(0.1)
-                i += 1
+            # Fetch playoffs game logs
+            if (today.month >= 9) or (today - latest_date).days > 150:
+                params.update({"season_type_nullable": "Playoffs"})
+                nba_gamelog.extend(_player_logs())
+                adv_gamelog.extend(_player_logs("Advanced"))
+                usg_gamelog.extend(_player_logs("Usage"))
+                teamlog.extend(_team_logs())
+                sco_teamlog.extend(_team_logs("Scoring"))
+                adv_teamlog.extend(_team_logs("Advanced"))
+        except NBAStatsError:
+            # All-or-nothing: a partial pull would mix populated and empty logs.
+            nba_gamelog = []
+            adv_gamelog = []
+            usg_gamelog = []
+            teamlog = []
+            sco_teamlog = []
+            adv_teamlog = []
 
         if nba_gamelog and adv_gamelog and usg_gamelog:
             nba_gamelog.sort(key=lambda x: (x["GAME_ID"], x["PLAYER_ID"]))


### PR DESCRIPTION
## Why

`StatsNBA.update()` and `StatsWNBA.update()` pull bios, shot locations, Synergy play types, and player/team game logs from **stats.nba.com** via `nba_api`. That API is notoriously flaky from server/cloud hosts and "always takes a few tries." Root causes, all of which `nba_api` lets you control but the code never did:

- **Stale default headers** — stats.nba.com silently drops/stalls requests lacking the right `Referer`/`Origin`/`x-nba-stats-*` headers.
- **No client timeout** — a hung connection blocks the whole pipeline instead of failing fast.
- **No real backoff** — the old workaround was `while i < 10: try: …big block… except: sleep(0.1)`, which swallowed every error, re-ran the *entire* multi-call block on any single failure, and hammered a rate-limiting server.

The Advanced/Usage/Synergy data only exists on stats.nba.com, so this hardens the **direct transport** rather than switching sources. No proxy (per request).

## What

**New `src/sportstradamus/stats/nba_client.py`** — a small transport wrapper:
- Injects the documented known-good browser header set + a real read timeout (`NBA_STATS_TIMEOUT = 60`) on every endpoint.
- Retries each call **independently** with exponential backoff + jitter (`NBA_MAX_ATTEMPTS = 5`), so one flaky call no longer forces re-running the whole batch.
- Logs each failure via `logger.warning` (no bare `except`) and raises `NBAStatsError` after exhausting attempts.
- All tunables are module-level constants with reason comments.

**`nba.py` / `wnba.py`** — replaced all five hand-rolled retry blocks with flat `nba_client.fetch(...)` calls wrapped in a single `try/except NBAStatsError`, **preserving devel's `tqdm` per-endpoint progress bars** and the existing empty-data graceful degradation. Repetitive Synergy and game-log calls are collapsed behind tiny local helpers.

## Notes

- **Targets `devel`** (rebased onto it). The two files conflicted with devel's recently-added progress-bar/logging work; the resolution keeps both the progress bars and the reliability hardening.
- Includes a few in-file style fixes from the mandated `refactoring-specialist` pass (one-line class docstring, `-> None` hints, `except Exception:` on the upcoming-games block, and removal of a commented-out diagnostic line).

## Verification — run exactly as CI does (staged `tests/ci_fixtures` stubs)

- `ruff check src/ tests/` — clean
- `ruff format --check src/ tests/` — clean (136 files)
- golden tests — **177 passed, 6 skipped**
- integration smoke (fake mode) — **1 passed, 10 skipped**

https://claude.ai/code/session_01YbUoYBywSqQWPC6vtGhR8i