### PR TITLE
Bump pyarrow to ^23.0.1 (Dependabot alert #41 / CVE-2026-25087)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ line-profiler = "^4.1.3"
 klepto = {extras = ["archives"], version = "^0.2.5"}
 nflreadpy = "^0.1.2"
 polars = "^1.33.1"
-pyarrow = "^21.0.0"
+pyarrow = "^23.0.1"
 scrapeops-python-requests = "^0.4.7"
 streamlit = ">=1.30"
 plotly = ">=5.18"


### PR DESCRIPTION
## What

Bumps the `pyarrow` constraint from `^21.0.0` to `^23.0.1` to clear Dependabot alert #41.

## The alert — CVE-2026-25087 (High)

- **Use-after-free** in Apache Arrow C++, affecting **15.0.0 → 23.0.0**.
- Triggered when reading an Arrow **IPC file** (not stream) with **pre-buffering enabled** on data containing variadic buffers (Binary View / String View).
- **Fixed in 23.0.1.** Our old `^21.0.0` pin resolved inside the vulnerable range.

## Risk assessment

Low. `pyarrow` is used only as the pandas parquet engine in `helpers/io.py`:

```python
df.to_parquet(tmp, engine="pyarrow", index=False)
pd.read_parquet(p, engine="pyarrow")
```

This is a stable API unaffected by the major version bump. Notably, the vulnerable pre-buffering path is **not exposed in the Python binding** at all, so our usage was never actually exploitable — but Dependabot fires on the version range regardless, and staying current is the right call.

No `poetry.lock` is committed, so `pyproject.toml` was the only pin to update.

## Verification

- [ ] CI: `poetry install`, `ruff check`, `pytest tests/golden/`

https://claude.ai/code/session_01TDBXdzNh869i5SYR7DRRWe

---
_Generated by [Claude Code](https://claude.ai/code/session_01TDBXdzNh869i5SYR7DRRWe)_