### PR TITLE
feat(hooks): stub gitignored runtime files from CI fixtures at session start

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -2,11 +2,17 @@
 # SessionStart hook: provision a Claude Code on the web session so the three
 # quality gates (ruff / pytest golden / integration smoke) can run.
 #
-# Two independent, remote-only, idempotent responsibilities:
+# Three independent, remote-only, idempotent responsibilities:
 #   1. Install the GitHub CLI so the web console's PR-status indicator
 #      (`gh pr checks`) works. Auth is left to the user: set GH_TOKEN in the
 #      environment-variables config and `gh` picks it up automatically.
-#   2. Install the Python dependency stack with Poetry. This needs the
+#   2. Stub the gitignored runtime files (creds/keys.json, book_weights.json,
+#      goalies.json, …) from tests/ci_fixtures/ — the same provisioning the
+#      CI quality job uses. helpers/config.py and helpers/scraping.py read
+#      them eagerly at import, so without them the golden/integration suites
+#      collapse at collection. Only missing files are stubbed; a tree synced
+#      from production is never clobbered.
+#   3. Install the Python dependency stack with Poetry. This needs the
 #      environment's network policy to allow download.pytorch.org (the pinned
 #      CPU-only torch source) on top of the default PyPI allowlist; until that
 #      is granted, `poetry install` 403s on the pytorch_cpu source.
@@ -40,7 +46,17 @@ if [ -z "${GH_TOKEN:-}" ] && [ -z "${GITHUB_TOKEN:-}" ]; then
   echo "gh installed. Set GH_TOKEN in your Claude Code on the web env to authenticate." >&2
 fi
 
-# --- 2. Python dependencies --------------------------------------------------
+# --- 2. Gitignored runtime stubs from the CI fixtures ------------------------
+_ROOT="${CLAUDE_PROJECT_DIR:-$(pwd)}"
+if [ ! -f "$_ROOT/src/sportstradamus/creds/keys.json" ]; then
+  cp "$_ROOT/tests/ci_fixtures/creds/keys.json" "$_ROOT/src/sportstradamus/creds/keys.json"
+fi
+for _fixture in "$_ROOT"/tests/ci_fixtures/data/*.json; do
+  _target="$_ROOT/src/sportstradamus/data/config/$(basename "$_fixture")"
+  [ -f "$_target" ] || cp "$_fixture" "$_target"
+done
+
+# --- 3. Python dependencies --------------------------------------------------
 # Skip when the package and the pinned torch already import (warm container).
 if poetry run python -c "import sportstradamus, torch" >/dev/null 2>&1; then
   exit 0


### PR DESCRIPTION
## Summary

Fresh Claude Code web containers fail the golden/integration gates at test
collection: `helpers/config.py` and `helpers/scraping.py` eagerly read three
gitignored runtime files production owns (`creds/keys.json`,
`data/config/book_weights.json`, `data/config/goalies.json`).

This adds a third idempotent responsibility to the SessionStart hook: copy the
same `tests/ci_fixtures/` set the CI quality job already provisions — per-file,
only when the target is missing, so a tree synced from production is never
clobbered.

## Verification

- `bash -n` clean; fresh-provision run copies all 5 fixtures; sentinel-file
  rerun confirms no clobber.
- Gates on the provisioned tree: ruff clean · golden 465 passed / 16 skipped ·
  integration 2 passed / 12 skipped (skips are by-design cached-parquet guards).

https://claude.ai/code/session_01JmuQXo4BRKtmeJGucq6FMx

---
_Generated by [Claude Code](https://claude.ai/code/session_01JmuQXo4BRKtmeJGucq6FMx)_