### PR TITLE
style + dedup (training, prediction, stats, top-level): behavior-preserving cleanup

### DIFF
--- a/src/sportstradamus/analysis.py
+++ b/src/sportstradamus/analysis.py
@@ -30,6 +30,10 @@ PAYOUT_TABLE = {
     ],
 }
 
+# Underdog applies a boost of 2x or more only to a clean entry (zero misses); a
+# boosted entry that drops a leg pays the un-boosted table value instead.
+_UNDERDOG_PERFECT_BOOST_MULT = 2
+
 TIMEFRAMES = [
     ("7d", 7),
     ("30d", 30),
@@ -37,6 +41,12 @@ TIMEFRAMES = [
     ("6m", 183),
     ("1y", 365),
 ]
+
+# Pick-quality floors for the dashboard summary splits: keep only legs the model
+# rates above _MODEL_PROB_PICK_FLOOR, and (for the "Book Filtered" split) that the
+# book also priced above _BOOK_PROB_PICK_FLOOR.
+_MODEL_PROB_PICK_FLOOR = 0.58
+_BOOK_PROB_PICK_FLOOR = 0.52
 
 
 def check_bet(bet, stats, stat_map):
@@ -206,7 +216,6 @@ def _migrate_flat_history(history):
             latest.get("Result")
             # Can't recover numeric Actual from Over/Under, but mark as resolved
             # so resolve_history will skip it if Actual is still NaN
-            pass
 
         rows.append(row)
 
@@ -422,7 +431,7 @@ def _compute_stats_row(subset, prob_col):
     sub_hit = (subset["Bet"] == subset["Result"]).astype(int)
     wins = sub_hit.sum()
     profit = wins * (100 / 110) - (len(subset) - wins)
-    row = {
+    return {
         "Accuracy": round(accuracy_score(subset["Bet"], subset["Result"]), 4),
         "Balance": round((subset["Bet"] == "Over").mean() - (subset["Result"] == "Over").mean(), 4),
         "LogLoss": round(log_loss(sub_hit, subset[prob_col].clip(0.01, 0.99), labels=[0, 1]), 4),
@@ -430,7 +439,6 @@ def _compute_stats_row(subset, prob_col):
         "ROI": round(profit / len(subset), 4),
         "Samples": len(subset),
     }
-    return row
 
 
 def compute_individual_metrics(history):
@@ -451,7 +459,7 @@ def compute_individual_metrics(history):
 
     # --- Summary table with timeframe splits ---
     rows = []
-    filtered = history.loc[history["Model"] > 0.58]
+    filtered = history.loc[history["Model"] > _MODEL_PROB_PICK_FLOOR]
 
     for tf_label, tf_days in TIMEFRAMES:
         cutoff = today - timedelta(days=tf_days)
@@ -463,7 +471,7 @@ def compute_individual_metrics(history):
             rows.append({"Period": tf_label, "Split": "All"} | r)
 
         # Book filtered
-        r = _compute_stats_row(tf_data.loc[tf_data["Books"] > 0.52], prob_col)
+        r = _compute_stats_row(tf_data.loc[tf_data["Books"] > _BOOK_PROB_PICK_FLOOR], prob_col)
         if r:
             rows.append({"Period": tf_label, "Split": "All, Book Filtered"} | r)
 
@@ -531,7 +539,9 @@ def compute_individual_metrics(history):
                 ("All", history.loc[history["_date"] >= cutoff]),
                 (
                     "Book Filtered",
-                    history.loc[(history["_date"] >= cutoff) & (history["Books"] > 0.52)],
+                    history.loc[
+                        (history["_date"] >= cutoff) & (history["Books"] > _BOOK_PROB_PICK_FLOOR)
+                    ],
                 ),
             ]:
                 t_sub = subset.loc[subset["Model"] > threshold]
@@ -590,7 +600,7 @@ def compute_parlay_metrics(parlays, stats, stat_map):
             lambda x: (
                 np.clip(
                     PAYOUT_TABLE["Underdog"][x.Legs][x.Misses]
-                    * (x.Boost if x.Boost < 2 or x.Misses == 0 else 1),
+                    * (x.Boost if x.Boost < _UNDERDOG_PERFECT_BOOST_MULT or x.Misses == 0 else 1),
                     None,
                     100,
                 )
@@ -753,8 +763,7 @@ def reconstruct_prob(row, line=None):
     r = param if dist in ("NegBin", "ZINB") else None
     alpha = param if dist in ("Gamma", "ZAGamma") else None
 
-    raw_under = get_odds(line, ev, dist, cv, alpha=alpha, r=r, gate=gate, step=step)
-    return raw_under
+    return get_odds(line, ev, dist, cv, alpha=alpha, r=r, gate=gate, step=step)
 
 
 def reconstruct_quantile(row, q):
@@ -785,14 +794,13 @@ def reconstruct_quantile(row, q):
             q_adj = (q - gate) / (1 - gate)
             return nbinom.ppf(q_adj, r, p)
         return nbinom.ppf(q, r, p)
-    else:
-        alpha = param if param is not None and not np.isnan(param) else 1 / cv**2
-        if gate is not None and dist == "ZAGamma":
-            if q <= gate:
-                return 0.0
-            q_adj = (q - gate) / (1 - gate)
-            return gamma_dist.ppf(q_adj, alpha, scale=ev / alpha)
-        return gamma_dist.ppf(q, alpha, scale=ev / alpha)
+    alpha = param if param is not None and not np.isnan(param) else 1 / cv**2
+    if gate is not None and dist == "ZAGamma":
+        if q <= gate:
+            return 0.0
+        q_adj = (q - gate) / (1 - gate)
+        return gamma_dist.ppf(q_adj, alpha, scale=ev / alpha)
+    return gamma_dist.ppf(q, alpha, scale=ev / alpha)
 
 
 def compute_crps_row(row):
@@ -838,47 +846,42 @@ def compute_crps_row(row):
 
         # CRPS = sum_k (F(k) - 1(k >= y))^2 for discrete distributions
         indicator = (k >= y).astype(float)
-        crps = np.sum((cdf - indicator) ** 2)
+        return np.sum((cdf - indicator) ** 2)
+
+    alpha = param if param is not None and not np.isnan(param) else 1 / cv**2
+    beta = alpha / ev  # rate parameter
+
+    if gate is not None and dist == "ZAGamma":
+        # ZA-Gamma CRPS: gate * |y| + (1-gate) * CRPS_gamma
+        # plus cross term for the mixture
+        # Simplified: numerical integration
+        from scipy.integrate import quad
+
+        def _cdf(x):
+            if x < 0:
+                return 0.0
+            base = gamma_dist.cdf(x, alpha, scale=1 / beta)
+            return gate + (1 - gate) * base
+
+        def integrand(x):
+            return (_cdf(x) - (1 if x >= y else 0)) ** 2
+
+        crps, _ = quad(integrand, 0, max(y, ev) * 5 + 50, limit=200)
         return crps
 
-    else:
-        alpha = param if param is not None and not np.isnan(param) else 1 / cv**2
-        beta = alpha / ev  # rate parameter
+    # Closed-form Gamma CRPS (Gneiting & Raftery 2007, eq. 21):
+    # CRPS(Gamma(alpha, beta), y) = y*(2*F(y) - 1) - alpha/beta*(2*F_a1(y) - 1)
+    #   - 1/(beta * B(0.5, alpha))
+    # where F is Gamma(alpha, beta) CDF, F_a1 is Gamma(alpha+1, beta) CDF,
+    # and B is the Beta function
+    from scipy.special import beta as beta_fn
 
-        if gate is not None and dist == "ZAGamma":
-            # ZA-Gamma CRPS: gate * |y| + (1-gate) * CRPS_gamma
-            # plus cross term for the mixture
-            # Simplified: numerical integration
-            from scipy.integrate import quad
-
-            def _cdf(x):
-                if x < 0:
-                    return 0.0
-                base = gamma_dist.cdf(x, alpha, scale=1 / beta)
-                return gate + (1 - gate) * base
-
-            def integrand(x):
-                return (_cdf(x) - (1 if x >= y else 0)) ** 2
-
-            crps, _ = quad(integrand, 0, max(y, ev) * 5 + 50, limit=200)
-            return crps
-
-        # Closed-form Gamma CRPS (Gneiting & Raftery 2007, eq. 21):
-        # CRPS(Gamma(alpha, beta), y) = y*(2*F(y) - 1) - alpha/beta*(2*F_a1(y) - 1)
-        #   - 1/(beta * B(0.5, alpha))
-        # where F is Gamma(alpha, beta) CDF, F_a1 is Gamma(alpha+1, beta) CDF,
-        # and B is the Beta function
-        from scipy.special import beta as beta_fn
-
-        scale = 1 / beta
-        cdf_y = gamma_dist.cdf(y, alpha, scale=scale)
-        cdf_y_a1 = gamma_dist.cdf(y, alpha + 1, scale=scale)
-        crps = (
-            y * (2 * cdf_y - 1)
-            - (alpha / beta) * (2 * cdf_y_a1 - 1)
-            - 1 / (beta * beta_fn(0.5, alpha))
-        )
-        return crps
+    scale = 1 / beta
+    cdf_y = gamma_dist.cdf(y, alpha, scale=scale)
+    cdf_y_a1 = gamma_dist.cdf(y, alpha + 1, scale=scale)
+    return (
+        y * (2 * cdf_y - 1) - (alpha / beta) * (2 * cdf_y_a1 - 1) - 1 / (beta * beta_fn(0.5, alpha))
+    )
 
 
 def compute_brier_skill_score(subset, base_rate=0.5):
@@ -999,9 +1002,9 @@ def compute_coverage(subset, levels=(0.5, 0.8, 0.9)):
     """
     valid = subset.dropna(subset=["Dist", "Actual"])
     if len(valid) == 0:
-        return {level: np.nan for level in levels}
+        return dict.fromkeys(levels, np.nan)
 
-    results = {level: 0 for level in levels}
+    results = dict.fromkeys(levels, 0)
     count = 0
 
     for _, row in valid.iterrows():
@@ -1016,6 +1019,6 @@ def compute_coverage(subset, levels=(0.5, 0.8, 0.9)):
                 results[level] += 1
 
     if count == 0:
-        return {level: np.nan for level in levels}
+        return dict.fromkeys(levels, np.nan)
 
     return {level: results[level] / count for level in levels}

--- a/src/sportstradamus/analysis.py
+++ b/src/sportstradamus/analysis.py
@@ -15,6 +15,12 @@ from sklearn.metrics import accuracy_score, brier_score_loss, log_loss
 from tqdm import tqdm
 
 from sportstradamus.helpers import UNDERDOG_BOOST_BASELINE, get_odds
+from sportstradamus.history_schema import (
+    CLOSING_FIELD_INDICES,
+    LEGACY_OFFER_ARITY,
+    OFFER_FIELDS,
+    PREDICTION_LEVEL_COLS,
+)
 
 LEG_PATTERN = re.compile(r"^(.+?)\s+(Over|Under)\s+([\d.]+)\s+(.+?)\s+-\s+[\d.]+%")
 
@@ -145,20 +151,8 @@ def _migrate_flat_history(history):
     pre-CLV rows; ``reflect`` populates them from the archive on resolution.
     """
     pred_key = ["Player", "League", "Date", "Market"]
-    offer_cols = ["Line", "Boost", "Platform", "Bet", "Model P", "Books P"]
-    pred_cols = [
-        "Team",
-        "Model EV",
-        "Books EV",
-        "Dist",
-        "CV",
-        "Model Param",
-        "Gate",
-        "Temperature",
-        "Disp Cal",
-        "Step",
-        "Actual",
-    ]
+    offer_cols = OFFER_FIELDS[:LEGACY_OFFER_ARITY]
+    pred_cols = [*PREDICTION_LEVEL_COLS, "Actual"]
 
     # Ensure columns exist
     for col in offer_cols + pred_cols + ["Actual"]:
@@ -211,12 +205,6 @@ def _migrate_flat_history(history):
         for col in pred_cols:
             row[col] = latest.get(col, np.nan)
 
-        # Try to recover Actual from old Result column
-        if pd.isna(row.get("Actual")) and "Result" in grp.columns:
-            latest.get("Result")
-            # Can't recover numeric Actual from Over/Under, but mark as resolved
-            # so resolve_history will skip it if Actual is still NaN
-
         rows.append(row)
 
     return pd.DataFrame(rows)
@@ -258,7 +246,7 @@ def _merge_offers(old_offers, new_offers):
 
 def _pad_legacy(offer):
     """Return ``offer`` padded to the canonical 9-field shape with NaN."""
-    if isinstance(offer, tuple | list) and len(offer) == 6:
+    if isinstance(offer, tuple | list) and len(offer) == LEGACY_OFFER_ARITY:
         return (*tuple(offer), np.nan, np.nan, np.nan)
     return tuple(offer)
 
@@ -266,7 +254,7 @@ def _pad_legacy(offer):
 def _preserve_closing(old_offer, new_offer):
     """Carry old closing-trio values forward when ``new_offer`` lacks them."""
     merged = list(new_offer)
-    for idx in (6, 7, 8):  # CloseBooksP, MarketCLV, ModelCLV
+    for idx in CLOSING_FIELD_INDICES:
         if idx < len(merged) and pd.isna(merged[idx]) and idx < len(old_offer):
             merged[idx] = old_offer[idx]
     return tuple(merged)
@@ -457,7 +445,6 @@ def compute_individual_metrics(history):
     history["_date"] = pd.to_datetime(history["Date"], errors="coerce").dt.date
     history = history.loc[history["_date"].notna()].copy()
 
-    # --- Summary table with timeframe splits ---
     rows = []
     filtered = history.loc[history["Model"] > _MODEL_PROB_PICK_FLOOR]
 
@@ -495,7 +482,6 @@ def compute_individual_metrics(history):
             ["Period", "Split", "Accuracy", "Balance", "LogLoss", "Brier", "ROI", "Samples"]
         ]
 
-    # --- Daily granular data for time series charting ---
     one_year = filtered.loc[filtered["_date"] >= today - timedelta(days=365)].copy()
     one_year["Hit"] = (one_year["Bet"] == one_year["Result"]).astype(int)
     one_year["Profit Unit"] = one_year["Hit"] * (100 / 110) - (1 - one_year["Hit"])
@@ -514,7 +500,6 @@ def compute_individual_metrics(history):
     daily["Date"] = daily["Date"].astype(str)
     daily = daily.sort_values(["Date", "League", "Market"])
 
-    # --- Calibration ---
     cal_data = one_year.copy()
     bins = np.linspace(0.5, 1.0, 11)
     cal_data["bin"] = pd.cut(cal_data[prob_col], bins=bins)
@@ -530,7 +515,6 @@ def compute_individual_metrics(history):
     calibration["Bin"] = calibration["bin"].astype(str)
     calibration = calibration[["Bin", "Predicted", "Actual", "Count"]]
 
-    # --- ROI by threshold ---
     roi_rows = []
     for threshold in [0.55, 0.58, 0.60, 0.65, 0.70]:
         for tf_label, tf_days in TIMEFRAMES:
@@ -592,7 +576,6 @@ def compute_parlay_metrics(parlays, stats, stat_map):
     parlays[["Legs", "Misses"]] = parlays[["Legs", "Misses"]].astype(int)
     parlays["Hit"] = (parlays["Misses"] == 0).astype(int)
 
-    # --- Underdog profit ---
     profit_rows = []
     ud_parlays = parlays.loc[parlays["Platform"] == "Underdog"].copy()
     if len(ud_parlays) > 0:
@@ -637,7 +620,6 @@ def compute_parlay_metrics(parlays, stats, stat_map):
 
     profit_df = pd.DataFrame(profit_rows)
 
-    # --- Daily parlay data for time series ---
     daily_rows = []
     for platform in parlays["Platform"].unique():
         plat_df = parlays.loc[parlays["Platform"] == platform]
@@ -674,7 +656,6 @@ def compute_parlay_metrics(parlays, stats, stat_map):
     else:
         daily_parlays = pd.DataFrame()
 
-    # --- Hit rate by parlay size with miss distributions (both platforms) ---
     size_rows = []
     for platform in parlays["Platform"].unique():
         plat_parlays = parlays.loc[parlays["Platform"] == platform]
@@ -709,7 +690,6 @@ def compute_parlay_metrics(parlays, stats, stat_map):
                 size_rows.append(row)
     size_stats = pd.DataFrame(size_rows)
 
-    # --- Correlation calibration ---
     if "P" in parlays.columns and len(parlays) > 0:
         cal_df = parlays.copy()
         bins = np.linspace(0, 1, 11)
@@ -728,7 +708,6 @@ def compute_parlay_metrics(parlays, stats, stat_map):
     else:
         corr_cal = pd.DataFrame()
 
-    # Clean up temp column
     parlays.drop(columns=["_date", "Hit"], inplace=True, errors="ignore")
 
     return profit_df, daily_parlays, size_stats, corr_cal

--- a/src/sportstradamus/books.py
+++ b/src/sportstradamus/books.py
@@ -7,6 +7,7 @@ live in ``src/deprecated/books_deprecated.py``.
 """
 
 from datetime import datetime, timedelta
+from http import HTTPStatus
 from operator import itemgetter
 
 from tqdm import tqdm
@@ -267,18 +268,18 @@ def get_sleeper():
     offers = {}
     res = requests.get(SLEEPER_AVAILABLE_URL)
 
-    if res.status_code != 200:
+    if res.status_code != HTTPStatus.OK:
         return offers
 
     res = res.json()
-    leagues = set([x["sport"] for x in res])
+    leagues = {x["sport"] for x in res}
 
     alt = requests.get(SLEEPER_ALT_URL)
-    if alt.status_code == 200:
+    if alt.status_code == HTTPStatus.OK:
         res.extend(alt.json())
 
     game_res = requests.get(SLEEPER_GAMES_URL)
-    if game_res.status_code != 200:
+    if game_res.status_code != HTTPStatus.OK:
         return offers
 
     games = {}
@@ -297,7 +298,7 @@ def get_sleeper():
 
     for league in tqdm(leagues, desc="Getting Sleeper lines...", leave=False):
         players = requests.get(SLEEPER_PLAYERS_URL.format(league=league))
-        if players.status_code != 200:
+        if players.status_code != HTTPStatus.OK:
             continue
 
         players = players.json()
@@ -317,7 +318,7 @@ def get_sleeper():
             game_date = games.get(league, {}).get(prop["game_id"], {}).get("date")
 
             all_outcomes = sorted(prop["options"], key=itemgetter("outcome", "outcome_value"))
-            lines = set([x["outcome_value"] for x in all_outcomes])
+            lines = {x["outcome_value"] for x in all_outcomes}
             for line in lines:
                 outcomes = [x for x in all_outcomes if x["outcome_value"] == line]
                 if len(outcomes) < 2:

--- a/src/sportstradamus/clv.py
+++ b/src/sportstradamus/clv.py
@@ -26,6 +26,7 @@ import pandas as pd
 
 from sportstradamus import data as _data_pkg
 from sportstradamus.helpers.logging import get_logger
+from sportstradamus.history_schema import LEGACY_OFFER_ARITY, OFFER_ARITY
 
 # Per-(League, Market, Platform) CLV summary segments require this many legs
 # to be reported. Smaller segments are statistical noise.
@@ -109,9 +110,9 @@ def fill_from_archive(history: pd.DataFrame, archive) -> pd.DataFrame:
 
         new_offers = []
         for offer in offers:
-            if isinstance(offer, tuple | list) and len(offer) == 6:
+            if isinstance(offer, tuple | list) and len(offer) == LEGACY_OFFER_ARITY:
                 offer = (*tuple(offer), np.nan, np.nan, np.nan)
-            elif not (isinstance(offer, tuple | list) and len(offer) == 9):
+            elif not (isinstance(offer, tuple | list) and len(offer) == OFFER_ARITY):
                 new_offers.append(offer)
                 continue
             line, boost, platform, bet, model_p, books_p, prev_close, _, _ = offer
@@ -171,9 +172,9 @@ def summarize(history: pd.DataFrame, archive=None) -> dict:
             movement = movement_cache[cache_key]
 
         for offer in offers:
-            if not (isinstance(offer, tuple | list) and len(offer) >= 9):
+            if not (isinstance(offer, tuple | list) and len(offer) >= OFFER_ARITY):
                 continue
-            _, _, platform, bet, model_p, _, close_p, market_clv, _model_clv = offer[:9]
+            _, _, platform, bet, model_p, _, close_p, market_clv, _model_clv = offer[:OFFER_ARITY]
             if pd.isna(close_p) or pd.isna(market_clv):
                 continue
             aligned = _movement_alignment(movement, model_p, bet)

--- a/src/sportstradamus/dashboard_detail.py
+++ b/src/sportstradamus/dashboard_detail.py
@@ -138,11 +138,17 @@ def _parse_corr(s: str, max_n: int = 3) -> list[tuple[str, float]]:
     return out
 
 
+# Correlation-strength badge thresholds: a leg whose multiplier on the base edge
+# clears these earns the Strong / Moderate badge in the offer-detail view.
+_CORR_STRONG_MULT = 1.25
+_CORR_MODERATE_MULT = 1.1
+
+
 def _strength_badge(mult: float) -> str:
     """Return emoji badge for correlation strength."""
-    if mult >= 1.25:
+    if mult >= _CORR_STRONG_MULT:
         return "🔴 Strong"
-    if mult >= 1.1:
+    if mult >= _CORR_MODERATE_MULT:
         return "🟡 Moderate"
     return "⚪ Mild"
 

--- a/src/sportstradamus/history_schema.py
+++ b/src/sportstradamus/history_schema.py
@@ -1,0 +1,51 @@
+"""Canonical schema for the normalized prediction-history frame.
+
+`prophecize` (``prediction/cli.py``) writes player predictions to the history
+parquet as one row per ``(Player, League, Date, Market)`` group, with the
+per-offer rows collapsed into an ``Offers`` list of fixed-arity tuples.
+`reflect` (``clv.py`` and ``analysis.py``) reads that frame back to fold in
+closing-line value and to explode offers for scoring. The writer and both
+readers must agree on the exact column set and offer-tuple shape; this module
+is the single source of truth so a schema change lands in one place instead of
+three.
+"""
+
+PREDICTION_LEVEL_COLS = [
+    "Team",
+    "Model EV",
+    "Books EV",
+    "Dist",
+    "CV",
+    "Model Param",
+    "Gate",
+    "Temperature",
+    "Disp Cal",
+    "Step",
+]
+
+# ``Team`` is hoisted next to the identity key; the rest of the prediction-level
+# block follows the (Player, League, Team, Date, Market) prefix.
+HISTORY_COLS = (
+    ["Player", "League", "Team", "Date", "Market"]
+    + [c for c in PREDICTION_LEVEL_COLS if c != "Team"]
+    + ["Offers", "Actual"]
+)
+
+# The trailing three (the closing trio) are NaN at prediction time and filled by
+# `reflect` once the line closes.
+OFFER_FIELDS = [
+    "Line",
+    "Boost",
+    "Platform",
+    "Bet",
+    "Model P",
+    "Books P",
+    "Close Books P",
+    "Market CLV",
+    "Model CLV",
+]
+OFFER_ARITY = len(OFFER_FIELDS)
+# Offers written before the CLV migration carried only the first six fields.
+LEGACY_OFFER_ARITY = 6
+# Tuple positions of the closing trio (Close Books P, Market CLV, Model CLV).
+CLOSING_FIELD_INDICES = tuple(range(LEGACY_OFFER_ARITY, OFFER_ARITY))

--- a/src/sportstradamus/moneylines.py
+++ b/src/sportstradamus/moneylines.py
@@ -26,6 +26,7 @@ American-sports start hours only — is::
 import importlib.resources as pkg_resources
 import json
 from datetime import datetime, timedelta
+from http import HTTPStatus
 from itertools import groupby
 from operator import itemgetter
 from pathlib import Path
@@ -74,6 +75,10 @@ ODDS_API_HISTORICAL_EVENT_ODDS_URL = (
 )
 ODDS_API_HISTORICAL_ODDS_URL = f"{_ODDS_API_BASE}/sports/{{sport}}/odds-history/"
 
+# Warn when the Odds API account drops below this many remaining requests so the
+# season-long token budget doesn't silently run dry mid-slate.
+_LOW_API_CREDITS_THRESHOLD = 50
+
 
 def _get_with_retry(url, params=None):
     """GET ``url`` with one 429-retry. Returns the ``requests.Response``.
@@ -83,7 +88,7 @@ def _get_with_retry(url, params=None):
     so callers can decide whether to ``continue`` or bail.
     """
     res = requests.get(url, params=params)
-    if res.status_code == 429:
+    if res.status_code == HTTPStatus.TOO_MANY_REQUESTS:
         sleep(1)
         res = requests.get(url, params=params)
     return res
@@ -179,10 +184,10 @@ def get_moneylines(
             logger.warning("All sports only supported if date is today")
             return archive
         res = _get_with_retry(ODDS_API_SPORTS_URL, params={"apiKey": apikey["odds_api"]})
-        if res.status_code != 200:
+        if res.status_code != HTTPStatus.OK:
             return archive
 
-        low_on_credits = int(res.headers.get("X-Requests-Remaining")) < 50
+        low_on_credits = int(res.headers.get("X-Requests-Remaining")) < _LOW_API_CREDITS_THRESHOLD
         res = res.json()
 
         sports = [
@@ -216,7 +221,7 @@ def get_moneylines(
 
     for sport, league in sports:
         res = _get_with_retry(url_template.format(sport=sport), params=params)
-        if res.status_code != 200:
+        if res.status_code != HTTPStatus.OK:
             continue
 
         res = res.json()["data"] if historical else res.json()
@@ -309,7 +314,7 @@ def get_props(
             logger.warning("All sports only supported if date is today")
             return archive
         res = _get_with_retry(ODDS_API_SPORTS_URL, params={"apiKey": apikey})
-        if res.status_code != 200:
+        if res.status_code != HTTPStatus.OK:
             return archive
 
         res = res.json()
@@ -343,7 +348,7 @@ def get_props(
         if league == "MLB":
             params["markets"] = params["markets"] + ",totals_1st_1_innings,spreads_1st_1_innings"
         events = _get_with_retry(event_url_template.format(sport=sport), params=params)
-        if events.status_code != 200:
+        if events.status_code != HTTPStatus.OK:
             continue
 
         events = events.json()["data"] if historical else events.json()
@@ -359,9 +364,9 @@ def get_props(
             res = _get_with_retry(
                 odds_url_template.format(sport=sport, eventId=event["id"]), params=event_params
             )
-            if res.status_code == 404:
+            if res.status_code == HTTPStatus.NOT_FOUND:
                 return archive
-            elif res.status_code != 200:
+            if res.status_code != HTTPStatus.OK:
                 continue
 
             game = res.json()["data"] if historical else res.json()
@@ -405,7 +410,7 @@ def _archive_event_props(archive, game, league, props, gameDate):
                 totals.setdefault(spread_name, {})
                 totals[spread_name][book["key"]] = get_ev(outcomes[1]["point"], sub_odds[1])
                 continue
-            elif "spread" in market["key"]:
+            if "spread" in market["key"]:
                 spread_name = " ".join(market["key"].split("_")[1:])
                 outcomes = sorted(market["outcomes"], key=itemgetter("point"))
                 sub_odds = no_vig_odds(outcomes[0]["price"], outcomes[1]["price"])
@@ -610,7 +615,7 @@ def _close_lines_pass(apikey, props):
             ODDS_API_EVENT_ODDS_URL.format(sport=sport_key, eventId=event_id),
             params=event_params,
         )
-        if res.status_code != 200:
+        if res.status_code != HTTPStatus.OK:
             logger.warning(f"close-lines: {league} {event_id} returned status {res.status_code}")
             continue
         game = res.json()

--- a/src/sportstradamus/pages/3_📊_Stats_Overview.py
+++ b/src/sportstradamus/pages/3_📊_Stats_Overview.py
@@ -146,7 +146,7 @@ if not volume_pivot.empty:
         volume_pivot.values,
         x=[str(d) for d in volume_pivot.columns],
         y=volume_pivot.index.tolist(),
-        labels=dict(x="Date", y="League", color="Predictions"),
+        labels={"x": "Date", "y": "League", "color": "Predictions"},
         aspect="auto",
         color_continuous_scale="Blues",
     )

--- a/src/sportstradamus/pages/4_📊_Stats_Diagnostics.py
+++ b/src/sportstradamus/pages/4_📊_Stats_Diagnostics.py
@@ -150,7 +150,7 @@ if not market_df.empty:
         ab = abs(b)
         if ab < 0.03:
             return "green"
-        elif ab < 0.07:
+        if ab < 0.07:
             return "orange"
         return "red"
 
@@ -260,7 +260,7 @@ fig_rel.add_trace(
         x=[0.5, 1.0],
         y=[0.5, 1.0],
         mode="lines",
-        line=dict(dash="dash", color="gray"),
+        line={"dash": "dash", "color": "gray"},
         name="Perfect calibration",
         showlegend=True,
     )
@@ -272,7 +272,7 @@ fig_rel.add_trace(
         y=cal_stats["Actual"],
         mode="lines+markers",
         name="Model",
-        marker=dict(size=cal_stats["Count"].clip(upper=500) / 20 + 5),
+        marker={"size": cal_stats["Count"].clip(upper=500) / 20 + 5},
         text=[f"n={c}" for c in cal_stats["Count"]],
         hovertemplate="Predicted: %{x:.3f}<br>Actual: %{y:.3f}<br>%{text}",
     )
@@ -288,8 +288,8 @@ fig_rel.add_trace(
     )
 )
 fig_rel.update_layout(
-    yaxis=dict(title="Actual Hit Rate", range=[0.4, 1.0]),
-    yaxis2=dict(title="Count", overlaying="y", side="right"),
+    yaxis={"title": "Actual Hit Rate", "range": [0.4, 1.0]},
+    yaxis2={"title": "Count", "overlaying": "y", "side": "right"},
     xaxis_title="Predicted Probability",
     height=450,
 )

--- a/src/sportstradamus/pages/5_📊_Stats_Correlations.py
+++ b/src/sportstradamus/pages/5_📊_Stats_Correlations.py
@@ -123,7 +123,7 @@ if has_indep and has_corr_p:
             x=[0, scatter_df[["Indep P", "P"]].max().max()],
             y=[0, scatter_df[["Indep P", "P"]].max().max()],
             mode="lines",
-            line=dict(dash="dash", color="gray"),
+            line={"dash": "dash", "color": "gray"},
             name="No adjustment line",
         )
     )
@@ -259,7 +259,7 @@ if "P" in resolved.columns and resolved["P"].notna().any():
             x=[0, cal_stats["Predicted"].max()],
             y=[0, cal_stats["Predicted"].max()],
             mode="lines",
-            line=dict(dash="dash", color="gray"),
+            line={"dash": "dash", "color": "gray"},
             name="Perfect",
         )
     )

--- a/src/sportstradamus/pages/6_📊_Stats_Profit_Sim.py
+++ b/src/sportstradamus/pages/6_📊_Stats_Profit_Sim.py
@@ -214,7 +214,7 @@ for name, result in all_results.items():
             fillcolor=color.replace(")", ",0.1)").replace("rgb", "rgba")
             if "rgb" in color
             else color + "1A",
-            line=dict(width=0),
+            line={"width": 0},
             name=f"{name} (10th-90th %ile)",
             showlegend=False,
             hoverinfo="skip",
@@ -228,7 +228,7 @@ for name, result in all_results.items():
             y=agg["mean_bankroll"],
             mode="lines",
             name=name,
-            line=dict(color=color, width=2),
+            line={"color": color, "width": 2},
         )
     )
 

--- a/src/sportstradamus/pages/7_📊_Stats_Model_Training.py
+++ b/src/sportstradamus/pages/7_📊_Stats_Model_Training.py
@@ -169,17 +169,14 @@ TAB_COLUMNS: dict[str, list[str]] = {
 }
 
 TAB_CAPTIONS: dict[str, str] = {
-    "Overview": (
-        "One row per (league, market). Columns are annotated ↑/↓/informational."
-    ),
+    "Overview": ("One row per (league, market). Columns are annotated ↑/↓/informational."),
     "Scoring rules": (
         "Proper scoring rules on the validation set. The model's `*_model` column"
         " should beat the `*_book` baseline; the derived `brier_skill_score` is the"
         " single-number gate the kelly chain reads. Columns are annotated ↑/↓/informational."
     ),
     "Discrimination": (
-        "How well the model separates winners from losers."
-        " Columns are annotated ↑/↓/informational."
+        "How well the model separates winners from losers. Columns are annotated ↑/↓/informational."
     ),
     "Rates": (
         "Rates and conditional Over% slices. Compare `predicted_over_rate` to"
@@ -267,7 +264,9 @@ with st.sidebar:
     sel_leagues = st.multiselect("Leagues", leagues, default=leagues)
     distributions = sorted(stats["distribution"].dropna().unique())
     sel_dists = st.multiselect("Distributions", distributions, default=distributions)
-    shipped_states = sorted(stats["shipped"].dropna().unique()) if "shipped" in stats.columns else []
+    shipped_states = (
+        sorted(stats["shipped"].dropna().unique()) if "shipped" in stats.columns else []
+    )
     sel_shipped = (
         st.multiselect("Shipped", shipped_states, default=shipped_states) if shipped_states else []
     )

--- a/src/sportstradamus/prediction/cli.py
+++ b/src/sportstradamus/prediction/cli.py
@@ -31,6 +31,7 @@ from sportstradamus.helpers.io import (
     write_history,
     write_parlay_hist,
 )
+from sportstradamus.history_schema import HISTORY_COLS, PREDICTION_LEVEL_COLS
 from sportstradamus.prediction.persist import write_current_offers
 from sportstradamus.prediction.scoring import process_offers
 from sportstradamus.spiderLogger import logger
@@ -187,7 +188,6 @@ def main(progress, legacy_correlation, contest_variant, log_level):
         contest_variant=contest_variant,
     )
 
-    # --- Append to rolling parlay history ---
     if not parlay_df.empty:
         old_parlays = read_parlay_hist()
         if not old_parlays.empty:
@@ -207,40 +207,9 @@ def main(progress, legacy_correlation, contest_variant, log_level):
         if "Offers" not in history.columns:
             history = _migrate_flat_history(history)
     else:
-        history = pd.DataFrame(
-            columns=[
-                "Player",
-                "League",
-                "Team",
-                "Date",
-                "Market",
-                "Model EV",
-                "Books EV",
-                "Dist",
-                "CV",
-                "Model Param",
-                "Gate",
-                "Temperature",
-                "Disp Cal",
-                "Step",
-                "Offers",
-                "Actual",
-            ]
-        )
+        history = pd.DataFrame(columns=HISTORY_COLS)
 
     pred_key = ["Player", "League", "Date", "Market"]
-    pred_level_cols = [
-        "Team",
-        "Model EV",
-        "Books EV",
-        "Dist",
-        "CV",
-        "Model Param",
-        "Gate",
-        "Temperature",
-        "Disp Cal",
-        "Step",
-    ]
 
     if all_offers:
         all_df = pd.concat(all_offers)
@@ -282,7 +251,7 @@ def main(progress, legacy_correlation, contest_variant, log_level):
                 "Market": market,
                 "Offers": offers,
             }
-            for col in pred_level_cols:
+            for col in PREDICTION_LEVEL_COLS:
                 row[col] = latest.get(col, np.nan)
             new_preds.append(row)
 
@@ -298,7 +267,7 @@ def main(progress, legacy_correlation, contest_variant, log_level):
                 if not isinstance(old_offers, list):
                     old_offers = []
                 history.at[idx, "Offers"] = _merge_offers(old_offers, new_df.at[idx, "Offers"])
-                for col in pred_level_cols:
+                for col in PREDICTION_LEVEL_COLS:
                     val = new_df.at[idx, col]
                     if pd.notna(val):
                         history.at[idx, col] = val

--- a/src/sportstradamus/prediction/correlation.py
+++ b/src/sportstradamus/prediction/correlation.py
@@ -246,7 +246,7 @@ def find_correlation(
     # single-multiplier-per-size list used inside the beam-search ranking;
     # ``full_payouts`` is the per-(size, miss-count) lookup driving push-aware
     # EV and the display Boost column.
-    search_payouts, full_payouts = _payout_curve_for(platform, contest_variant, legacy)
+    search_payouts, full_payouts = _payout_curve_for(platform, contest_variant, legacy=legacy)
 
     for league in ["NFL", "NBA", "WNBA", "MLB", "NHL"]:
         league_df = df.loc[df["League"] == league]

--- a/src/sportstradamus/prediction/model_prob.py
+++ b/src/sportstradamus/prediction/model_prob.py
@@ -47,6 +47,16 @@ _NONZERO_DENOM_GATE = 0.05
 # SkewNormal prediction frame for downstream gate-aware blending.
 _GATE_PUBLISH_THRESHOLD = 0.02
 
+# Minimum bookmaker line for a "yards" market to be scored. Combo legs ("vs.")
+# are exempt; single-player yards lines at or below this are too low to model
+# reliably and are dropped.
+_MIN_YARDS_LINE = 8
+
+# Maximum Underdog boost multiplier kept when de-duplicating a player's offers.
+# Above this the promo is an outlier (e.g. a discounted special) that distorts
+# the per-player distance ranking, so it is filtered out.
+_MAX_UNDERDOG_BOOST = 3.65
+
 
 def _decode_skewnormal(
     prob_params: pd.DataFrame,
@@ -142,6 +152,8 @@ def model_prob(
     Returns:
         list[dict]: Scored offer records, or ``[]`` on failure.
     """
+    # style: allow-length  pre-existing distribution-decode orchestrator
+    # (§2.8/§18.9): flag, don't split. Already over the limit before this edit.
 
     def odds_from_boost(o):
         p = [
@@ -167,7 +179,9 @@ def model_prob(
     offer_df = pd.DataFrame(offers)
     offer_df.index = offer_df.Player
     if "yards" in market:
-        offer_df = offer_df.loc[(offer_df.Player.str.contains("vs.")) | (offer_df.Line > 8)]
+        offer_df = offer_df.loc[
+            (offer_df.Player.str.contains("vs.")) | (offer_df.Line > _MIN_YARDS_LINE)
+        ]
     if os.path.isfile(filepath):
         with open(filepath, "rb") as infile:
             filedict = pickle.load(infile)
@@ -331,7 +345,7 @@ def model_prob(
 
         # Blend model and book distributions via fused_loc
         if dist == "SkewNormal":
-            _zi_kw = dict(gate_book=hist_gate) if hist_gate > _GATE_PUBLISH_THRESHOLD else {}
+            _zi_kw = {"gate_book": hist_gate} if hist_gate > _GATE_PUBLISH_THRESHOLD else {}
             blended_base_mean, sigma_blend, skew_blend, gate_blend = fused_loc(
                 model_weight,
                 offer_df["Model EV"].to_numpy(),
@@ -356,7 +370,7 @@ def model_prob(
 
         elif dist in ("NegBin", "ZINB"):
             _zi_kw = (
-                dict(gate_model=offer_df["Model Gate"].to_numpy(), gate_book=hist_gate)
+                {"gate_model": offer_df["Model Gate"].to_numpy(), "gate_book": hist_gate}
                 if dist == "ZINB" and "Model Gate" in offer_df.columns
                 else {}
             )
@@ -378,7 +392,7 @@ def model_prob(
             offer_df["Model R"] = r_blend
         else:
             _zi_kw = (
-                dict(gate_model=offer_df["Model Gate"].to_numpy(), gate_book=hist_gate)
+                {"gate_model": offer_df["Model Gate"].to_numpy(), "gate_book": hist_gate}
                 if dist == "ZAGamma" and "Model Gate" in offer_df.columns
                 else {}
             )
@@ -520,7 +534,7 @@ def model_prob(
             1 / offer_df.loc[offer_df["Distance"] < 1, "Distance"]
         )
         offer_df = (
-            offer_df.loc[offer_df["Boost"] <= 3.65]
+            offer_df.loc[offer_df["Boost"] <= _MAX_UNDERDOG_BOOST]
             .sort_values("Distance", ascending=True)
             .groupby("Player")
             .head(3)
@@ -610,6 +624,5 @@ def model_prob(
             ]
         ].to_dict("records")
 
-    else:
-        logger.warning(f"{filename} missing")
-        return []
+    logger.warning(f"{filename} missing")
+    return []

--- a/src/sportstradamus/prediction/parlay.py
+++ b/src/sportstradamus/prediction/parlay.py
@@ -108,6 +108,7 @@ def _pooled_underdog_curve() -> dict[int, list[float]]:
 def _payout_curve_for(
     platform: str,
     contest_variant: Literal["pooled", "power", "flex", "insurance", "rivals"],
+    *,
     legacy: bool,
 ) -> tuple[list[float], dict[int, list[float]]]:
     """Build the (per-size search list, per-(size,misses) payout table) for a platform.

--- a/src/sportstradamus/scripts/comp_feature_stability.py
+++ b/src/sportstradamus/scripts/comp_feature_stability.py
@@ -155,9 +155,7 @@ def load_stacked_seasons(min_games: int) -> pd.DataFrame:
     stacked = apply_rolling_transforms(stacked)
 
     # Min-games filter mirrors the half-season cutoff used in stickiness lit.
-    stacked = stacked.loc[stacked[GAMES_COLUMN] >= min_games].copy()
-
-    return stacked
+    return stacked.loc[stacked[GAMES_COLUMN] >= min_games].copy()
 
 
 def collect_pairs(stacked: pd.DataFrame, feature: str, position: str | None = None) -> pd.DataFrame:

--- a/src/sportstradamus/scripts/evaluate_comp_features.py
+++ b/src/sportstradamus/scripts/evaluate_comp_features.py
@@ -89,7 +89,7 @@ def discover_numeric_features(profile, min_coverage=0.5, min_unique=3):
     """Find all numeric features with adequate coverage."""
     features = []
     for col in profile.columns:
-        if col.endswith("growth") or col.endswith("short"):
+        if col.endswith(("growth", "short")):
             continue
         try:
             vals = pd.to_numeric(profile[col], errors="coerce")
@@ -640,7 +640,7 @@ def main():
 
         elif args.save and (added or removed):
             # Save with equal weights normalized
-            equal_w = {f: 1.0 for f in best_features}
+            equal_w = dict.fromkeys(best_features, 1.0)
             current_weights[args.league][position] = normalize_weights(equal_w)
 
     if args.save:

--- a/src/sportstradamus/scripts/migrate_archive_to_duckdb.py
+++ b/src/sportstradamus/scripts/migrate_archive_to_duckdb.py
@@ -77,7 +77,7 @@ def _iter_league(archive_root: Path, league: str, cutoff: datetime.date):
     """
     league_dir = archive_root / league
     if not league_dir.is_dir():
-        return
+        return None
     a = hdfdir_archive(str(league_dir), {}, protocol=-1)
     a.load()
 

--- a/src/sportstradamus/scripts/model_calibration/test_model_weight.py
+++ b/src/sportstradamus/scripts/model_calibration/test_model_weight.py
@@ -101,40 +101,36 @@ def fit_dispersion_on_raw_model(data):
         d["r"] = r_raw * c_opt
         return c_opt, d
 
-    else:  # Gamma / ZAGamma
-        alpha_raw = data["alpha"]
+    # Gamma / ZAGamma
+    alpha_raw = data["alpha"]
 
-        def loss(c):
-            alpha_cal = alpha_raw * c
-            scale_cal = model_ev / alpha_cal  # mean-preserving
-            if gate is not None:
-                x_max = max(result.max() * 2, np.mean(model_ev) * 4)
-                x_grid = np.linspace(0, x_max, 500)
-                dx = x_grid[1] - x_grid[0]
-                cdf_grid = gamma_dist.cdf(
-                    x_grid[:, None], alpha_cal[None, :], scale=scale_cal[None, :]
-                )
-                cdf_grid = gate[None, :] + (1 - gate[None, :]) * cdf_grid
-                indicator = (result[None, :] <= x_grid[:, None]).astype(float)
-                crps = np.mean(np.sum((cdf_grid - indicator) ** 2, axis=0) * dx)
-            else:
-                F_y = gamma_dist.cdf(result, alpha_cal, scale=scale_cal)
-                F_y_a1 = gamma_dist.cdf(result, alpha_cal + 1, scale=scale_cal)
-                mu = model_ev
-                crps = np.mean(
-                    result * (2 * F_y - 1)
-                    - mu * (2 * F_y_a1 - 1)
-                    - scale_cal / beta_fn(0.5, alpha_cal)
-                )
-            reg = 0.01 * np.log(c) ** 2
-            return crps + reg
+    def loss(c):
+        alpha_cal = alpha_raw * c
+        scale_cal = model_ev / alpha_cal  # mean-preserving
+        if gate is not None:
+            x_max = max(result.max() * 2, np.mean(model_ev) * 4)
+            x_grid = np.linspace(0, x_max, 500)
+            dx = x_grid[1] - x_grid[0]
+            cdf_grid = gamma_dist.cdf(x_grid[:, None], alpha_cal[None, :], scale=scale_cal[None, :])
+            cdf_grid = gate[None, :] + (1 - gate[None, :]) * cdf_grid
+            indicator = (result[None, :] <= x_grid[:, None]).astype(float)
+            crps = np.mean(np.sum((cdf_grid - indicator) ** 2, axis=0) * dx)
+        else:
+            F_y = gamma_dist.cdf(result, alpha_cal, scale=scale_cal)
+            F_y_a1 = gamma_dist.cdf(result, alpha_cal + 1, scale=scale_cal)
+            mu = model_ev
+            crps = np.mean(
+                result * (2 * F_y - 1) - mu * (2 * F_y_a1 - 1) - scale_cal / beta_fn(0.5, alpha_cal)
+            )
+        reg = 0.01 * np.log(c) ** 2
+        return crps + reg
 
-        res = minimize_scalar(loss, bounds=(0.1, 10.0), method="bounded")
-        c_opt = res.x
+    res = minimize_scalar(loss, bounds=(0.1, 10.0), method="bounded")
+    c_opt = res.x
 
-        d = dict(data)
-        d["alpha"] = alpha_raw * c_opt
-        return c_opt, d
+    d = dict(data)
+    d["alpha"] = alpha_raw * c_opt
+    return c_opt, d
 
 
 def eval_accuracy(w, data, use_dispersion_cal=False):
@@ -143,7 +139,7 @@ def eval_accuracy(w, data, use_dispersion_cal=False):
     base_dist = "NegBin" if dist in ("NegBin", "ZINB") else "Gamma"
     zi_kwargs = {}
     if dist in ("ZINB", "ZAGamma") and data["hist_gate"] > 0:
-        zi_kwargs = dict(gate_model=data["gate"], gate_book=data["hist_gate"])
+        zi_kwargs = {"gate_model": data["gate"], "gate_book": data["hist_gate"]}
 
     if base_dist == "NegBin":
         r_blend, p_blend, gate_blend = fused_loc(
@@ -180,7 +176,7 @@ def objective_nll(w, data, clamp=-20):
     zi_kwargs = {}
     has_gate = dist in ("ZINB", "ZAGamma") and data["hist_gate"] > 0
     if has_gate:
-        zi_kwargs = dict(gate_model=data["gate"], gate_book=data["hist_gate"])
+        zi_kwargs = {"gate_model": data["gate"], "gate_book": data["hist_gate"]}
 
     if base_dist == "NegBin":
         r_blend, p_blend, g_blend = fused_loc(
@@ -196,27 +192,24 @@ def objective_nll(w, data, clamp=-20):
             )
             return -np.mean(loglik)
         return -np.mean(base_logpmf)
-    else:
-        alpha_bl, beta_bl, g_blend = fused_loc(
-            w,
-            data["model_ev"],
-            data["book_ev"],
-            data["cv"],
-            "Gamma",
-            alpha=data["alpha"],
-            **zi_kwargs,
+    alpha_bl, beta_bl, g_blend = fused_loc(
+        w,
+        data["model_ev"],
+        data["book_ev"],
+        data["cv"],
+        "Gamma",
+        alpha=data["alpha"],
+        **zi_kwargs,
+    )
+    base_logpdf = np.clip(gamma_dist.logpdf(data["result"], alpha_bl, scale=1 / beta_bl), clamp, 0)
+    if has_gate:
+        loglik = np.where(
+            data["result"] == 0,
+            np.log(np.clip(g_blend, 1e-12, None)),
+            np.log(np.clip(1 - g_blend, 1e-12, None)) + base_logpdf,
         )
-        base_logpdf = np.clip(
-            gamma_dist.logpdf(data["result"], alpha_bl, scale=1 / beta_bl), clamp, 0
-        )
-        if has_gate:
-            loglik = np.where(
-                data["result"] == 0,
-                np.log(np.clip(g_blend, 1e-12, None)),
-                np.log(np.clip(1 - g_blend, 1e-12, None)) + base_logpdf,
-            )
-            return -np.mean(loglik)
-        return -np.mean(base_logpdf)
+        return -np.mean(loglik)
+    return -np.mean(base_logpdf)
 
 
 def objective_nll_unclamped(w, data):
@@ -231,7 +224,7 @@ def objective_crps(w, data):
     zi_kwargs = {}
     has_gate = dist in ("ZINB", "ZAGamma") and data["hist_gate"] > 0
     if has_gate:
-        zi_kwargs = dict(gate_model=data["gate"], gate_book=data["hist_gate"])
+        zi_kwargs = {"gate_model": data["gate"], "gate_book": data["hist_gate"]}
 
     if base_dist == "NegBin":
         r_blend, p_blend, g_blend = fused_loc(
@@ -246,35 +239,33 @@ def objective_crps(w, data):
             cdf = g_blend[None, :] + (1 - g_blend[None, :]) * cdf
         indicator = (result_int[None, :] <= k_vals[:, None]).astype(float)
         return np.mean(np.sum((cdf - indicator) ** 2, axis=0))
-    else:
-        alpha_bl, beta_bl, g_blend = fused_loc(
-            w,
-            data["model_ev"],
-            data["book_ev"],
-            data["cv"],
-            "Gamma",
-            alpha=data["alpha"],
-            **zi_kwargs,
-        )
-        scale_bl = 1 / beta_bl
-        mu_bl = alpha_bl * scale_bl
-        if has_gate and g_blend is not None:
-            x_max = max(data["result"].max() * 2, np.mean(mu_bl) * 4)
-            x_grid = np.linspace(0, x_max, 500)
-            dx = x_grid[1] - x_grid[0]
-            cdf_grid = gamma_dist.cdf(x_grid[:, None], alpha_bl[None, :], scale=scale_bl[None, :])
-            cdf_grid = g_blend[None, :] + (1 - g_blend[None, :]) * cdf_grid
-            indicator = (data["result"][None, :] <= x_grid[:, None]).astype(float)
-            return np.mean(np.sum((cdf_grid - indicator) ** 2, axis=0) * dx)
-        else:
-            F_y = gamma_dist.cdf(data["result"], alpha_bl, scale=scale_bl)
-            F_y_a1 = gamma_dist.cdf(data["result"], alpha_bl + 1, scale=scale_bl)
-            crps_vals = (
-                data["result"] * (2 * F_y - 1)
-                - mu_bl * (2 * F_y_a1 - 1)
-                - scale_bl / beta_fn(0.5, alpha_bl)
-            )
-            return np.mean(crps_vals)
+    alpha_bl, beta_bl, g_blend = fused_loc(
+        w,
+        data["model_ev"],
+        data["book_ev"],
+        data["cv"],
+        "Gamma",
+        alpha=data["alpha"],
+        **zi_kwargs,
+    )
+    scale_bl = 1 / beta_bl
+    mu_bl = alpha_bl * scale_bl
+    if has_gate and g_blend is not None:
+        x_max = max(data["result"].max() * 2, np.mean(mu_bl) * 4)
+        x_grid = np.linspace(0, x_max, 500)
+        dx = x_grid[1] - x_grid[0]
+        cdf_grid = gamma_dist.cdf(x_grid[:, None], alpha_bl[None, :], scale=scale_bl[None, :])
+        cdf_grid = g_blend[None, :] + (1 - g_blend[None, :]) * cdf_grid
+        indicator = (data["result"][None, :] <= x_grid[:, None]).astype(float)
+        return np.mean(np.sum((cdf_grid - indicator) ** 2, axis=0) * dx)
+    F_y = gamma_dist.cdf(data["result"], alpha_bl, scale=scale_bl)
+    F_y_a1 = gamma_dist.cdf(data["result"], alpha_bl + 1, scale=scale_bl)
+    crps_vals = (
+        data["result"] * (2 * F_y - 1)
+        - mu_bl * (2 * F_y_a1 - 1)
+        - scale_bl / beta_fn(0.5, alpha_bl)
+    )
+    return np.mean(crps_vals)
 
 
 def objective_brier(w, data):
@@ -284,7 +275,7 @@ def objective_brier(w, data):
     zi_kwargs = {}
     has_gate = dist in ("ZINB", "ZAGamma") and data["hist_gate"] > 0
     if has_gate:
-        zi_kwargs = dict(gate_model=data["gate"], gate_book=data["hist_gate"])
+        zi_kwargs = {"gate_model": data["gate"], "gate_book": data["hist_gate"]}
 
     if base_dist == "NegBin":
         r_blend, p_blend, gate_blend = fused_loc(
@@ -352,7 +343,7 @@ def eval_accuracy_2w(w_mean, w_shape, data):
     base_dist = "NegBin" if dist in ("NegBin", "ZINB") else "Gamma"
     has_gate = dist in ("ZINB", "ZAGamma") and data["hist_gate"] > 0
     if has_gate:
-        dict(gate_model=data["gate"], gate_book=data["hist_gate"])
+        {"gate_model": data["gate"], "gate_book": data["hist_gate"]}
 
     if base_dist == "NegBin":
         # Blend mean with w_mean, shape with w_shape
@@ -469,31 +460,30 @@ def objective_nll_2w(params, data, clamp=-20):
             )
             return -np.mean(loglik)
         return -np.mean(base_logpmf)
-    else:
-        model_alpha = np.asarray(data["alpha"], dtype=float)
-        book_alpha = 1 / data["cv"] ** 2
-        inv_var_m = model_alpha / np.asarray(data["model_ev"], dtype=float) ** 2
-        inv_var_b = book_alpha / np.asarray(data["book_ev"], dtype=float) ** 2
-        total_inv_var = w_mean * inv_var_m + (1 - w_mean) * inv_var_b
-        blended_mean = (
-            w_mean * data["model_ev"] * inv_var_m + (1 - w_mean) * data["book_ev"] * inv_var_b
-        ) / total_inv_var
-        blended_alpha = w_shape * model_alpha + (1 - w_shape) * book_alpha
-        blended_beta = blended_alpha / blended_mean
-        base_logpdf = np.clip(
-            gamma_dist.logpdf(data["result"], blended_alpha, scale=1 / blended_beta), clamp, 0
+    model_alpha = np.asarray(data["alpha"], dtype=float)
+    book_alpha = 1 / data["cv"] ** 2
+    inv_var_m = model_alpha / np.asarray(data["model_ev"], dtype=float) ** 2
+    inv_var_b = book_alpha / np.asarray(data["book_ev"], dtype=float) ** 2
+    total_inv_var = w_mean * inv_var_m + (1 - w_mean) * inv_var_b
+    blended_mean = (
+        w_mean * data["model_ev"] * inv_var_m + (1 - w_mean) * data["book_ev"] * inv_var_b
+    ) / total_inv_var
+    blended_alpha = w_shape * model_alpha + (1 - w_shape) * book_alpha
+    blended_beta = blended_alpha / blended_mean
+    base_logpdf = np.clip(
+        gamma_dist.logpdf(data["result"], blended_alpha, scale=1 / blended_beta), clamp, 0
+    )
+    if has_gate:
+        gate_blend = (
+            w_mean * np.asarray(data["gate"], dtype=float) + (1 - w_mean) * data["hist_gate"]
         )
-        if has_gate:
-            gate_blend = (
-                w_mean * np.asarray(data["gate"], dtype=float) + (1 - w_mean) * data["hist_gate"]
-            )
-            loglik = np.where(
-                data["result"] == 0,
-                np.log(np.clip(gate_blend, 1e-12, None)),
-                np.log(np.clip(1 - gate_blend, 1e-12, None)) + base_logpdf,
-            )
-            return -np.mean(loglik)
-        return -np.mean(base_logpdf)
+        loglik = np.where(
+            data["result"] == 0,
+            np.log(np.clip(gate_blend, 1e-12, None)),
+            np.log(np.clip(1 - gate_blend, 1e-12, None)) + base_logpdf,
+        )
+        return -np.mean(loglik)
+    return -np.mean(base_logpdf)
 
 
 def main():

--- a/src/sportstradamus/scripts/plot_parlay_hist.py
+++ b/src/sportstradamus/scripts/plot_parlay_hist.py
@@ -81,50 +81,49 @@ def reflect():
         ]
         if game.empty:
             return np.nan, np.nan
-        else:
-            legs = 0
-            misses = 0
-            for leg in bet:
-                if isinstance(leg, str) and "%" in leg:
-                    legs += 1
-                    if " Under " in leg:
-                        split_leg = leg.split(" Under ")
-                        over = False
+        legs = 0
+        misses = 0
+        for leg in bet:
+            if isinstance(leg, str) and "%" in leg:
+                legs += 1
+                if " Under " in leg:
+                    split_leg = leg.split(" Under ")
+                    over = False
+                else:
+                    split_leg = leg.split(" Over ")
+                    over = True
+                player = split_leg[0]
+                rest = split_leg[1].split(" - ")[0]
+                line = rest.split(" ")[0]
+                market = rest[(len(line) + 1) :].replace("H2H ", "")
+                line = float(line)
+                market = new_map.get(market, market)
+
+                if " + " in player:
+                    players = player.split(" + ")
+                    result1 = game.loc[game[nameStr[bet.League]] == players[0], market]
+                    result2 = game.loc[game[nameStr[bet.League]] == players[1], market]
+                    if result1.empty or result2.empty:
+                        result = result1
                     else:
-                        split_leg = leg.split(" Over ")
-                        over = True
-                    player = split_leg[0]
-                    rest = split_leg[1].split(" - ")[0]
-                    line = rest.split(" ")[0]
-                    market = rest[(len(line) + 1) :].replace("H2H ", "")
-                    line = float(line)
-                    market = new_map.get(market, market)
-
-                    if " + " in player:
-                        players = player.split(" + ")
-                        result1 = game.loc[game[nameStr[bet.League]] == players[0], market]
-                        result2 = game.loc[game[nameStr[bet.League]] == players[1], market]
-                        if result1.empty or result2.empty:
-                            result = result1
-                        else:
-                            result = pd.Series(result1.iat[0] + result2.iat[0])
-                    elif " vs. " in player:
-                        players = player.split(" vs. ")
-                        result1 = game.loc[game[nameStr[bet.League]] == players[0], market]
-                        result2 = game.loc[game[nameStr[bet.League]] == players[1], market]
-                        if result1.empty or result2.empty:
-                            result = result1
-                        else:
-                            result = pd.Series(result1.iat[0] + result2.iat[0])
+                        result = pd.Series(result1.iat[0] + result2.iat[0])
+                elif " vs. " in player:
+                    players = player.split(" vs. ")
+                    result1 = game.loc[game[nameStr[bet.League]] == players[0], market]
+                    result2 = game.loc[game[nameStr[bet.League]] == players[1], market]
+                    if result1.empty or result2.empty:
+                        result = result1
                     else:
-                        result = game.loc[game[nameStr[bet.League]] == player, market]
+                        result = pd.Series(result1.iat[0] + result2.iat[0])
+                else:
+                    result = game.loc[game[nameStr[bet.League]] == player, market]
 
-                    if result.empty or result.iat[0] == line:
-                        legs -= 1
-                    elif (result.iat[0] < line and over) or (result.iat[0] > line and not over):
-                        misses += 1
+                if result.empty or result.iat[0] == line:
+                    legs -= 1
+                elif (result.iat[0] < line and over) or (result.iat[0] > line and not over):
+                    misses += 1
 
-            return legs, misses
+        return legs, misses
 
     parlays.loc[parlays.Legs.isna(), ["Legs", "Misses"]] = (
         parlays.loc[parlays.Legs.isna()].progress_apply(check_bet, axis=1).to_list()

--- a/src/sportstradamus/skew_normal.py
+++ b/src/sportstradamus/skew_normal.py
@@ -22,9 +22,9 @@ from lightgbmlss.distributions.distribution_utils import DistributionClass
 from lightgbmlss.utils import exp_fn, identity_fn, softplus_fn
 from torch.distributions import constraints
 
-# ---------------------------------------------------------------------------
-# PyTorch Distribution: SkewNormal
-# ---------------------------------------------------------------------------
+# Below this z-value, log Φ(z) switches to the erfc tail form (avoids log-underflow
+# in the left tail); above it the direct log(½(1+erf)) form is numerically stable.
+_LOG_NDTR_ERFC_CROSSOVER = -5.0
 
 
 class SkewNormalTorch(D.Distribution):
@@ -69,32 +69,27 @@ class SkewNormalTorch(D.Distribution):
         batch_shape = self.loc.shape
         super().__init__(batch_shape=batch_shape, validate_args=validate_args)
 
-    # ---- helpers ----------------------------------------------------------
     _standard_normal = D.Normal(0.0, 1.0)
 
     @staticmethod
     def _log_ndtr(x: torch.Tensor) -> torch.Tensor:
         """Numerically stable log Φ(x) using erfc for the left tail."""
-        # For large positive x, log(Phi(x)) ≈ 0.
-        # For large negative x, use the erfc formulation to avoid log(0).
         return torch.where(
-            x > -5.0,
+            x > _LOG_NDTR_ERFC_CROSSOVER,
             torch.log(torch.clamp(0.5 * (1.0 + torch.erf(x / math.sqrt(2.0))), min=1e-30)),
             # log(erfc(-x/sqrt(2))/2)  – numerically stable for x << 0
             torch.log(torch.clamp(torch.erfc(-x / math.sqrt(2.0)), min=1e-30)) - math.log(2.0),
         )
 
-    # ---- core methods -----------------------------------------------------
     def log_prob(self, value):
         z = (value - self.loc) / self.scale
         # log(2) + log φ(z) + log Φ(α·z) - log(ω)
-        log_pdf = (
+        return (
             math.log(2.0)
             + self._standard_normal.log_prob(z)
             + self._log_ndtr(self.alpha * z)
             - torch.log(self.scale)
         )
-        return log_pdf
 
     def rsample(self, sample_shape=torch.Size()):
         """Reparameterised sample via the stochastic representation:
@@ -115,8 +110,7 @@ class SkewNormalTorch(D.Distribution):
         # |Z₀| via soft-abs (retains gradient flow)
         abs_z0 = torch.abs(z0)
 
-        x = self.loc + self.scale * (delta * abs_z0 + torch.sqrt(1.0 - delta**2) * z1)
-        return x
+        return self.loc + self.scale * (delta * abs_z0 + torch.sqrt(1.0 - delta**2) * z1)
 
     @property
     def mean(self):
@@ -127,11 +121,6 @@ class SkewNormalTorch(D.Distribution):
     def variance(self):
         delta = self.alpha / torch.sqrt(1.0 + self.alpha**2)
         return self.scale**2 * (1.0 - 2.0 * delta**2 / math.pi)
-
-
-# ---------------------------------------------------------------------------
-# LightGBMLSS Distribution wrapper: SkewNormal
-# ---------------------------------------------------------------------------
 
 
 class SkewNormal(DistributionClass):
@@ -171,7 +160,6 @@ class SkewNormal(DistributionClass):
         loss_fn: str = "nll",
         initialize: bool = False,
     ):
-        # Input Checks
         if stabilization not in ["None", "MAD", "L2"]:
             raise ValueError(
                 "Invalid stabilization method. Please choose from 'None', 'MAD' or 'L2'."
@@ -181,14 +169,12 @@ class SkewNormal(DistributionClass):
         if not isinstance(initialize, bool):
             raise ValueError("Invalid initialize. Please choose from True or False.")
 
-        # Specify Response Functions
         response_functions = {"exp": exp_fn, "softplus": softplus_fn}
         if response_fn in response_functions:
             response_fn = response_functions[response_fn]
         else:
             raise ValueError("Invalid response function. Please choose from 'exp' or 'softplus'.")
 
-        # Set the parameters specific to the distribution
         distribution = SkewNormalTorch
         param_dict = {
             "loc": identity_fn,  # unconstrained
@@ -197,7 +183,6 @@ class SkewNormal(DistributionClass):
         }
         torch.distributions.Distribution.set_default_validate_args(False)
 
-        # Specify Distribution Class
         super().__init__(
             distribution=distribution,
             univariate=True,

--- a/src/sportstradamus/stats/base.py
+++ b/src/sportstradamus/stats/base.py
@@ -104,6 +104,109 @@ def _profile_rows_for_teams(profile: pd.DataFrame, team_keys: pd.Index | list[st
     return profile.reindex(team_keys)
 
 
+def scale_team_volume_to_budget(
+    player_profile: pd.DataFrame,
+    market: str,
+    *,
+    budget_mean: float,
+    typical_rotation: int,
+    avg_unmodeled_min: float,
+    per_player_floor: float,
+    per_player_cap: float,
+) -> None:
+    """Rescale per-player SkewNormal volume projections to a team minutes budget.
+
+    For each team, distributes the (budget - modeled-total) deficit across the
+    team's modeled players precision-weighted by variance, clips each player to
+    ``per_player_cap``, and rescales loc/scale together to preserve every
+    player's coefficient of variation. Mutates ``player_profile`` in place.
+    Shared by the NBA and NHL volume models, which differ only in the per-league
+    ``budget_mean`` derivation and the rotation/floor/cap parameters.
+
+    Two real-world constraints complicate a simple minutes cap:
+
+    1. Overtime: games sometimes go beyond regulation. With probability p_ot per
+       period, each OT adds ot_per_period player-minutes. Modelling this as a
+       geometric process gives:
+           budget_mean = reg_minutes + ot_per_period * p_ot / (1 - p_ot)
+
+    2. Unmodeled players: incomplete roster coverage (rookies, fringe benchwarmers)
+       means some minutes go to players we have no projection for. We reserve:
+           unmodeled_reserve = max(0, typical_rotation - N) * avg_unmodeled_min
+
+    The precision-weighted adjustment is the minimum-information-loss solution to:
+        minimise  sum_i (d_i / sigma_i)^2
+        subject to  sum_i (mu_i + d_i) = target
+        -> d_i = sigma_i^2 / sum_j(sigma_j^2) * (target - total)
+    Players we are most uncertain about absorb the correction; confidently
+    projected players are left largely untouched.
+
+    Args:
+        player_profile: DataFrame with columns ``"team"``, ``"proj {market} loc"``,
+            ``"proj {market} scale"``, and optionally ``"proj {market} alpha"``.
+            Rows with ``team == 0`` are skipped (unassigned players).
+            Writes back ``"proj {market} loc"``, ``"proj {market} scale"``,
+            ``"proj {market} mean"``, and ``"proj {market} std"`` in place.
+        market: Stat name used to construct the column key (e.g. ``"MIN"``).
+        budget_mean: Expected total team volume (minutes or TOI) per game,
+            including overtime expectation.  Units match ``per_player_cap``.
+        typical_rotation: Median number of modeled players per team per game;
+            used to size the unmodeled reserve.
+        avg_unmodeled_min: Mean volume for players outside the modeled tier;
+            units match ``budget_mean``.
+        per_player_floor: Minimum per-player volume used to set the lower target
+            (``N * per_player_floor``).  Units match ``budget_mean``.
+        per_player_cap: Hard ceiling clipped onto each player's new mean before
+            ratio rescaling.
+    """
+    teams = player_profile.loc[player_profile["team"] != 0].groupby("team")
+    for _team, team_df in teams:
+        loc = team_df[f"proj {market} loc"].copy()
+        scale = team_df[f"proj {market} scale"].copy()
+        sn_alpha = (
+            team_df[f"proj {market} alpha"].copy()
+            if f"proj {market} alpha" in team_df.columns
+            else pd.Series(0, index=loc.index)
+        )
+        N = len(team_df)
+
+        delta = sn_alpha / np.sqrt(1 + sn_alpha**2)
+        true_means = loc + scale * delta * np.sqrt(2 / np.pi)
+        true_vars = scale**2
+
+        total = true_means.sum()
+        if total <= 0:
+            continue
+
+        unmodeled_count = max(0, typical_rotation - N)
+        unmodeled_reserve = unmodeled_count * avg_unmodeled_min
+
+        upper_target = budget_mean - unmodeled_reserve
+        lower_target = N * per_player_floor
+        target = max(upper_target, lower_target)
+
+        deficit = target - total
+        total_var = true_vars.sum()
+        if total_var > 0:
+            adjustments = true_vars / total_var * deficit
+        else:
+            adjustments = true_means / total * deficit
+
+        new_means = (true_means + adjustments).clip(lower=0, upper=per_player_cap)
+
+        ratio = new_means / true_means.replace(0, np.nan)
+        ratio = ratio.fillna(1.0).clip(
+            lower=_VOLUME_SCALE_RATIO_FLOOR, upper=_VOLUME_SCALE_RATIO_CAP
+        )
+        new_scale = scale * ratio
+        new_loc = new_means - new_scale * delta * np.sqrt(2 / np.pi)
+
+        player_profile.loc[loc.index, f"proj {market} loc"] = new_loc
+        player_profile.loc[scale.index, f"proj {market} scale"] = new_scale
+        player_profile.loc[loc.index, f"proj {market} mean"] = new_means
+        player_profile.loc[scale.index, f"proj {market} std"] = new_scale
+
+
 class Stats:
     """A parent class for handling and analyzing sports statistics.
 

--- a/src/sportstradamus/stats/nba.py
+++ b/src/sportstradamus/stats/nba.py
@@ -35,11 +35,10 @@ from sportstradamus.helpers.io import read_gamelog, write_gamelog
 from sportstradamus.spiderLogger import logger
 from sportstradamus.stats import nba_client
 from sportstradamus.stats.base import (
-    _VOLUME_SCALE_RATIO_CAP,
-    _VOLUME_SCALE_RATIO_FLOOR,
     Stats,
     archive,
     clean_data,
+    scale_team_volume_to_budget,
     scraper,
 )
 from sportstradamus.stats.nba_client import NBAStatsError
@@ -1297,7 +1296,6 @@ class StatsNBA(Stats):
                 logger.warning(f"{filename} missing")
                 return []
 
-        # Slice to the trained schema embedded in the pickle.
         cols = self._volume_model_cache["expected_columns"]
         if any(col not in playerStats.columns for col in cols):
             logger.warning(f"Gamelog missing - {date}")
@@ -1326,7 +1324,6 @@ class StatsNBA(Stats):
         # Drop gate column for ZI distributions — not needed for budget normalization
         prob_params.drop(columns=["gate"], inplace=True, errors="ignore")
 
-        # SkewNormal: rename loc/scale/alpha to proj {market} loc/scale/alpha
         rename_map = {
             "loc": f"proj {market} loc",
             "scale": f"proj {market} scale",
@@ -1340,53 +1337,13 @@ class StatsNBA(Stats):
             columns=[col for col in self.playerProfile.columns if "_obs" in col], inplace=True
         )
 
-        # ------------------------------------------------------------------
-        # Minutes-budget normalization
-        #
-        # Two real-world constraints complicate a simple 300-minute cap:
-        #
-        #   1. Overtime: Games sometimes go beyond regulation. With probability
-        #      p_ot per period, each OT adds ot_per_period player-minutes.
-        #      Modelling this as a geometric process gives an expected total of:
-        #          budget_mean = reg_minutes + ot_per_period * p_ot / (1 - p_ot)
-        #
-        #   2. Unmodeled players: When our roster coverage is incomplete (e.g.
-        #      rookies or fringe benchwarmers lacking enough data), those players
-        #      still consume real minutes. We reserve a portion of the budget for
-        #      them so we don't over-inflate the projections of modeled players.
-        #          unmodeled_reserve = max(0, typical_rotation - N) * avg_unmodeled_min
-        #
-        # Given these facts, the target range for modeled players' total is:
-        #   lower_target = N * per_player_floor   (sanity floor — each player logged)
-        #   upper_target = budget_mean - unmodeled_reserve
-        #
-        # When the projected total falls outside [lower_target, upper_target] we
-        # apply a precision-weighted adjustment. Rather than scaling everyone by
-        # the same factor, we distribute the correction in proportion to each
-        # player's variance. This is the minimum-information-loss solution to the
-        # constrained optimisation:
-        #
-        #   minimise  sum_i (d_i / sigma_i)^2
-        #   subject to  sum_i (mu_i + d_i) = target
-        #
-        #   -> d_i = sigma_i^2 / sum_j(sigma_j^2) * (target - total)
-        #
-        # Players we are most uncertain about absorb the correction; confidently
-        # projected players are left largely untouched.
-        # ------------------------------------------------------------------
-
-        # ------------------------------------------------------------------
-        # Budget parameters — derived by analyzing historical gamelogs.
-        #
-        # Methodology (run offline against self.gamelog, hardcoded for speed):
+        # Budget parameters derived from historical gamelogs (methodology in
+        # scale_team_volume_to_budget docstring):
         #   typical_rotation : median players logging >3 min per team per game
-        #   ot_rate          : fraction of games where any player exceeded
-        #                      regulation max minutes (0.55% NBA, 3.9% WNBA)
-        #   avg_unmodeled_min: mean minutes for players ranked beyond the top-7
-        #                      modeled tier (ranks 8-10 NBA, 8-9 WNBA)
-        #   per_player_floor : 5th-percentile minutes for top-7 tier players
+        #   ot_rate          : fraction of games going to OT (6% NBA, 3.9% WNBA)
+        #   avg_unmodeled_min: mean min for players ranked beyond the modeled tier
+        #   per_player_floor : 5th-pct min for top-7 tier players
         #   per_player_cap   : regulation max + one 5-min OT period (hard rule)
-        # ------------------------------------------------------------------
         if self.league == "NBA":
             reg_minutes = 240  # 5 players × 48 min regulation
             ot_per_period = 25  # 5 players × 5 min per OT period
@@ -1408,55 +1365,15 @@ class StatsNBA(Stats):
         ot_expected = ot_per_period * ot_rate / (1.0 - ot_rate)
         budget_mean = reg_minutes + ot_expected
 
-        teams = self.playerProfile.loc[self.playerProfile["team"] != 0].groupby("team")
-        for _team, team_df in teams:
-            # SkewNormal: E[X] = loc + scale * delta * sqrt(2/pi) where delta = alpha/sqrt(1+alpha^2)
-            loc = team_df[f"proj {market} loc"].copy()
-            scale = team_df[f"proj {market} scale"].copy()
-            sn_alpha = (
-                team_df[f"proj {market} alpha"].copy()
-                if f"proj {market} alpha" in team_df.columns
-                else pd.Series(0, index=loc.index)
-            )
-            N = len(team_df)
-
-            delta = sn_alpha / np.sqrt(1 + sn_alpha**2)
-            true_means = loc + scale * delta * np.sqrt(2 / np.pi)
-            true_vars = scale**2
-
-            total = true_means.sum()
-            if total <= 0:
-                continue
-
-            # Minutes reserved for fringe bench players not captured in our model.
-            unmodeled_count = max(0, typical_rotation - N)
-            unmodeled_reserve = unmodeled_count * avg_unmodeled_min
-
-            upper_target = budget_mean - unmodeled_reserve
-            lower_target = N * per_player_floor
-            target = max(upper_target, lower_target)
-
-            # Precision-weighted deficit distribution
-            deficit = target - total
-            total_var = true_vars.sum()
-            if total_var > 0:
-                adjustments = true_vars / total_var * deficit
-            else:
-                adjustments = true_means / total * deficit
-            new_means = (true_means + adjustments).clip(lower=0, upper=per_player_cap)
-
-            # Scale both loc and scale to preserve coefficient of variation
-            ratio = new_means / true_means.replace(0, np.nan)
-            ratio = ratio.fillna(1.0).clip(
-                lower=_VOLUME_SCALE_RATIO_FLOOR, upper=_VOLUME_SCALE_RATIO_CAP
-            )
-            new_scale = scale * ratio
-            new_loc = new_means - new_scale * delta * np.sqrt(2 / np.pi)
-
-            self.playerProfile.loc[loc.index, f"proj {market} loc"] = new_loc
-            self.playerProfile.loc[scale.index, f"proj {market} scale"] = new_scale
-            self.playerProfile.loc[loc.index, f"proj {market} mean"] = new_means
-            self.playerProfile.loc[scale.index, f"proj {market} std"] = new_scale
+        scale_team_volume_to_budget(
+            self.playerProfile,
+            market,
+            budget_mean=budget_mean,
+            typical_rotation=typical_rotation,
+            avg_unmodeled_min=avg_unmodeled_min,
+            per_player_floor=per_player_floor,
+            per_player_cap=per_player_cap,
+        )
 
         self.playerProfile.fillna(0, inplace=True)
         return None

--- a/src/sportstradamus/stats/nfl_fp_weekly_aggregate.py
+++ b/src/sportstradamus/stats/nfl_fp_weekly_aggregate.py
@@ -38,7 +38,7 @@ a ``target_game_date`` was passed.
 from __future__ import annotations
 
 import json
-from collections.abc import Sequence
+from collections.abc import Iterator, Sequence
 from dataclasses import dataclass
 
 import numpy as np
@@ -1075,6 +1075,23 @@ def _dispatch(df: pd.DataFrame, recipe: _Recipe) -> pd.Series | None:
     return None
 
 
+def _iter_bucket_payloads(df: pd.DataFrame) -> Iterator[tuple[object, dict[str, object]]]:
+    """Yield ``(player_id, payload)`` for each row whose JSON ``bucket`` parses to a dict.
+
+    Shared preamble for the separation/coverage aggregators — each reads the
+    same per-game ``bucket`` JSON column but extracts different inner keys.
+    """
+    for player_id, bucket_str in zip(df[PLAYER_GROUP_COL], df["bucket"], strict=True):
+        if not isinstance(bucket_str, str) or not bucket_str:
+            continue
+        try:
+            payload = json.loads(bucket_str)
+        except (TypeError, ValueError):
+            continue
+        if isinstance(payload, dict):
+            yield player_id, payload
+
+
 def _aggregate_separation_by_routes(
     windows: Sequence[tuple[int, int, int]],
 ) -> pd.DataFrame:
@@ -1102,15 +1119,7 @@ def _aggregate_separation_by_routes(
         return pd.DataFrame()
 
     long_rows: list[dict[str, object]] = []
-    for player_id, bucket_str in zip(df[PLAYER_GROUP_COL], df["bucket"], strict=True):
-        if not isinstance(bucket_str, str) or not bucket_str:
-            continue
-        try:
-            payload = json.loads(bucket_str)
-        except (TypeError, ValueError):
-            continue
-        if not isinstance(payload, dict):
-            continue
+    for player_id, payload in _iter_bucket_payloads(df):
         for route_key, route_payload in payload.items():
             if not isinstance(route_payload, dict):
                 continue
@@ -1241,15 +1250,7 @@ def _aggregate_separation_by_coverage(
         return pd.DataFrame()
 
     long_rows: list[dict[str, object]] = []
-    for player_id, bucket_str in zip(df[PLAYER_GROUP_COL], df["bucket"], strict=True):
-        if not isinstance(bucket_str, str) or not bucket_str:
-            continue
-        try:
-            payload = json.loads(bucket_str)
-        except (TypeError, ValueError):
-            continue
-        if not isinstance(payload, dict):
-            continue
+    for player_id, payload in _iter_bucket_payloads(df):
         for bucket_name, key in _SEP_BY_COVERAGE_SCHEMES.items():
             inner = payload.get(key)
             if not isinstance(inner, dict):
@@ -1311,15 +1312,7 @@ def _aggregate_separation_by_alignment_bucket(
         return pd.DataFrame()
 
     long_rows: list[dict[str, object]] = []
-    for player_id, bucket_str in zip(df[PLAYER_GROUP_COL], df["bucket"], strict=True):
-        if not isinstance(bucket_str, str) or not bucket_str:
-            continue
-        try:
-            payload = json.loads(bucket_str)
-        except (TypeError, ValueError):
-            continue
-        if not isinstance(payload, dict):
-            continue
+    for player_id, payload in _iter_bucket_payloads(df):
         for align_name, key in _SEP_BY_ALIGNMENT_BUCKETS.items():
             inner = payload.get(key)
             if not isinstance(inner, dict):
@@ -1398,15 +1391,7 @@ def _aggregate_man_vs_zone_bucket(
         return pd.DataFrame()
 
     long_rows: list[dict[str, object]] = []
-    for player_id, bucket_str in zip(df[PLAYER_GROUP_COL], df["bucket"], strict=True):
-        if not isinstance(bucket_str, str) or not bucket_str:
-            continue
-        try:
-            payload = json.loads(bucket_str)
-        except (TypeError, ValueError):
-            continue
-        if not isinstance(payload, dict):
-            continue
+    for player_id, payload in _iter_bucket_payloads(df):
         for shell_name, key in _MZ_BUCKETS.items():
             inner = payload.get(key)
             if not isinstance(inner, dict):

--- a/src/sportstradamus/stats/nhl.py
+++ b/src/sportstradamus/stats/nhl.py
@@ -34,11 +34,10 @@ from sportstradamus.helpers import (
 from sportstradamus.helpers.io import write_gamelog
 from sportstradamus.spiderLogger import logger
 from sportstradamus.stats.base import (
-    _VOLUME_SCALE_RATIO_CAP,
-    _VOLUME_SCALE_RATIO_FLOOR,
     Stats,
     archive,
     clean_data,
+    scale_team_volume_to_budget,
     scraper,
 )
 
@@ -823,7 +822,6 @@ class StatsNHL(Stats):
 
         if filename in self._volume_model_cache:
             filedict = self._volume_model_cache[filename]
-            # Slice to the trained schema embedded in the pickle.
             playerStats = playerStats[filedict["expected_columns"]]
             model = filedict["model"]
             dist = filedict["distribution"]
@@ -851,7 +849,6 @@ class StatsNHL(Stats):
         # Drop gate column for ZI distributions — not needed for budget normalization
         prob_params.drop(columns=["gate"], inplace=True, errors="ignore")
 
-        # SkewNormal: rename loc/scale/alpha to proj {market} loc/scale/alpha
         rename_map = {
             "loc": f"proj {market} loc",
             "scale": f"proj {market} scale",
@@ -866,17 +863,13 @@ class StatsNHL(Stats):
         )
 
         if not pitcher:
-            # ------------------------------------------------------------------
-            # Budget parameters — derived by analyzing historical NHL gamelogs.
-            #
-            # Methodology:
+            # Budget parameters derived from historical NHL gamelogs:
             #   typical_rotation : median skaters (non-G) logging >3 min per team-game
             #   ot_rate          : fraction of team-games where total skater TOI > 300
             #   ot_extra         : mean extra team TOI above 300 when OT occurs (9.6 min)
             #   avg_unmodeled_min: mean TOI for ranked 8-18 skaters (rank > 7 tier)
-            #   per_player_floor : 5th-percentile TOI for top-7 tier skaters
-            #   per_player_cap   : 99th-percentile TOI for top-7 tier skaters
-            # ------------------------------------------------------------------
+            #   per_player_floor : 5th-pct TOI for top-7 tier skaters
+            #   per_player_cap   : 99th-pct TOI for top-7 tier skaters
             reg_minutes = 300  # 5 skaters × 60 min regulation
             ot_rate = 0.189  # measured: 18.9% of team-games go to OT
             ot_extra = 9.6  # measured: mean extra team TOI when OT occurs
@@ -888,56 +881,15 @@ class StatsNHL(Stats):
             # Expected total team TOI including OT
             budget_mean = reg_minutes + ot_rate * ot_extra
 
-            teams = self.playerProfile.loc[self.playerProfile["team"] != 0].groupby("team")
-            for _team, team_df in teams:
-                # SkewNormal: E[X] = loc + scale * delta * sqrt(2/pi)
-                loc = team_df[f"proj {market} loc"].copy()
-                scale = team_df[f"proj {market} scale"].copy()
-                sn_alpha = (
-                    team_df[f"proj {market} alpha"].copy()
-                    if f"proj {market} alpha" in team_df.columns
-                    else pd.Series(0, index=loc.index)
-                )
-                N = len(team_df)
-
-                delta = sn_alpha / np.sqrt(1 + sn_alpha**2)
-                true_means = loc + scale * delta * np.sqrt(2 / np.pi)
-                true_vars = scale**2
-
-                total = true_means.sum()
-                if total <= 0:
-                    continue
-
-                # Reserve TOI for the many unmodeled skaters (rank 8-18)
-                unmodeled_count = max(0, typical_rotation - N)
-                unmodeled_reserve = unmodeled_count * avg_unmodeled_min
-
-                upper_target = budget_mean - unmodeled_reserve
-                lower_target = N * per_player_floor
-                target = max(upper_target, lower_target)
-
-                # Precision-weighted deficit distribution
-                deficit = target - total
-                total_var = true_vars.sum()
-                if total_var > 0:
-                    adjustments = true_vars / total_var * deficit
-                else:
-                    adjustments = true_means / total * deficit
-
-                new_means = (true_means + adjustments).clip(lower=0, upper=per_player_cap)
-
-                # Scale both loc and scale to preserve coefficient of variation
-                ratio = new_means / true_means.replace(0, np.nan)
-                ratio = ratio.fillna(1.0).clip(
-                    lower=_VOLUME_SCALE_RATIO_FLOOR, upper=_VOLUME_SCALE_RATIO_CAP
-                )
-                new_scale = scale * ratio
-                new_loc = new_means - new_scale * delta * np.sqrt(2 / np.pi)
-
-                self.playerProfile.loc[loc.index, f"proj {market} loc"] = new_loc
-                self.playerProfile.loc[scale.index, f"proj {market} scale"] = new_scale
-                self.playerProfile.loc[loc.index, f"proj {market} mean"] = new_means
-                self.playerProfile.loc[scale.index, f"proj {market} std"] = new_scale
+            scale_team_volume_to_budget(
+                self.playerProfile,
+                market,
+                budget_mean=budget_mean,
+                typical_rotation=typical_rotation,
+                avg_unmodeled_min=avg_unmodeled_min,
+                per_player_floor=per_player_floor,
+                per_player_cap=per_player_cap,
+            )
 
         # Drop SkewNormal parameters (keep only mean/std for downstream use)
         self.playerProfile.drop(

--- a/src/sportstradamus/training/calibration.py
+++ b/src/sportstradamus/training/calibration.py
@@ -32,6 +32,11 @@ _ZINB_ZERO_INFLATION_THRESHOLD: float = 0.1
 # over/under threshold near the bookmaker line.
 _ZAGAMMA_ZERO_INFLATION_THRESHOLD: float = 0.05
 
+# Minimum graded (book line vs realized result) samples before per-book weights
+# are fit. With fewer, the fit overfits a handful of games, so the caller keeps
+# the prior weights instead.
+_MIN_SAMPLES_FOR_BOOK_FIT: int = 9
+
 
 def fit_book_weights(league: str, market: str, stat_data, archive, book_weights: dict) -> dict:
     """Fit optimal weights for multiple sportsbooks using historical accuracy."""
@@ -147,7 +152,7 @@ def fit_book_weights(league: str, market: str, stat_data, archive, book_weights:
     x = test_df.loc[~test_df.isna().all(axis=1)].to_numpy()
     x[x < 0] = np.nan
     y = result.loc[~test_df.isna().all(axis=1)].to_numpy()
-    if len(x) > 9:
+    if len(x) > _MIN_SAMPLES_FOR_BOOK_FIT:
         prev_weights = book_weights.get(league, {}).get(market, {})
         guess = {}
         for book in test_df.columns:

--- a/src/sportstradamus/training/calibration.py
+++ b/src/sportstradamus/training/calibration.py
@@ -6,7 +6,9 @@ import numpy as np
 from scipy.optimize import minimize
 from scipy.stats import fit, gamma, nbinom, norm, poisson, skewnorm
 
-from sportstradamus.helpers import fused_loc, stat_cv
+from sportstradamus.helpers import fused_loc, get_logger, stat_cv
+
+logger = get_logger(__name__)
 
 # Blend-weight bounds for the model-vs-book optimization. 0.05 keeps a minimum
 # bookmaker signal even when the model is dominant; 0.9 keeps a minimum model
@@ -43,7 +45,7 @@ def fit_book_weights(league: str, market: str, stat_data, archive, book_weights:
     warnings.simplefilter("ignore", UserWarning)
     from sportstradamus.training.config import load_distribution_config
 
-    print(f"Fitting Book Weights - {league}, {market}")
+    logger.info("Fitting Book Weights - %s, %s", league, market)
     df = archive.to_pandas(league, market)
     df = df[[col for col in df.columns if col != "pinnacle"]]
     if len([col for col in df.columns if col not in ["Line", "Result", "Over"]]) == 0:
@@ -336,10 +338,7 @@ def select_distribution(player_stats) -> tuple[str, float]:
         resolutions = player_stats.apply(_player_resolution).dropna()
         resolution = resolutions.median()
         dist = "NegBin" if resolution > _NEGBIN_RESOLUTION_THRESHOLD else "Gamma"
-        print(
-            f"  Resolution: {resolution:.4f}"
-            f" ({'NegBin' if resolution > _NEGBIN_RESOLUTION_THRESHOLD else 'Gamma'})"
-        )
+        logger.info("  Resolution: %.4f (%s)", resolution, dist)
 
     observed_zeros = player_stats.agg(lambda x: x.eq(0).mean())
 
@@ -367,8 +366,9 @@ def select_distribution(player_stats) -> tuple[str, float]:
         if p_zero > _ZAGAMMA_ZERO_INFLATION_THRESHOLD:
             dist = "ZAGamma"
 
-    print(f"  Data type: {f'integer (step={int(step)})' if is_integer else 'continuous'}")
-    print(f"  Zero inflation - {p_zero:.4f}")
-    print(f"  Selected: {dist}")
+    data_type = f"integer (step={int(step)})" if is_integer else "continuous"
+    logger.info("  Data type: %s", data_type)
+    logger.info("  Zero inflation - %.4f", p_zero)
+    logger.info("  Selected: %s", dist)
 
     return dist, p_zero

--- a/src/sportstradamus/training/cli.py
+++ b/src/sportstradamus/training/cli.py
@@ -227,7 +227,7 @@ def meditate(
             if stat_data is None:
                 continue
             stat_data.update_player_comps()
-            correlate(lg, stat_data, force)
+            correlate(lg, stat_data, force=force)
         return
 
     archive = Archive()
@@ -260,7 +260,7 @@ def meditate(
             json.dump(book_weights, outfile, indent=4)
 
         stat_data.update_player_comps()
-        correlate(lg, stat_data, force)
+        correlate(lg, stat_data, force=force)
         league_start_date = stat_data.trim_gamelog()
 
         for market in markets:
@@ -293,9 +293,9 @@ def meditate(
                 lg,
                 market,
                 stat_data,
-                force,
                 archive,
                 league_start_date,
+                force=force,
                 deterministic=deterministic,
                 target_strategy=cell_strategy,
                 zinb_mode=zinb_mode,

--- a/src/sportstradamus/training/correlate.py
+++ b/src/sportstradamus/training/correlate.py
@@ -31,6 +31,9 @@ import pandas as pd
 from tqdm import tqdm
 
 from sportstradamus import data
+from sportstradamus.helpers import get_logger
+
+logger = get_logger(__name__)
 
 # Lookback window for game inclusion. ~1 calendar year covers a full regular
 # season + post-season for the major leagues.
@@ -745,7 +748,7 @@ def correlate(league: str, stat_data, force: bool = False) -> None:
     When the prior run's outputs are present and the inputs are unchanged
     (gamelog freshness, tracked stat schema, and module constants all
     match the prior ``cache_key`` in ``corr_metadata.json``), the function
-    prints a "cache valid" line and returns without recomputing. Pass
+    logs a "cache valid" line and returns without recomputing. Pass
     ``force=True`` (CLI: ``--rebuild-correlations`` or ``--force``) to
     bypass the skip.
 
@@ -771,12 +774,12 @@ def correlate(league: str, stat_data, force: bool = False) -> None:
             per-game record cache from scratch instead of reusing the prior
             run's parquet.
     """
-    print(f"Correlating {league}...")
+    logger.info("Correlating %s...", league)
     log = stat_data
 
     cache_key = _build_cache_key(league, log)
     if not force and _corr_outputs_present(league) and _cache_key_matches(league, cache_key):
-        print(f"Correlating {league}... cache valid, skipped")
+        logger.info("Correlating %s... cache valid, skipped", league)
         return
 
     training_data_dir = pkg_resources.files(data) / "training_data"

--- a/src/sportstradamus/training/correlate.py
+++ b/src/sportstradamus/training/correlate.py
@@ -742,7 +742,7 @@ def _stratify_team_pairs(team_corr: pd.Series) -> tuple[pd.Series, pd.Series]:
     return same, cross
 
 
-def correlate(league: str, stat_data, force: bool = False) -> None:
+def correlate(league: str, stat_data, *, force: bool = False) -> None:
     """Build stratified per-league correlation matrices and metadata sidecar.
 
     When the prior run's outputs are present and the inputs are unchanged

--- a/src/sportstradamus/training/hyperparams.py
+++ b/src/sportstradamus/training/hyperparams.py
@@ -3,6 +3,10 @@
 import numpy as np
 import torch
 
+from sportstradamus.helpers import get_logger
+
+logger = get_logger(__name__)
+
 
 class _BoundedResponseFn:
     """Picklable callable that clamps a response function's output."""
@@ -92,17 +96,17 @@ def warm_start_hyper_opt(
 
     study.optimize(objective, n_trials=n_trials, timeout=60 * max_minutes, show_progress_bar=True)
 
-    print("\nWarm-Start Hyper-Parameter Optimization finished.")
-    print("  Number of finished trials: ", len(study.trials))
-    print("  Best trial:")
+    logger.info("Warm-Start Hyper-Parameter Optimization finished.")
+    logger.info("  Number of finished trials: %d", len(study.trials))
+    logger.info("  Best trial:")
     opt_param = study.best_trial
     opt_param.params["opt_rounds"] = int(
         study.trials_dataframe()["user_attrs_opt_round"][study.trials_dataframe()["value"].idxmin()]
     )
 
-    print(f"    Value: {opt_param.value}")
-    print("    Params: ")
+    logger.info("    Value: %s", opt_param.value)
+    logger.info("    Params:")
     for key, value in opt_param.params.items():
-        print(f"    {key}: {value}")
+        logger.info("    %s: %s", key, value)
 
     return opt_param.params

--- a/src/sportstradamus/training/pipeline.py
+++ b/src/sportstradamus/training/pipeline.py
@@ -506,6 +506,7 @@ def _step_load_matrix(
     stat_data,
     league: str,
     market: str,
+    *,
     deterministic: bool,
     force: bool,
     need_model: bool,
@@ -593,7 +594,7 @@ def _step_synthesize_odds(
 
 
 def _step_persist_matrix_and_comps(
-    M: pd.DataFrame, filepath, deterministic: bool, stat_data
+    M: pd.DataFrame, filepath, stat_data, *, deterministic: bool
 ) -> pd.DataFrame:
     """Trim the matrix, write parquet, save comps. Deterministic mode skips I/O."""
     M = trim_matrix(M, 15000)
@@ -728,6 +729,7 @@ def _step_build_lss_model(
     dist_obj,
     X_train,
     shape_ceiling,
+    *,
     normalize: bool,
     offset_mode: bool,
     use_hurdle: bool,
@@ -765,10 +767,11 @@ def _step_select_hyperparams(
     X_train,
     dist: str,
     model,
-    use_hurdle: bool,
-    deterministic: bool,
     opt_params_in: dict | None,
     dtrain,
+    *,
+    use_hurdle: bool,
+    deterministic: bool,
 ) -> tuple[dict, list[int]]:
     """Pick Optuna-tuned params, warm-start, or the deterministic fixed set.
 
@@ -845,13 +848,13 @@ def _step_select_hyperparams(
 
 
 def _step_fit_model(
-    use_hurdle: bool,
     dist: str,
     dist_obj,
     X_train,
     y_train_labels,
     opt_params: dict,
     *,
+    use_hurdle: bool,
     normalize: bool,
     offset_mode: bool,
     shape_ceiling,
@@ -877,7 +880,7 @@ def _step_fit_model(
 
 
 def _step_predict_splits(
-    model, dist: str, splits: dict, normalize: bool, offset_mode: bool
+    model, dist: str, splits: dict, *, normalize: bool, offset_mode: bool
 ) -> dict:
     """Predict raw distribution params on train/validation/test splits.
 
@@ -1885,6 +1888,7 @@ def _step_select_distribution(
     league: str,
     target_strategy: str,
     zinb_mode: str,
+    *,
     deterministic: bool,
 ) -> dict:
     """Choose distribution family + apply target transform + compute shape priors.
@@ -2031,9 +2035,10 @@ def train_market(
     league: str,
     market: str,
     stat_data,
-    force: bool,
     archive,
     league_start_date,
+    *,
+    force: bool,
     deterministic: bool = False,
     target_strategy: str = "ratio_meanyr",
     zinb_mode: str = "joint",
@@ -2074,6 +2079,8 @@ def train_market(
             when the count-branch chooses ``dist == "ZINB"``. ``"joint"`` is
             byte-identical to pre-P2.B production behavior.
     """
+    # style: allow-length  pre-existing research orchestrator (§2.8/§18.9): flag,
+    # don't split. Already over the limit before the FBT keyword-only conversion.
     if zinb_mode not in {"joint", "hurdle"}:
         raise ValueError(f"zinb_mode must be 'joint' or 'hurdle', got {zinb_mode!r}")
 
@@ -2089,20 +2096,22 @@ def train_market(
         stat_data,
         league,
         market,
-        deterministic,
-        force,
-        init["need_model"],
+        deterministic=deterministic,
+        force=force,
+        need_model=init["need_model"],
     )
     if loaded is None:
         return
     M, training_data_path = loaded
 
     M, step = _step_synthesize_odds(M, league, market, dist, cv)
-    M = _step_persist_matrix_and_comps(M, training_data_path, deterministic, stat_data)
+    M = _step_persist_matrix_and_comps(
+        M, training_data_path, stat_data, deterministic=deterministic
+    )
 
     splits = _step_build_splits(M, stat_data, market)
     dist_info = _step_select_distribution(
-        splits, stat_data, market, league, target_strategy, zinb_mode, deterministic
+        splits, stat_data, market, league, target_strategy, zinb_mode, deterministic=deterministic
     )
     dist = dist_info["dist"]
     cv = dist_info["cv"]
@@ -2115,9 +2124,9 @@ def train_market(
         dist_info["dist_obj"],
         splits["X_train"],
         shape_ceiling,
-        dist_info["normalize"],
-        dist_info["offset_mode"],
-        use_hurdle,
+        normalize=dist_info["normalize"],
+        offset_mode=dist_info["offset_mode"],
+        use_hurdle=use_hurdle,
     )
     dtrain = lgb.Dataset(splits["X_train"], label=splits["y_train_labels"])
     opt_params_in = filedict.get("params")
@@ -2125,18 +2134,18 @@ def train_market(
         splits["X_train"],
         dist,
         model,
-        use_hurdle,
-        deterministic,
         opt_params_in,
         dtrain,
+        use_hurdle=use_hurdle,
+        deterministic=deterministic,
     )
     model = _step_fit_model(
-        use_hurdle,
         dist,
         dist_info["dist_obj"],
         splits["X_train"],
         splits["y_train_labels"],
         opt_params,
+        use_hurdle=use_hurdle,
         normalize=dist_info["normalize"],
         offset_mode=dist_info["offset_mode"],
         shape_ceiling=shape_ceiling,
@@ -2144,7 +2153,7 @@ def train_market(
     )
 
     preds = _step_predict_splits(
-        model, dist, splits, dist_info["normalize"], dist_info["offset_mode"]
+        model, dist, splits, normalize=dist_info["normalize"], offset_mode=dist_info["offset_mode"]
     )
     prob_params = preds["prob_params"]
 

--- a/src/sportstradamus/training/pipeline.py
+++ b/src/sportstradamus/training/pipeline.py
@@ -487,7 +487,7 @@ def _step_init_market(league: str, market: str, stat_data, archive) -> dict:
         cv = stat_cv[league].get(market, 1)
         step = None
 
-    print(f"Training {league} - {market}")
+    logger.info("Training %s - %s", league, market)
     cv = stat_cv[league].get(market, 1)
     return {
         "filedict": filedict,
@@ -545,7 +545,7 @@ def _step_load_matrix(
 
     M = pd.concat([M, new_M], ignore_index=True)
     if M.empty:
-        print(f"  No usable training data for {league} {market}, skipping")
+        logger.warning("  No usable training data for %s %s, skipping", league, market)
         return None
     M.Date = pd.to_datetime(M.Date, format="mixed")
     if "Player" in M.columns:

--- a/src/sportstradamus/training/pipeline.py
+++ b/src/sportstradamus/training/pipeline.py
@@ -66,6 +66,9 @@ _PROBA_CLIP = 1e-6
 # accuracy / over% statistics.  Mirrors the live scoring path in
 # prediction/scoring.py. Value from CLAUDE.md "Performance Table".
 _MODE_CONFIDENCE_THRESHOLD: float = 0.54
+# Minimum rows in an EV-conditioned, confidence-masked subset before its over-
+# rate is reported; thinner slices give a noisy mean, so the diagnostic is NaN.
+_MIN_DIAGNOSTIC_ROWS: int = 10
 # Temporal train/test split fraction: earliest 70% of the matrix goes to
 # training, latest 30% is held out for evaluation.  Temporal ordering (not
 # random split) prevents look-ahead leakage of player form.
@@ -1082,12 +1085,12 @@ def _step_compute_diagnostics(
     conf_mask = np.max(y_proba_no_filt, axis=1) > _MODE_CONFIDENCE_THRESHOLD
     diag_over_pct_ev_gt = (
         float(y_class[ev_gt_mask & conf_mask].mean())
-        if (ev_gt_mask & conf_mask).sum() > 10
+        if (ev_gt_mask & conf_mask).sum() > _MIN_DIAGNOSTIC_ROWS
         else float("nan")
     )
     diag_over_pct_ev_lt = (
         float(y_class[ev_lt_mask & conf_mask].mean())
-        if (ev_lt_mask & conf_mask).sum() > 10
+        if (ev_lt_mask & conf_mask).sum() > _MIN_DIAGNOSTIC_ROWS
         else float("nan")
     )
 
@@ -1116,7 +1119,9 @@ def _step_compute_diagnostics(
         cf_pred = (cf_over > 0.5).astype(int)
         cf_mask = np.maximum(cf_under, cf_over) > _MODE_CONFIDENCE_THRESHOLD
         diag_cf_over_pct = (
-            float(cf_pred[cf_mask].mean() / cf_mask.mean()) if cf_mask.sum() > 10 else float("nan")
+            float(cf_pred[cf_mask].mean() / cf_mask.mean())
+            if cf_mask.sum() > _MIN_DIAGNOSTIC_ROWS
+            else float("nan")
         )
     else:
         diag_cf_over_pct = float("nan")

--- a/tests/golden/test_correlate.py
+++ b/tests/golden/test_correlate.py
@@ -263,7 +263,7 @@ def test_rebuild_correlations_does_not_touch_models(monkeypatch) -> None:
 
     calls: list[tuple[str, bool]] = []
 
-    def fake_correlate(league: str, stat_data, force: bool = False) -> None:
+    def fake_correlate(league: str, stat_data, *, force: bool = False) -> None:
         calls.append((league, force))
 
     monkeypatch.setattr("sportstradamus.training.cli.StatsNBA", _StubStats)

--- a/tests/golden/test_correlate.py
+++ b/tests/golden/test_correlate.py
@@ -228,23 +228,32 @@ def test_correlate_skips_when_cache_valid(_preserve_nba_correlate_outputs) -> No
     assert first_same_mtime == second_same_mtime, "skip path must not rewrite the parquet"
 
 
-def test_correlate_force_bypasses_skip(_preserve_nba_correlate_outputs, capsys) -> None:
+def test_correlate_force_bypasses_skip(_preserve_nba_correlate_outputs, caplog) -> None:
     """``force=True`` always rebuilds, even when the cache_key matches."""
+    import logging
+
     stub = _StubStats()
 
     correlate("NBA", stub, force=True)
-    capsys.readouterr()  # discard the priming-run banner
 
+    # correlate's logger sets propagate=False (helpers.get_logger), so attach
+    # caplog's handler directly to it by its real name to capture INFO records.
+    target = logging.getLogger("sportstradamus.cli.sportstradamus.training.correlate")
+    target.addHandler(caplog.handler)
+    caplog.clear()
     # Inputs are identical and the metadata is freshly valid — but force=True
-    # must still take the full rebuild path. The skip banner would print
-    # "Correlating NBA... cache valid, skipped"; the rebuild banner prints
+    # must still take the full rebuild path. The skip path logs
+    # "Correlating NBA... cache valid, skipped"; the rebuild path logs
     # only "Correlating NBA...".
-    correlate("NBA", stub, force=True)
-    out = capsys.readouterr().out
+    try:
+        correlate("NBA", stub, force=True)
+    finally:
+        target.removeHandler(caplog.handler)
+    messages = [record.getMessage() for record in caplog.records]
 
-    assert "Correlating NBA..." in out
-    assert "cache valid, skipped" not in out, (
-        f"force=True took the skip path: {out!r}"
+    assert any(msg == "Correlating NBA..." for msg in messages)
+    assert not any("cache valid, skipped" in msg for msg in messages), (
+        f"force=True took the skip path: {messages!r}"
     )
 
 
@@ -275,5 +284,3 @@ def test_rebuild_correlations_does_not_touch_models(monkeypatch) -> None:
     assert result.exit_code == 0, f"meditate exited {result.exit_code}: {result.output}"
     assert calls == [("NBA", False)], f"expected single NBA correlate call, got {calls}"
     assert _models_snapshot() == before, "model files were modified during --rebuild-correlations"
-
-

--- a/tests/golden/test_feature_prune.py
+++ b/tests/golden/test_feature_prune.py
@@ -15,28 +15,34 @@ from sportstradamus.training.pipeline import _prune_uninformative_features
 
 
 def test_drops_all_nan_columns() -> None:
-    X_train = pd.DataFrame({
-        "informative": [1.0, 2.0, 3.0, 4.0],
-        "all_nan": [np.nan, np.nan, np.nan, np.nan],
-    })
+    X_train = pd.DataFrame(
+        {
+            "informative": [1.0, 2.0, 3.0, 4.0],
+            "all_nan": [np.nan, np.nan, np.nan, np.nan],
+        }
+    )
     kept = _prune_uninformative_features(X_train, categorical_cols=[])
     assert kept == ["informative"]
 
 
 def test_drops_zero_variance_columns() -> None:
-    X_train = pd.DataFrame({
-        "informative": [1.0, 2.0, 3.0, 4.0],
-        "constant": [7.0, 7.0, 7.0, 7.0],
-    })
+    X_train = pd.DataFrame(
+        {
+            "informative": [1.0, 2.0, 3.0, 4.0],
+            "constant": [7.0, 7.0, 7.0, 7.0],
+        }
+    )
     kept = _prune_uninformative_features(X_train, categorical_cols=[])
     assert kept == ["informative"]
 
 
 def test_keeps_categorical_columns_even_when_degenerate() -> None:
-    X_train = pd.DataFrame({
-        "informative": [1.0, 2.0, 3.0, 4.0],
-        "Home": pd.Series([True, True, True, True], dtype="category"),
-    })
+    X_train = pd.DataFrame(
+        {
+            "informative": [1.0, 2.0, 3.0, 4.0],
+            "Home": pd.Series([True, True, True, True], dtype="category"),
+        }
+    )
     kept = _prune_uninformative_features(X_train, categorical_cols=["Home"])
     # Home is constant but categorical — it must survive.
     assert "Home" in kept
@@ -44,30 +50,36 @@ def test_keeps_categorical_columns_even_when_degenerate() -> None:
 
 
 def test_keeps_column_with_some_nans_and_two_distinct_values() -> None:
-    X_train = pd.DataFrame({
-        "sparse_but_varied": [1.0, np.nan, 2.0, np.nan, 1.0],
-    })
+    X_train = pd.DataFrame(
+        {
+            "sparse_but_varied": [1.0, np.nan, 2.0, np.nan, 1.0],
+        }
+    )
     kept = _prune_uninformative_features(X_train, categorical_cols=[])
     # Has 2 distinct non-NaN values → informative.
     assert kept == ["sparse_but_varied"]
 
 
 def test_drops_column_with_one_distinct_value_and_nans() -> None:
-    X_train = pd.DataFrame({
-        "near_constant": [1.0, np.nan, 1.0, np.nan, 1.0],
-    })
+    X_train = pd.DataFrame(
+        {
+            "near_constant": [1.0, np.nan, 1.0, np.nan, 1.0],
+        }
+    )
     kept = _prune_uninformative_features(X_train, categorical_cols=[])
     # nunique(dropna=True) == 1 → cannot split → dropped.
     assert kept == []
 
 
 def test_preserves_column_order() -> None:
-    X_train = pd.DataFrame({
-        "a": [1.0, 2.0],
-        "b": [3.0, 3.0],  # constant, dropped
-        "c": [4.0, 5.0],
-        "d": [np.nan, np.nan],  # all-nan, dropped
-        "e": [6.0, 7.0],
-    })
+    X_train = pd.DataFrame(
+        {
+            "a": [1.0, 2.0],
+            "b": [3.0, 3.0],  # constant, dropped
+            "c": [4.0, 5.0],
+            "d": [np.nan, np.nan],  # all-nan, dropped
+            "e": [6.0, 7.0],
+        }
+    )
     kept = _prune_uninformative_features(X_train, categorical_cols=[])
     assert kept == ["a", "c", "e"]

--- a/tests/golden/test_report_none_safe.py
+++ b/tests/golden/test_report_none_safe.py
@@ -66,7 +66,7 @@ def test_wide_row_handles_none_in_every_diag_key():
         "model_shape",
         "empirical_shape",
     )
-    model = _model_with_diag({key: None for key in diag_keys})
+    model = _model_with_diag(dict.fromkeys(diag_keys))
 
     row = _wide_row(model, "NBA", "FG3A", "devel", {}, {})
 

--- a/tests/golden/test_training_metrics.py
+++ b/tests/golden/test_training_metrics.py
@@ -97,8 +97,9 @@ def _make_model(*, with_book: bool = True, brier: float = 0.197) -> dict:
 def patched_paths(tmp_path):
     parquet = tmp_path / "model_stats.parquet"
     csv = tmp_path / "model_stats.csv"
-    with mock.patch.object(report_module, "MODEL_STATS_PATH", parquet), mock.patch.object(
-        report_module, "MODEL_STATS_CSV_PATH", csv
+    with (
+        mock.patch.object(report_module, "MODEL_STATS_PATH", parquet),
+        mock.patch.object(report_module, "MODEL_STATS_CSV_PATH", csv),
     ):
         yield parquet, csv
 

--- a/tests/integration/test_end_to_end.py
+++ b/tests/integration/test_end_to_end.py
@@ -151,8 +151,8 @@ def test_pipeline_smoke(
     # ----- Phase 3: prophecize (CLI invoked; parquet snapshot + scrapers mocked) -----
     from sportstradamus.prediction import cli as prediction_cli
 
-    monkeypatch.setattr(prediction_cli, "get_ud", lambda: {})
-    monkeypatch.setattr(prediction_cli, "get_sleeper", lambda: {})
+    monkeypatch.setattr(prediction_cli, "get_ud", dict)
+    monkeypatch.setattr(prediction_cli, "get_sleeper", dict)
 
     captured: dict[str, tuple[pd.DataFrame, pd.DataFrame]] = {}
 

--- a/tests/test_nfl_fp_bucket_payloads.py
+++ b/tests/test_nfl_fp_bucket_payloads.py
@@ -1,0 +1,73 @@
+"""Characterization tests for `_iter_bucket_payloads`.
+
+The four nfl_fp separation/coverage aggregators shared an identical JSON
+``bucket`` parsing preamble that was extracted into one generator. These tests
+pin the generator's skip semantics and assert it yields exactly what the old
+inline scaffolding did, so the aggregators (whose divergent bodies were left
+untouched) produce identical output by construction.
+"""
+
+import json
+
+import numpy as np
+import pandas as pd
+
+from sportstradamus.stats.nfl_fp_aggregation import PLAYER_GROUP_COL
+from sportstradamus.stats.nfl_fp_weekly_aggregate import _iter_bucket_payloads
+
+
+def _old_inline(df):
+    """The scaffolding the four aggregators shared before consolidation."""
+    out = []
+    for player_id, bucket_str in zip(df[PLAYER_GROUP_COL], df["bucket"], strict=True):
+        if not isinstance(bucket_str, str) or not bucket_str:
+            continue
+        try:
+            payload = json.loads(bucket_str)
+        except (TypeError, ValueError):
+            continue
+        if not isinstance(payload, dict):
+            continue
+        out.append((player_id, payload))
+    return out
+
+
+def _frame(rows):
+    return pd.DataFrame(rows, columns=[PLAYER_GROUP_COL, "bucket"])
+
+
+def test_yields_only_valid_dict_payloads():
+    df = _frame(
+        [
+            ("p1", json.dumps({"man": {"v": 1}})),
+            ("p2", ""),
+            ("p3", None),
+            ("p4", np.nan),
+            ("p5", "not json"),
+            ("p6", json.dumps([1, 2, 3])),
+            ("p7", json.dumps("scalar")),
+            ("p8", json.dumps({"zone": {"v": 2}})),
+        ]
+    )
+    assert list(_iter_bucket_payloads(df)) == [
+        ("p1", {"man": {"v": 1}}),
+        ("p8", {"zone": {"v": 2}}),
+    ]
+
+
+def test_matches_pre_consolidation_scaffolding():
+    df = _frame(
+        [
+            ("a", json.dumps({"x": {"value": 0.4, "weight": 10}})),
+            ("b", ""),
+            ("c", "garbage{"),
+            ("d", json.dumps(42)),
+            ("e", json.dumps({"y": {"value": 0.1, "weight": 3}})),
+            ("f", 3.14),
+        ]
+    )
+    assert list(_iter_bucket_payloads(df)) == _old_inline(df)
+
+
+def test_empty_frame_yields_nothing():
+    assert list(_iter_bucket_payloads(_frame([]))) == []

--- a/tests/test_team_volume_scaling.py
+++ b/tests/test_team_volume_scaling.py
@@ -1,0 +1,141 @@
+"""Characterization test for the shared NBA/NHL team-volume budget scaler.
+
+`scale_team_volume_to_budget` was extracted from a per-team loop that lived
+byte-identical in StatsNBA.get_volume_stats and StatsNHL.get_volume_stats. This
+test pins it against a verbatim reference copy of that loop across synthetic
+playerProfile frames and every edge branch (team==0 skip, total<=0 skip,
+zero-variance fallback, no-alpha Gaussian path, ratio/cap clipping). The scaler
+is pure DataFrame math, so no cached game logs are needed.
+"""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from sportstradamus.stats.base import (
+    _VOLUME_SCALE_RATIO_CAP,
+    _VOLUME_SCALE_RATIO_FLOOR,
+    scale_team_volume_to_budget,
+)
+
+_PARAMS = {
+    "budget_mean": 240.0,
+    "typical_rotation": 9,
+    "avg_unmodeled_min": 14.0,
+    "per_player_floor": 12.0,
+    "per_player_cap": 40.0,
+}
+
+
+def _reference(
+    player_profile,
+    market,
+    *,
+    budget_mean,
+    typical_rotation,
+    avg_unmodeled_min,
+    per_player_floor,
+    per_player_cap,
+):
+    """Verbatim copy of the pre-consolidation NBA/NHL per-team loop."""
+    teams = player_profile.loc[player_profile["team"] != 0].groupby("team")
+    for _team, team_df in teams:
+        loc = team_df[f"proj {market} loc"].copy()
+        scale = team_df[f"proj {market} scale"].copy()
+        sn_alpha = (
+            team_df[f"proj {market} alpha"].copy()
+            if f"proj {market} alpha" in team_df.columns
+            else pd.Series(0, index=loc.index)
+        )
+        N = len(team_df)
+
+        delta = sn_alpha / np.sqrt(1 + sn_alpha**2)
+        true_means = loc + scale * delta * np.sqrt(2 / np.pi)
+        true_vars = scale**2
+
+        total = true_means.sum()
+        if total <= 0:
+            continue
+
+        unmodeled_count = max(0, typical_rotation - N)
+        unmodeled_reserve = unmodeled_count * avg_unmodeled_min
+
+        upper_target = budget_mean - unmodeled_reserve
+        lower_target = N * per_player_floor
+        target = max(upper_target, lower_target)
+
+        deficit = target - total
+        total_var = true_vars.sum()
+        if total_var > 0:
+            adjustments = true_vars / total_var * deficit
+        else:
+            adjustments = true_means / total * deficit
+
+        new_means = (true_means + adjustments).clip(lower=0, upper=per_player_cap)
+
+        ratio = new_means / true_means.replace(0, np.nan)
+        ratio = ratio.fillna(1.0).clip(
+            lower=_VOLUME_SCALE_RATIO_FLOOR, upper=_VOLUME_SCALE_RATIO_CAP
+        )
+        new_scale = scale * ratio
+        new_loc = new_means - new_scale * delta * np.sqrt(2 / np.pi)
+
+        player_profile.loc[loc.index, f"proj {market} loc"] = new_loc
+        player_profile.loc[scale.index, f"proj {market} scale"] = new_scale
+        player_profile.loc[loc.index, f"proj {market} mean"] = new_means
+        player_profile.loc[scale.index, f"proj {market} std"] = new_scale
+
+
+def _synthetic(seed, n=14, market="PTS", with_alpha=True):
+    rng = np.random.default_rng(seed)
+    cols = {
+        "team": rng.integers(0, 4, n),  # 0 is the "no team" sentinel and is skipped
+        f"proj {market} loc": rng.uniform(0, 30, n),
+        f"proj {market} scale": rng.uniform(0.5, 8, n),
+    }
+    if with_alpha:
+        cols[f"proj {market} alpha"] = rng.uniform(-2, 2, n)
+    return pd.DataFrame(cols)
+
+
+def _assert_match(df, market):
+    expected = df.copy()
+    actual = df.copy()
+    _reference(expected, market, **_PARAMS)
+    scale_team_volume_to_budget(actual, market, **_PARAMS)
+    pd.testing.assert_frame_equal(expected, actual)
+
+
+@pytest.mark.parametrize("seed", range(8))
+def test_matches_reference_random(seed):
+    _assert_match(_synthetic(seed), "PTS")
+
+
+def test_no_alpha_column_gaussian_path():
+    _assert_match(_synthetic(3, market="TOI", with_alpha=False), "TOI")
+
+
+def test_zero_total_team_skipped():
+    df = pd.DataFrame(
+        {
+            "team": [1, 1],
+            "proj PTS loc": [0.0, 0.0],
+            "proj PTS scale": [0.0, 0.0],
+            "proj PTS alpha": [0.0, 0.0],
+        }
+    )
+    actual = df.copy()
+    scale_team_volume_to_budget(actual, "PTS", **_PARAMS)
+    pd.testing.assert_frame_equal(actual, df)
+
+
+def test_zero_variance_fallback():
+    df = pd.DataFrame(
+        {
+            "team": [1, 1, 1],
+            "proj PTS loc": [10.0, 20.0, 5.0],
+            "proj PTS scale": [0.0, 0.0, 0.0],
+            "proj PTS alpha": [0.0, 0.0, 0.0],
+        }
+    )
+    _assert_match(df, "PTS")


### PR DESCRIPTION
## Behavior-preserving style + duplicate-code cleanup

Cleanup toward CLAUDE.md + `docs/STYLE_GUIDE.md`. **No change** to outputs, schemas, key names, Sheet column order, archive rows, `model_stats`/training-report numbers, CLI flags, or pickles (§2.1, §18.1). Continues from #65 (Phases 1–2 + first `training/` lint, already merged into the foundation); stacked on `claude/zen-pasteur-xa99I` so the diff is exactly the remaining cleanup, not the foundation merge.

Every commit ran the three quality gates green and the mandatory `refactoring-specialist` review (§19) before push.

### Commits

| SHA | Scope |
|---|---|
| `e446f7e` | `training/`: extract sample-size threshold constants (§9) |
| `d164a57` | `training/`: stray `print` → project logger (§9) |
| `b8532cb` | `training/`: boolean-trap args keyword-only (FBT) |
| `30c67b6` | `prediction/`: C4/RET/FBT + magic-number constants (§9) |
| `004d1db` | `moneylines.py`+`books.py`: HTTP codes → `http.HTTPStatus`, credit threshold (§9) |
| `f9c19c1` | `analysis.py`+`dashboard_detail.py`: pick/book/boost/badge thresholds + active lint (§9,§10) |
| `2dfb225` | `skew_normal.py`: log-CDF crossover constant, RET504, de-narrate (§9,§10,§12) |
| `2c5c8d0` | `pages/`+`scripts/`+`tests/`: clear remaining tree-wide ruff lint for green CI (C4/RET/PIE) |
| `94f7653` | `prediction/`+`stats/`: single-source the normalized-history schema (new `history_schema.py`) |
| `16534a6` | `stats/`: dedupe `nfl_fp` JSON-bucket parse into one generator |
| `6418ba8` | `stats/`: share NBA/NHL team-volume budget scaler |

### Duplicate-code consolidation (Phase 6)

Three **must-match** duplications collapsed to a single source of truth, so a future change lands in one place instead of N — directly addressing the "change it in one spot but not the other" drift risk:

- **Normalized-history schema** (`94f7653`) — the per-prediction column list (`pred_level_cols` in `prediction/cli.py` was a verbatim copy of `pred_cols[:-1]` in `analysis.py`), the 16-column empty-history frame, and the 9-field offer-tuple shape (arity literals `6`/`9` and the closing-trio indices, scattered across `analysis.py` + `clv.py`) now come from one leaf module `sportstradamus/history_schema.py` (`PREDICTION_LEVEL_COLS`, `HISTORY_COLS`, `OFFER_FIELDS`, `OFFER_ARITY`, `LEGACY_OFFER_ARITY`, `CLOSING_FIELD_INDICES`). The positional offer tuples stay plain tuples (the history parquet persists them) — only the column lists and arities are consolidated. Constants verified byte-identical to the old literals; the 46 clv/analysis/nightly round-trip tests stay green.
- **`nfl_fp` JSON-bucket parse** (`16534a6`) — the four FP separation/coverage aggregators shared an identical ~8-line `bucket` JSON preamble; lifted into `_iter_bucket_payloads(df)`. The divergent inner-key extraction in each aggregator is untouched.
- **NBA/NHL team-volume scaler** (`6418ba8`) — the byte-identical per-team SkewNormal volume-rescaling loop in `StatsNBA`/`StatsNHL` `get_volume_stats` → `base.scale_team_volume_to_budget(...)`, parameterized by the per-league budget/rotation/floor/cap. The per-league constant setup, `budget_mean` derivation, and post-loop cleanup stay in each caller.

**Tests-first**: both `stats/` consolidations shipped with a characterization test that asserts the extracted unit reproduces a verbatim reference copy of the original code byte-for-byte (`pd.testing.assert_frame_equal` / list equality) across every skip/edge branch — `tests/test_nfl_fp_bucket_payloads.py` (3) and `tests/test_team_volume_scaling.py` (11, incl. team==0 skip, total≤0 skip, zero-variance fallback, no-alpha Gaussian path). Buildable on synthetic inputs — no cached `data/` needed.

### Deliberately left un-consolidated (flagged)
- `prediction/persist.py` `_OFFER_KEEP_COLS` vs `model_prob.py` emit-list vs `pages/1_…` display schema — a *projection over the post-correlation frame*, not a must-match copy (`find_correlation` adds `Team/Opp Correlation`; decode adds `Model R/Alpha/Sigma/Skew`). Forcing them equal would break the intentional drop/add.
- `training/correlate.py` ↔ `markets.py` per-league market lists — coincidental market-name vocabulary, different structure (position-keyed vs flat) and membership; not a lockstep copy.
- **Volume-model *load* family** (`mlb`↔`nhl` `get_volume_stats` head) and **schedule-scrape** (`nba`↔`wnba`) — these touch trained model pickles + `model.predict` inference and network scraping, which can't be exercised end-to-end without `data/models` + cached gamelogs (absent on a fresh clone). Flagged for a data-equipped session per §18.9 rather than extracted blind.

### Earlier waves (lint/smell), by area

**`training/`** — `print` → `get_logger`; FBT keyword-only (`correlate`, `pipeline._step_*`, `train_market`) with `cli.py`/`test_correlate.py` lockstep; §9 constants `_MIN_DIAGNOSTIC_ROWS`, `_MIN_SAMPLES_FOR_BOOK_FIT`; `pipeline.py` kept a `# style: allow-length` (§18.9, not split).

**`prediction/`** — `model_prob.py` (§18.9 decode, structural only): `dict()`→`{}`, RET505, `_MIN_YARDS_LINE`/`_MAX_UNDERDOG_BOOST`, `# style: allow-length`; `parlay._payout_curve_for(..., *, legacy)` keyword-only.

**top-level** — `moneylines.py`+`books.py`: HTTP literals → `http.HTTPStatus`, `_LOW_API_CREDITS_THRESHOLD`, C403; `analysis.py`: `_MODEL_PROB_PICK_FLOOR`/`_BOOK_PROB_PICK_FLOOR`/`_UNDERDOG_PERFECT_BOOST_MULT`, RET504, removed a dead `latest.get("Result")` no-op + metric-function banners (CRPS math operand-identical); `dashboard_detail.py`: `_CORR_STRONG_MULT`/`_CORR_MODERATE_MULT`; `skew_normal.py` (§18.9): `_LOG_NDTR_ERFC_CROSSOVER`, RET504, de-narrated.

### Magic-number / FBT leave-decisions (flagged, not done)
- HTTP status **ranges** in `fantasypoints/client.py` — protocol-class ranges read best bare.
- Definitional bare-math: Over/Under pair (`> 2`), two teams (`!= 2`), probability midpoint (`p >= 0.5`).
- Click-CLI FBT (`confer`'s `close_lines`; scorecard CLI) — Click injects flags by name.
- `SkewNormal.__init__(initialize: bool)` — mirrors the LightGBMLSS `DistributionClass` API.

### Quality gates
- `ruff check` + `ruff format --check` clean on every touched file; **the whole tree is now ruff-clean** (the last `pages/`/`scripts/` ratchet debt cleared in `2c5c8d0`).
- `pytest tests/golden/` — **252 passed, 6 skipped**; new unit tests `test_nfl_fp_bucket_payloads` (3) + `test_team_volume_scaling` (11) green.
- `pytest -m integration` — **2 passed, 10 skipped**.
- `refactoring-specialist` (§19) ran per wave.

### CI
The `quality` job lints the whole tree. With `2c5c8d0` clearing the last `pages/`/`scripts/` debt the tree is fully clean, so `quality` now passes on `6418ba8` (was red earlier only because of pre-existing non-production ratchet debt, now gone).

### Environment note
`creds/keys.json`, `data/config/book_weights.json`, `data/config/goalies.json` are git-ignored runtime artifacts absent on a fresh clone; created as local stubs only — **not committed**.

https://claude.ai/code/session_018EdQ72SQ39xZFA43Hd8pGe

---
_Generated by [Claude Code](https://claude.ai/code/session_018EdQ72SQ39xZFA43Hd8pGe)_