### PR TITLE
docs: consolidate the model improvement track into one progression doc

### DIFF
--- a/.claude/agents/devel-ship-curator.md
+++ b/.claude/agents/devel-ship-curator.md
@@ -21,9 +21,10 @@ package**.
    the authoritative keep/drop table and the two-phase model. When this prompt and
    that section disagree, the section wins (it is version-controlled; update this
    agent if it drifts).
-2. `docs/operation_ship_75.md` — the **§1c gate definitions** and the **Gate 1 /
-   Gate 2** lifecycle (the per-cell ship mechanism itself is in CONTRIBUTING's
-   "Shipping to Production" section above; thresholds in `docs/ship_gate.md`).
+2. `docs/model_improvement_track.md` — the **§3 gate definitions** and the
+   **Gate 1 / Gate 2** lifecycle (the per-cell ship mechanism itself is in
+   CONTRIBUTING's "Shipping to Production" section above; thresholds in
+   `docs/ship_gate.md`).
 3. `CLAUDE.md` — hard rules and the three quality gates (`ruff`, `pytest
    tests/golden/`, `pytest -m integration`) that must pass before you claim success.
 

--- a/.claude/agents/prompt-engineer.md
+++ b/.claude/agents/prompt-engineer.md
@@ -292,7 +292,7 @@ Always prioritize effectiveness, efficiency, and safety while building prompt sy
 
 This repo uses this agent primarily to draft **phase-handoff prompts** —
 the prompt a fresh Claude Code session reads at the start of a new
-phase of `docs/operation_ship_75.md`. The next agent inherits
+phase of `docs/model_improvement_track.md`. The next agent inherits
 no conversation context, so the handoff prompt is the entire briefing.
 
 ### Required reading on every handoff-prompt invocation
@@ -305,9 +305,9 @@ no conversation context, so the handoff prompt is the entire briefing.
    the prompt must inherit. The brief template is
    `docs/handoffs/_template.md`.
 4. The lane's home-of-record docs per the brief's §2 — for the model track
-   that is `docs/operation_ship_75.md` (Current standings, §9 verification /
-   inference-path notes, §7 failure protocol, the target lever's body and its
-   Go/No-Go and if-it-fails branch).
+   that is `docs/model_improvement_track.md` (§2 ground truth, §11
+   verification / inference-path checklist, §9 failure protocol, the target
+   stage's body and its acceptance and if-it-fails branch).
 5. The most recent prior handoff prompt in `/tmp/*_handoff_prompt.md` for
    style reference. Mirror its structure, not its exact wording.
 

--- a/.claude/agents/research-analyst.md
+++ b/.claude/agents/research-analyst.md
@@ -1,6 +1,6 @@
 ---
 name: research-analyst
-description: "Use when a diagnostic or experiment result is ambiguous, or a path-forward decision in docs/operation_ship_75.md needs literature + statistical synthesis — distribution-family routing, dispersion diagnostics, ship/kill cost-benefit calls, strategic forks. Reads the local diagnostic outputs, may re-run read-only diagnostics, searches the literature, and writes a cited statistician's brief to /tmp/researcher_{topic}.md. Read-only w.r.t. production."
+description: "Use when a diagnostic or experiment result is ambiguous, or a path-forward decision in docs/model_improvement_track.md needs literature + statistical synthesis — distribution-family routing, dispersion diagnostics, ship/kill cost-benefit calls, strategic forks. Reads the local diagnostic outputs, may re-run read-only diagnostics, searches the literature, and writes a cited statistician's brief to /tmp/researcher_{topic}.md. Read-only w.r.t. production."
 tools: Read, Grep, Glob, Bash, WebSearch, WebFetch, Write
 model: opus
 ---
@@ -10,7 +10,7 @@ reviews ambiguous experiment results, searches the primary literature, and
 returns an implementable verdict. You are the in-repo replacement for the
 claude.ai research round-trip: a Claude Code session runs a diagnostic, you read
 the actual output, you do the literature work, and you write a cited brief that
-the main session distills into `docs/operation_ship_75.md`. You do not
+the main session distills into `docs/model_improvement_track.md`. You do not
 write production code and you do not decide alone — you give the user and the
 main session the evidence and a recommendation sharp enough to act on.
 
@@ -71,9 +71,11 @@ answered with evidence:
 
 ## Project-specific use: Sportstradamus distribution-routing research
 
-This repo runs `docs/operation_ship_75.md` — a multi-session program to
-fix GBDT regression-toward-the-mean in a LightGBMLSS distributional-regression
-pipeline for sports-betting markets. Two branches: a **SkewNormal** branch
+This repo runs `docs/model_improvement_track.md` — a multi-session program to
+push market cells of a LightGBMLSS distributional-regression pipeline for
+sports-betting markets through five offline ship gates (dominant symptom:
+predictive under-dispersion; legacy GBDT mean-compression context in
+`docs/operation_ship_references.md`). Two branches: a **SkewNormal** branch
 (`global_mean >= 2.0`, e.g. NBA PTS/FGA) and a **NegBin/ZINB count** branch
 (`global_mean < 2.0`, e.g. FTM/STL/FG3M). The recurring questions are about
 **distribution-family choice**, **dispersion**, **zero-inflation**, and whether
@@ -91,16 +93,18 @@ a method's projected lift justifies its build cost.
 
 ### Required reading every invocation
 
-1. `docs/operation_ship_75.md` (the home-of-record), the relevant parts:
-   - the **Current standings** table (where the program is now),
-   - the **target lever's body + its Go/No-Go and if-it-fails branch** (§5),
-   - the **five offline ship gates** (§1c) and the **§9 supersession bar**
-     (`supersede_verdict`); the quantitative thresholds are mirrored in
+1. `docs/model_improvement_track.md` (the home-of-record), the relevant parts:
+   - the **§2 ground-truth commands** (where the program is now — run them,
+     never trust prose standings),
+   - the **target stage's body + its acceptance and if-it-fails branch** (§7),
+   - the **five offline ship gates and the supersession bar** (§3,
+     `supersede_verdict`); the quantitative thresholds are mirrored in
      `docs/ship_gate.md` (authoritative),
-   - the **§7 Failure protocol** — the lever-cap / `deferred-90` stop-the-track
-     principle and the Gate 1 → Gate 2 lifecycle,
-   - the **§8 Research holes** and the **§6 per-league path** (cross-league caveats),
-   - the **citations [1]–[48]** in `docs/operation_ship_references.md` — the
+   - the **§9 Failure protocol** — matrix-exhaustion policy (the `deferred-90`
+     tag is retired) and the Gate 1 → Gate 2 lifecycle,
+   - the **§10 Research holes** and the **§8 per-league routing** (cross-league
+     caveats: §11.4),
+   - the **citations [1]–[71]** in `docs/operation_ship_references.md` — the
      literature base already established. Build on it; do not re-derive it.
 2. The most recent `/tmp/researcher_*.md` for the house brief format.
    `/tmp/researcher_track_b_rescope_response.md` is the gold-standard example —
@@ -197,7 +201,7 @@ Read-only with respect to production. You may:
 
 You may **not**:
 - write or edit any file under `src/`; train or overwrite a model pickle; flip a
-  default flag; touch the inference path; edit `docs/operation_ship_75.md`
+  default flag; touch the inference path; edit `docs/model_improvement_track.md`
   or any other doc; commit, push, or open/update a PR.
 
 You are a third, orthogonal role: `prompt-engineer` drafts handoff prompts,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,7 +137,8 @@ These conventions pair with the hooks in `.claude/hooks/`.
   `poetry run pytest -m integration -n0 && touch "$CLAUDE_PROJECT_DIR/.claude/.state/integration_green"`
   so a clean run clears the push prompt. Editing any `.py` afterward re-arms it.
 
-* **Research-first.** Before building any Operation Ship 75 §8-flagged lever, or
+* **Research-first.** Before building any `docs/model_improvement_track.md`
+  §10-flagged lever, or
   changing a distribution family / dispersion mechanism, dispatch the
   `research-analyst` subagent first and cite its `/tmp/researcher_*.md` brief.
   The research-gate hook enforces the discrete cases (a `shipped:` flip in

--- a/docs/archive/feature_improvement_plan.md
+++ b/docs/archive/feature_improvement_plan.md
@@ -1,5 +1,10 @@
 # Feature Improvement Plan
 
+> **ARCHIVED — superseded by [`../model_improvement_track.md`](../model_improvement_track.md)
+> (feature stages → §7.0/§7.3/§7.4/§7.6/§7.7, validation protocol + worked example → §11.2,
+> feature-count verdict → §7.4 item 5).** Status claims below are stale and non-normative.
+> Retained for the full per-item hypothesis/evidence prose the consolidation compressed.
+
 > **Status: ACTIVE — stage 0 (hygiene + quick wins).** Canonical home for feature-lever
 > detail across all five leagues; [`operation_ship_75.md`](operation_ship_75.md) §5.8
 > cross-references this doc. Gate thresholds live in [`ship_gate.md`](ship_gate.md);

--- a/docs/archive/model-track-brief.md
+++ b/docs/archive/model-track-brief.md
@@ -1,5 +1,9 @@
 # Model Track — Ship-75 → Ship-90
 
+> **ARCHIVED — superseded by [`../model_improvement_track.md`](../model_improvement_track.md),
+> which absorbs this brief's session mechanics (→ §11.5), stage plan (→ §7), verify block
+> (→ §2), and ledger (→ §12). The roadmap v3 §4 lane row points there now.**
+
 > Status: ACTIVE — Ship-75 lever work
 
 ## 1. Mission & money logic

--- a/docs/archive/operation_ship_75.md
+++ b/docs/archive/operation_ship_75.md
@@ -1,5 +1,12 @@
 # Operation Ship 75
 
+> **ARCHIVED — superseded by [`../model_improvement_track.md`](../model_improvement_track.md)
+> (the consolidated model-track home of record: lever stack → §5–§7, per-league path → §8,
+> failure protocol → §9, research holes → §10, verification → §11).** Status claims and
+> per-cell counts below are stale and non-normative. Retained for the full lever-stack prose
+> the consolidation compressed; research verdicts live on in
+> [`operation_ship_references.md`](../operation_ship_references.md).
+
 > **Home of record for the model-research push to 75% breadth.** Research verdicts,
 > citations, and the inference-path checklist live in
 > [`operation_ship_references.md`](operation_ship_references.md). Current gate

--- a/docs/archive/operation_ship_90.md
+++ b/docs/archive/operation_ship_90.md
@@ -1,5 +1,11 @@
 # Operation Ship 90 — Stub
 
+> **ARCHIVED — superseded by [`../model_improvement_track.md`](../model_improvement_track.md)
+> §7.8 (the D5 → Ship-90 stage).** Several concepts below (the `deferred-90` register, the
+> excluded-markets placeholders, "Steps 0–4") were retired by the no-defer policy and are
+> non-normative. Retained for the original idea list; the live levers it names (T11, CMPμ,
+> tail heads) are on the consolidated doc's §7.6 table.
+
 > **Status:** stub. Filled in as Operation Ship 75 lands and we see
 > which cells resisted. This doc captures ideas as they surface so they
 > aren't lost.

--- a/docs/handoffs/_template.md
+++ b/docs/handoffs/_template.md
@@ -66,7 +66,7 @@ relitigate; changes are owner-only. Workstream-scoped decisions live HERE
 paths (sportstradamus.stats / .training / .prediction / .helpers — per
 CONTRIBUTING §Package Map) so deleted shims are not recreated. Editing outside
 the footprint is a stop condition (§8). If the lane touches the serving path,
-add the inference-path compatibility pointer (operation_ship_references.md)
+add the inference-path compatibility pointer (model_improvement_track.md §11.3)
 — reference it, don't restate it. -->
 
 ## 6. Stage plan
@@ -79,8 +79,9 @@ Per stage:
 - **Acceptance** — commands + expected outcomes a session can run itself.
   "Owner is satisfied" is an escalation, never an acceptance criterion.
 - **Est. sessions**
-- **Kill criteria / if-it-fails branch** — mandatory (ship_75 §5 discipline:
-  scrap the path, take the next; record the verdict in the ledger). -->
+- **Kill criteria / if-it-fails branch** — mandatory (model_improvement_track.md
+  §7/§9 discipline: scrap the path, take the next; record the verdict in the
+  ledger). -->
 
 ## 7. Working rules
 

--- a/docs/handoffs/bestball-2027.md
+++ b/docs/handoffs/bestball-2027.md
@@ -117,7 +117,7 @@ owner-only.
   `sportstradamus.training` interfaces. The projection layer is a TRANSLATION
   layer; no new model (archived v2 §5.2). Never edit serving-path modules from
   this lane; compat notes:
-  [operation_ship_references.md](../operation_ship_references.md).
+  [model_improvement_track.md](../model_improvement_track.md) §11.3.
 - `sportstradamus.helpers` — `Scrape` for ADP HTTP, config loaders. Reuse,
   don't fork.
 - `src/sportstradamus/pages/` — companion/exposure views (stages 5–6). Parquet

--- a/docs/handoffs/hygiene-closeout.md
+++ b/docs/handoffs/hygiene-closeout.md
@@ -21,9 +21,9 @@ accuracy has never been verified on production data.
    subject.
 4. [`../../src/sportstradamus/scripts/audit_parlay_calibration.py`](../../src/sportstradamus/scripts/audit_parlay_calibration.py)
    — the calibration harness stage 2 re-runs.
-5. [`../operation_ship_90.md`](../operation_ship_90.md) +
-   [`../operation_ship_75.md`](../operation_ship_75.md) §5.9 — the
-   `deferred-90` inconsistency stage 3 reconciles.
+5. [`../model_improvement_track.md`](../model_improvement_track.md) §9 — the
+   no-defer / matrix-exhaustion policy stage 3's drift sweeps guard
+   (`deferred-90` is a retired tag).
 
 ## 3. Verify before you trust
 
@@ -31,7 +31,7 @@ accuracy has never been verified on production data.
 git fetch origin && git log --oneline origin/devel -3
 ls docs/DEPRECATED_TRIAGE.md 2>/dev/null          # stage 1 done?
 ls src/deprecated/                                 # triage subject
-grep -n "deferred-90" docs/operation_ship_90.md docs/operation_ship_75.md
+grep -rn "deferred-90" docs/*.md   # only model_improvement_track.md's retirement notes should hit
 grep -rn "roadmap_v2" docs/*.md .claude/ 2>/dev/null | grep -v archive  # drift
 ```
 
@@ -73,15 +73,16 @@ edits to), `src/sportstradamus/scripts/` (read/run), `pyproject.toml`
    derive from production data (dates + row counts in the ledger line).
    1 session + owner time. *If production data can't be exported:* park the
    stage, note in ledger, move on.
-3. **Drift sweeps + recurring checks.** (a) Reconcile
-   [`../operation_ship_90.md`](../operation_ship_90.md)'s `deferred-90`
-   mentions with ship_75 §5.9 (tag retired, zero cells qualify) — revise in
-   place. (b) Verify `pyproject.toml` script registrations match shipped
-   CLIs. (c) Run the recurring checks and record results: per-season
-   `underdog_payouts.json` verification vs the live product (archived v2
-   §3.2 mandate); monthly free-passer re-score reminder to the model-track
-   lane (ship_75 §5.1). Acceptance: each check's result in the ledger.
-   ~1 session each visit; repeats.
+3. **Drift sweeps + recurring checks.** (a) `deferred-90` drift grep (§3
+   block) — the tag is retired
+   ([`../model_improvement_track.md`](../model_improvement_track.md) §9);
+   only its retirement notes should match. (b) Verify `pyproject.toml`
+   script registrations match shipped CLIs. (c) Run the recurring checks and
+   record results: per-season `underdog_payouts.json` verification vs the
+   live product (archived v2 §3.2 mandate); monthly free-passer re-score
+   reminder to the model-track lane (model_improvement_track.md §7.0).
+   Acceptance: each check's result in the ledger. ~1 session each visit;
+   repeats.
 
 Lane-level: items here are independent; any can be parked without blocking
 the others.

--- a/docs/handoffs/mlb-nhl-activation.md
+++ b/docs/handoffs/mlb-nhl-activation.md
@@ -15,7 +15,7 @@ decision engines (kelly, pickem-build, parlay pricing) are league-agnostic and
 already built; what MLB/NHL need is model-quality work + data-freshness repair
 plus a small, known CLI-wiring delta (§3 findings) — not new architecture. No
 doc gives these leagues a breadth target —
-[`operation_ship_75.md`](../operation_ship_75.md) §North Star covers
+[`model_improvement_track.md`](../model_improvement_track.md) §0 covers
 NBA/WNBA/NFL only; this lane exists to close that gap. Seasonal urgency: **MLB
 is in season now** — the apps price it heavily while NBA/NFL are dark, and the
 D1 option decays as the season burns. NHL starts in October; D2 wants its
@@ -27,9 +27,10 @@ packet by ~Sep.
    (seasonality) + §7 (the D1/D2 rows) — why now, and who decides. Predecessor
    design sketches: [`../archive/sportstradamus_roadmap_v2.md`](../archive/sportstradamus_roadmap_v2.md)
    (non-normative, status claims stale).
-2. [`../operation_ship_75.md`](../operation_ship_75.md) §Purpose (the lens),
-   §3 (the failure-mode-census pattern stage 0 copies), §5.0 operating loop +
-   §5 lever stack (the post-GO method, reused wholesale — never restated here).
+2. [`../model_improvement_track.md`](../model_improvement_track.md) §1 (the
+   lens), §4.3 (the failure-mode-census pattern stage 0 copies), §6 operating
+   loop + §5/§7 lever stages (the post-GO method, reused wholesale — never
+   restated here).
 3. [`../ship_gate.md`](../ship_gate.md) — g1–g5 thresholds the packets score
    against.
 4. [`CONTRIBUTING.md`](../../CONTRIBUTING.md) §Package Map, §Adding a New
@@ -38,8 +39,8 @@ packet by ~Sep.
 5. [`CLAUDE.md`](../../CLAUDE.md) §Hard rules (DuckDB lock) + §Agentic workflow
    conventions (research-first) — assumed law; the two rules this lane leans
    on hardest.
-6. [`model-track.md`](model-track.md) — the lane whose footprint and per-cell
-   loop stage 1+ mirrors.
+6. [`../model_improvement_track.md`](../model_improvement_track.md) §11.5 —
+   the model-track footprint and session mechanics stage 1+ mirrors.
 7. `src/sportstradamus/stats/mlb.py`, `src/sportstradamus/stats/nhl.py` — the
    two Stats classes under audit (`season_start`, `load`/`update`).
 8. `src/sportstradamus/training/markets.py` +
@@ -113,8 +114,8 @@ Findings verified 2026-06-10 (each re-derivable above — re-verify, don't trust
   coverage "thin"; books scrapers were the intended source).
   `scripts/backfill_historical_odds.py` does carry `baseball_mlb` /
   `icehockey_nhl` sport keys. The archive's MLB/NHL book side is therefore
-  legacy-era until proven otherwise — the ship_75 §1b "is the book honest?"
-  check is mandatory before any g1 verdict is believed.
+  legacy-era until proven otherwise — the model_improvement_track.md §4.2
+  "is the book honest?" check is mandatory before any g1 verdict is believed.
 - **All 40 cells are `dist: SkewNormal`** with `target_normalization` /
   `posthoc` `"none"` — including count-shaped stats (home runs, stolen bases,
   goals, assists, blocked). Any re-route is research-gated (§4).
@@ -123,9 +124,10 @@ Findings verified 2026-06-10 (each re-derivable above — re-verify, don't trust
   (gitignored — freshness is only checkable where the data lives).
 - `meditate` skips + pickle-prunes withheld cells; audit training needs
   `--bypass-withholding` or a `--deterministic` sandbox run (writes to
-  `research/models/deterministic/`, never production). The ship_75 §5.0
-  strategy driver may not be landed on the working branch — `ls
-  src/sportstradamus/training/model_strategy_driver.py` before planning around it.
+  `research/models/deterministic/`, never production). The strategy driver
+  lives on `model-research` only (model_improvement_track.md §5 branch
+  asymmetry) — `ls src/sportstradamus/training/model_strategy_driver.py`
+  before planning around it.
 
 ### Volatile product assumptions
 
@@ -164,8 +166,9 @@ run, but nothing merges in stage 0.
 **Post-GO (stage 1+):** mirrors the model-track footprint —
 `sportstradamus.training` (pipeline, scorecard, report),
 `data/config/stat_meta.json`, ship-config plumbing — see
-[`model-track.md`](model-track.md) §5 and ship_75 §5; not restated here. Plus
-the activation-specific deltas this audit names:
+[`../model_improvement_track.md`](../model_improvement_track.md) §11.5 and
+§5–§7; not restated here. Plus the activation-specific deltas this audit
+names:
 
 | Module | Why |
 |---|---|
@@ -178,7 +181,7 @@ the activation-specific deltas this audit names:
 
 Editing outside the footprint is a stop condition (§8). Serving-path changes
 carry the inference-path compatibility checklist
-([`../operation_ship_references.md`](../operation_ship_references.md)) —
+([`../model_improvement_track.md`](../model_improvement_track.md) §11.3) —
 reference it, don't restate it.
 
 ## 6. Stage plan
@@ -193,15 +196,15 @@ reference it, don't restate it.
      `StatsMLB.load()/update()` still run against today's statsapi;
      `season_start` fix.
   2. Archive odds coverage by market (counts, date range, distinct books) +
-     the honesty check: real two-sided prices or a legacy seed (ship_75 §1b
-     pattern)? g1 grades against this.
+     the honesty check: real two-sided prices or a legacy seed
+     (model_improvement_track.md §4.2 pattern)? g1 grades against this.
   3. App coverage census: markets Underdog/Sleeper actually price, mapped onto
      the 24 cells; unpriced cells flagged for the owner's denominator call.
   4. Wiring-delta list (§3 findings) with cost estimate.
   5. `meditate --league MLB --bypass-withholding --market <subset>` smoke on a
      scratch branch (or `--deterministic` sandbox) + full scorecard sweep →
      free-passer count (cells already clearing g1–g5) + a failure-mode census
-     table à la ship_75 §3.
+     table à la model_improvement_track.md §4.3.
   6. Recommended GO/NO-GO with reasons + a proposed breadth target for the
      owner to lock at D1.
 - **Acceptance:** packet committed + §10 ledger line + owner pointed at it.
@@ -223,21 +226,23 @@ acceptance and kill criteria.
 
 - **Entry:** D1 (MLB) or D2 (NHL) = GO, owner-committed; breadth target locked.
 - **Procedure:** land the packet's wiring deltas + data repair first (one
-  module per subagent), then the ship_75 §5.0 operating loop verbatim — free
-  passers first (§5.1 pattern), then the lever stack cheapest-first. Loop and
-  stack live in [`../operation_ship_75.md`](../operation_ship_75.md) §5; this
-  brief does not restate them.
+  module per subagent), then the model_improvement_track.md §6 operating loop
+  verbatim — free passers first (§7.0 pattern), then the §7 stage ladder
+  cheapest-first. Loop and stages live in
+  [`../model_improvement_track.md`](../model_improvement_track.md) §6–§7;
+  this brief does not restate them.
 - **Acceptance per cell:** official full-HPO scorecard 5/5
   ([`../ship_gate.md`](../ship_gate.md)) → `shipped: "devel"` via standard
   mechanics (CONTRIBUTING §Shipping; devel-ship-curator carves every PR).
 - **Est. sessions:** set by the packet's free-passer count + failure census.
-- **Kill criteria:** ship_75 §7 failure protocol per lever/cell. League-level
-  kill is an owner call → status `DONE (no-go)` or `BLOCKED (on: next season)`.
+- **Kill criteria:** model_improvement_track.md §9 failure protocol per
+  lever/cell. League-level kill is an owner call → status `DONE (no-go)` or
+  `BLOCKED (on: next season)`.
 
 ## 7. Working rules
 
 - Conflict order: command output > CLAUDE.md/CONTRIBUTING.md > home-of-record
-  doc (ship_75, ship_gate) > this brief > roadmap v3.
+  doc (model_improvement_track, ship_gate) > this brief > roadmap v3.
 - **Archive lock discipline.** Probes open `duckdb.connect(...,
   read_only=True)` and close immediately. `Archive()` is a read-write
   singleton whose DuckDB file lock lives for the connection lifetime — never
@@ -247,8 +252,8 @@ acceptance and kill criteria.
 - Production data flows one way here: `scripts/sync_from_prod.sh` (pull).
   `sync_to_prod.sh`, crontab edits, anything on the prod box: owner-only.
 - Compute: full-league `meditate` is hours; default to `--market` scoping and
-  `--deterministic` sandbox runs for exploration (ship_75 §5.0); real-HPO only
-  to confirm a ship candidate.
+  `--deterministic` sandbox runs for exploration (model_improvement_track.md
+  §6); real-HPO only to confirm a ship candidate.
 - Packets and this brief revise in place (STYLE_GUIDE §16); the §10 ledger is
   the only append-only zone.
 
@@ -263,8 +268,8 @@ acceptance and kill criteria.
 - anything touching credentials, paid APIs (incl. Odds API probes for MLB/NHL
   coverage), cron, or ToS surface (live Underdog/Sleeper scrapes);
 - a full-league `meditate` looks necessary — it is real cost; prefer
-  `--market` scoping and the deterministic sandbox (ship_75 §5.0), and ask
-  before any full run;
+  `--market` scoping and the deterministic sandbox (model_improvement_track.md
+  §6), and ask before any full run;
 - cron / production-box changes of any kind — owner-only;
 - two consecutive sessions with no acceptance criterion moving (grind detector).
 

--- a/docs/handoffs/parlay-dependence.md
+++ b/docs/handoffs/parlay-dependence.md
@@ -19,17 +19,16 @@ Money logic: the five ship gates certify **marginals only**; the product is
 **parlays**; and the DFS apps largely don't tax leg correlation — that
 asymmetry is the core of why they're beatable. The predecessor design calls
 this "the audit's single largest *product*-EV lever"
-([archived v2 §1.2](../archive/sportstradamus_roadmap_v2.md));
-[`operation_ship_75.md`](../operation_ship_75.md) §10 defers it here as "the
-audit-deferred tail (post-Ship-75): the parlay copula / dependence layer
-(Phase 1.2 follow-ups)". Better joint pricing multiplies the EV of every
-entry on both apps.
+([archived v2 §1.2](../archive/sportstradamus_roadmap_v2.md)); the model
+track defers it here (roadmap v3 §4 lane row — "biggest product-EV lever",
+gated on calibrated marginals, D3). Better joint pricing multiplies the EV of
+every entry on both apps.
 
 ## 2. Read first (in order)
 
-1. [`operation_ship_75.md`](../operation_ship_75.md) §Purpose + §10 — the
-   lens (calibration is the product; Gate 4 PIT-KS is the real bar) and the
-   deferral this lane resumes.
+1. [`model_improvement_track.md`](../model_improvement_track.md) §1 + §12 —
+   the lens (calibration is the product; Gate 4 PIT-KS is the real bar) and
+   the doc map for the marginals this lane consumes.
 2. [`archive/sportstradamus_roadmap_v2.md`](../archive/sportstradamus_roadmap_v2.md)
    §1.2 — the design sketch this brief restates, plus the open Phase 1.2.x
    audit findings.
@@ -104,7 +103,7 @@ ls -la data/parlay_hist.parquet 2>/dev/null
   verdict; mirror the existing `legacy` flag pattern (parlay.py:533,
   correlation.py:554). Default stays incumbent until stage 3 acceptance.
 - 2026-06-10 — Never loosen gates, harness thresholds, or test tolerances to
-  pass (ship_75 §Purpose discipline).
+  pass (model_improvement_track.md §1/§9 discipline).
 - 2026-06-10 — Vine copulas are out of scope at dims 2–6 (archived v2 §1.2);
   relitigating that is owner-only.
 
@@ -200,7 +199,8 @@ valuable verdict.
 ## 7. Working rules
 
 - Conflict order: command output > CLAUDE.md/CONTRIBUTING.md >
-  [`operation_ship_75.md`](../operation_ship_75.md) > this brief > roadmap v3.
+  [`model_improvement_track.md`](../model_improvement_track.md) > this brief >
+  roadmap v3.
 - Reuse before you write (CLAUDE.md): residualization, stratification, and
   shrinkage exist in `training/correlate.py`; the lane parameterizes or
   extends them, never re-implements them beside themselves.

--- a/docs/handoffs/sleeper-parity.md
+++ b/docs/handoffs/sleeper-parity.md
@@ -111,7 +111,8 @@ condition (§8).
 | [`tests/golden/`](../../tests/golden/) | New EV-engine and orchestrator tests; existing pickem/kelly/dashboard gates stay green |
 
 This lane touches the serving path (`prophecize` → snapshots): see the
-inference-path compatibility pointer in [`operation_ship_references.md`](../operation_ship_references.md).
+inference-path compatibility checklist in
+[`model_improvement_track.md`](../model_improvement_track.md) §11.3.
 
 ## 6. Stage plan
 

--- a/docs/model_improvement_track.md
+++ b/docs/model_improvement_track.md
@@ -1,0 +1,1061 @@
+# Model Improvement Track
+
+> Status: ACTIVE — Ship-75 rung
+>
+> **The single home of record for the model improvement track** — the lead lane of
+> [`sportstradamus_roadmap_v3.md`](sportstradamus_roadmap_v3.md). Every lever, stage, per-league
+> path, validation recipe, and session rule for pushing market cells through the offline ship
+> gates lives here, from the current Ship-75 rung through the D5 decision to the Ship-90 rung.
+>
+> Consolidated 2026-06-12 from four docs, now archived: `operation_ship_75.md`,
+> `operation_ship_90.md`, `feature_improvement_plan.md`, `handoffs/model-track.md`
+> (see [`archive/`](archive/); pre-consolidation text recoverable via
+> `git show 805cea7:docs/operation_ship_75.md` on devel and
+> `git show 46338ef:docs/operation_ship_75.md` on model-research, whose operating-loop
+> refinements are folded in below). Three companions stay canonical and are **not** restated
+> here: [`ship_gate.md`](ship_gate.md) (gate thresholds — owner-only),
+> [`operation_ship_references.md`](operation_ship_references.md) (research verdicts, citations
+> [1]–[71], commit refs), and the roadmap (program index, other lanes, deferred register).
+
+## 0. Mission, north stars, locked decisions
+
+**Get ≥ 75% of each covered league's markets past the five offline ship gates (g1–g5) in
+[`training/scorecard.py`](../src/sportstradamus/training/scorecard.py), then take the Ship-90
+rung when gate D5 fires.** This is the lead lane: calibrated full predictive distributions are
+the input every decision engine consumes, breadth is the number of +EV opportunities per slate,
+and Gate-4 PIT-KS calibration *is* alt-line pricing accuracy. Nothing downstream out-earns its
+marginals.
+
+| League | Ship-75 target | Ship-90 target |
+|---|---|---|
+| NBA | ≥ 16 / 21 | ≥ 19 / 21 |
+| WNBA | ≥ 14 / 18 | ≥ 17 / 18 |
+| NFL | ≥ 15 / 20 | ≥ 18 / 20 |
+
+A cell counts toward the numerator once it is `shipped ∈ {"devel", "main"}` in
+[`stat_meta.json`](../src/sportstradamus/data/config/stat_meta.json) — the production server
+tracks `devel`, so a Gate-1-clearing cell in its 14-day Gate-2 soak is already live and already
+counts. Mantra: *don't let perfect be the enemy of good.* The gate certifies **deployable**; the
+Kelly sizer and the live soak certify **profitable**. MLB and NHL have cells in `stat_meta.json`
+but no breadth target until their activation gates decide (D1/D2 —
+[`handoffs/mlb-nhl-activation.md`](handoffs/mlb-nhl-activation.md)).
+
+**Failure is not an option at the operation level.** Individual *levers* are allowed to fail —
+when one doesn't move a cell, scrap that path and take the next. The plan is built so every
+league has more independent levers than it has cells to flip, and the failure branches are
+written down in advance (§7, §9).
+
+**Locked decisions (owner):**
+
+- 2026-06-10 — the model track stays the lead lane; other lanes never preempt it.
+- 2026-06-10 — gate definitions and thresholds are owner-only; a gate change never counts as a
+  lever (§9).
+- Standing — ship incrementally: a Gate-1-clearing cell goes to `shipped: "devel"` and counts;
+  don't hold ships for batches.
+- Standing — new external data is free sources only; all five leagues get equal feature-effort
+  budget (refinement for NBA/WNBA/NFL, foundation parity for MLB/NHL).
+
+**Conflict order:** command output > `CLAUDE.md` / `CONTRIBUTING.md` > this doc > roadmap v3.
+If command output contradicts prose here, the output wins — fix the doc in place (minor) or stop
+and ask (material).
+
+## 1. The lens — beat the DFS apps; the sharp book is an asset, not an adversary
+
+Read this before anything about a "gate." It is the lens for the whole operation and the
+correction that had to be repeated most often during the gate audits.
+
+**We are beating the DFS pick'em apps (Underdog, PrizePicks, Sleeper), not the sportsbooks.**
+The apps price slates of over/under and alt-line picks that players combine into parlays. We win
+by handing the parlay builder **more accurate, better-calibrated probabilities than the app's
+implied prices** — across the standard line and the whole alt-line ladder.
+
+**The sharp sportsbook consensus is an asset we blend into, never a wall to beat.** It is a
+weighted, closing, de-vigged consensus — by construction it sits very close to the true
+probability, so beating it *standalone* is genuinely hard and is **not the goal**. `fused_loc`
+blends our model with that sharp line (the ensemble that actually prices our offers) precisely so
+we inherit its sharpness and add whatever marginal signal the model carries.
+
+**Calibration is the product.** The parlay builder needs well-shaped full predictive
+distributions to price alt-lines and to assemble correlated legs without compounding mispricing.
+That is why Gate 4 (PIT-KS calibration) is the real quality bar — and why fixing
+under-dispersion is central to the plan (§4, §7).
+
+**Gate 1 is a no-regression guardrail, not a "beat the book" demand.** It is a *non-inferiority*
+test: it certifies that blending our model into the sharp line does not make the ensemble *worse*
+than the line alone. A tie passes — that is the entire point. It follows that:
+
+- A cell that fails Gate 1 is one where the current model is **regressing the blend** — adding
+  noise, not signal (typically a small-sample, under-calibrated cell). The fix is a better model
+  (calibration, real signal via features), or leaning harder on the book in the blend. It is
+  **never** evidence that "the market is too efficient to win," and **never** a reason to loosen
+  a gate.
+- A sharp book can never be a wall. The worst case is a cell where the model adds nothing and we
+  ride the book line (a tie) — and even then the calibration work (g4) still matters, because the
+  parlay builder still needs a well-shaped distribution around that line.
+
+## 2. Ground truth — run, don't read
+
+Numbers drift on every ship and every `meditate`. Per-cell standings are **never** restated as
+prose anywhere in this doc; derive them:
+
+```bash
+# What production tracks
+git fetch origin && git log --oneline origin/devel -5
+
+# Shipped counts per league (withheld / devel / main)
+python3 -c "import json,collections; m=json.load(open('src/sportstradamus/data/config/stat_meta.json')); [print(l, dict(collections.Counter(c['shipped'] for c in v.values()))) for l,v in m.items()]"
+
+# Per-cell gate numbers (g1–g5, pit_ks slack, ship) — rewritten by every meditate
+ls -la data/training/model_stats.csv   # stale ⇒ re-run meditate before trusting
+
+# Lifecycle per (league, market): not-shipped / in-test / graduated / demoted
+poetry run check-graduation
+
+# Feature-importance hygiene (cells per league, stale rows, active features per cell)
+python3 -c "
+import pandas as pd, collections
+fi = pd.read_csv('src/sportstradamus/data/training/feature_importances.csv', index_col=0)
+print(dict(collections.Counter(c.split('_')[0] for c in fi.columns)))
+print('stale Player Player rows:', sum(i.startswith('Player Player ') for i in fi.index))
+nz = (fi > fi.max().max()*0.001).sum(); print('active features per cell (median):', int(nz.median()))"
+
+# Training-cache column counts per league (one cell each)
+python3 -c "
+import pandas as pd
+for f in ['NBA_PTS','NFL_attempts','MLB_hits','WNBA_PTS']:
+    try: print(f, len(pd.read_parquet(f'src/sportstradamus/data/training_data/{f}.parquet').columns))
+    except FileNotFoundError: print(f, 'no cache')"
+
+# Archive odds coverage per league (movement-feature / regen feasibility)
+python3 -c "
+import duckdb
+con = duckdb.connect('archive/archive.duckdb', read_only=True)
+print(con.execute('select league, min(game_date), max(game_date), count(*) from odds group by league').fetchall())"
+```
+
+Column dictionary for `model_stats.csv` / `.parquet`: CLAUDE.md §Training stats.
+
+**Volatile product assumptions:** none directly — this track prices stats, not app products.
+App-side payout drift is the decision lanes' problem.
+
+## 3. The bar — five gates, lifecycle, supersession
+
+Full thresholds, rationale, and the tighten/loosen procedure live in
+[`ship_gate.md`](ship_gate.md) (canonical; owner-only). Convenience snapshot of the five
+first-ship gates:
+
+| # | Gate | Statistic | Threshold |
+|---|---|---|---|
+| 1 | Brier vs book (non-inferiority) | paired-bootstrap 95% CI of `(p_model−y)² − (p_book−y)²` | `ci_hi < 0.005` |
+| 2 | Star σ-match | `\|mean(Blended_EV) − mean(Result)\| / std` on top-mean decile | `z < 0.5` |
+| 3 | Bench σ-match | same on bottom-mean quartile | `z < 0.5` |
+| 4 | **PIT-KS calibration** | `KS(randomized-PIT, Uniform)` of the predictive CDF | `pit_ks < max(0.05, 1.358/√n)` |
+| 5 | Equal-mass debiased ECE | 10 equal-mass `p_model` bins | `ece < 0.075` |
+
+Gate 4 is the load-bearing one: `pit_ks = sup|F_model − F_true|` **is** the worst-case alt-line
+mispricing, and the randomized PIT (Brockwell 2007) is exactly Uniform under calibration for
+count *and* continuous families, so one threshold spans both. Report-only companions name the
+*direction* a KS scalar can't: `central50_coverage` / `central80_coverage` (below nominal ⇒
+predictive too narrow), `g4_tail_pit_ks` (alt-over wobble), `g1_has_edge`, `betting_active`, and
+the retired IQR ratio survives as `g4_iqr_ratio`. Advisory diagnostics worth adding (report-only,
+never a gate): Anderson-Darling PIT (tail-weighted), conditional/stratified PIT-KS (by
+mean-decile / blowout / position / home-away), the non-randomized PIT for the count head, and a
+CRPS reliability decomposition (Arnold et al. 2024).
+
+**Lifecycle.** Five offline gates (Gate 1) certify a first ship → `shipped: "withheld" → "devel"`
+(one-line `stat_meta.json` edit; production tracks devel) → 14-day live Gate-2 soak →
+`check-graduation` classifies {not-shipped, in-test, graduated, demoted} → the monthly
+`gate-status` cron promotes graduates to `main` via PR. Demotions flow back the same way.
+
+**Supersession (Tier 1).** A *baselined* (already-shipped) cell never re-ships on a fresh 5/5 —
+the candidate must beat the incumbent via `scorecard.supersede_verdict(baseline, candidate)`:
+**S1** candidate clears the 5 gates standalone, **S2** paired Brier CI lower-bound > 0, **S3**
+paired Kelly-Sharpe Memmel-z > min. All three → SUPERSEDE (swap the strategy in
+`stat_meta.json`); any fail → HOLD. The S2/S3 asymmetry is deliberate — it stops strategy-churn
+on noise. First-ships use Tier-0 absolute gates only. CLI:
+`python -m sportstradamus.training.scorecard --baseline … --candidate …` (both sides full-HPO,
+row-aligned test dumps).
+
+## 4. State of the board
+
+### 4.1 The gates are trustworthy (audits closed)
+
+Every gate was independently audited; several were measuring artifacts and were fixed. A cell
+that fails a gate today is failing on real model quality, not a scorer bug:
+
+| Audit | Verdict | Status today |
+|---|---|---|
+| G4 IQR ratio (orig) | Sharpness-vs-calibration category error + decode/EV artifacts | **Retired** — replaced by PIT-KS; survives as report-only `g4_iqr_ratio` |
+| G5 equal-mass ECE | Positively biased at finite N (false-fails up to 44% of calibrated NFL-N cells) | **Fixed** — Monte-Carlo null-bias offset; gate reads `g5_ece_debiased` |
+| G2/G3 bias gates | ZINB/ZAGamma stored base-distribution μ vs zero-inclusive mean, overstating by `1/(1−π)` | **Fixed** — `_zero_inflated_mean`; gates score the fused `Blended_EV` |
+| G1 strict-superiority | Over-specified ("at least as good as the book") | **Reframed** — non-inferiority `ci_hi < 0.005`; strict superiority survives as reported `g1_has_edge` |
+| G1 selection-gate proposal | Precision-on-value-picks gate = multiplicity trap (0/6 NFL cells survive Bonferroni) | **KEEP g1 as-is.** Standing rule: never gate on a model-conditioned statistic |
+| G1 −0.0 rounding | Sign-bit preserved; genuinely-negative CI bound in (−5e-5, 0) false-failed | **Fixed** — `np.signbit` |
+
+### 4.2 The book we grade against is real (archive repair, permanent infrastructure)
+
+The archived per-book `ev` for the passing/count families was a legacy klepto-era seed (every
+book = consensus median ⇒ `p_book ≡ 0.5`), not a real price. Real two-sided historical prices
+were re-fetched (Odds API, `backfill_historical_odds.py`) and injected rebuild-equivalently
+(`inject_backfilled_odds.py`); every g1 verdict now grades against an honest book. The repair
+also confirmed how sharp the asset is: honest continuous NFL volume lines sit at the median
+(`p_book ≈ 0.5`, `brier_book ≈ 0.25` by construction) — per §1 that makes them good blend
+ingredients, not walls. NFL is the hard league because its small samples (≈300–1000 rows/cell)
+make the *don't-regress-the-blend* bar harder to clear — not because any market is unwinnable.
+
+### 4.3 Diagnosis — under-dispersion is the dominant symptom
+
+The 2026-06-03 full-board re-score (every test CSV through `compute_gates`, the exact production
+path) found failure modes overwhelmingly concentrated on Gate 4, pointing one direction: **too
+narrow**. Census of the then-40 withheld cells (evidence snapshot — regenerate from
+`model_stats.csv`, never cite these counts as current):
+
+| Primary failure | Count | Routed to |
+|---|---|---|
+| Gate 4 only (g1/g2/g3/g5 all pass) | 24 | calibration (§7.1) / normalization (§7.2) |
+| Gate 4 + marginal Gate 1 (`ci_hi` 0.007–0.018) | 6 (all NFL) | calibration → features (§7.3) / blend (§7.5) |
+| Gate 4 + Gate 2/3 (bias) | 3 | mean rung then scale rung (§7.1) |
+| Multi-gate (g1+g3+g4) | 2 (NFL passing-first-downs, qb-yards) | hardest; features + per-position (§7.6) |
+| Gate 1 only / Gate 1+5 (edge) | 2 (WNBA STL; NBA PF) | features (§7.3) |
+| Pass now, un-promoted | 3 (WNBA BLK, FG3M, TOV) | promoted since — free-passer sweep is §7.0 |
+
+The two modeling **heads fail in opposite directions** (Czado-Gneiting-Held 2009) — there is no
+single "widen everything" fix:
+
+- **Continuous (SkewNormal)** — *under-dispersed* (PIT U-shaped, central-50 below nominal:
+  shipped cells sat at ≈0.44–0.46, withheld ones as low as 0.23–0.38 in the snapshot). Needs
+  widening.
+- **Count (ZINB / NegBin / ZAGamma)** — *over-covers* (PIT inverted-U, central-50 above nominal).
+  Needs narrowing — and the negative-binomial conditional variance is bounded below by its mean,
+  so a near-equidispersed-or-tighter truth is *forced* too wide: the deepest count cells need a
+  both-directions family (§7.6), a structural ceiling post-hoc cannot clear.
+
+**Root cause and what remains.** The original sin — SkewNormal received no dispersion calibration
+at all (two hardcoded exclusions) — **is fixed**: the pipeline now fits a joint `(c, skew_cal)`
+scale/skew against PIT-KS for SkewNormal and applies it on the served path (§7.1 Rung B). What
+remains is the *residual* under-dispersion a scalar can't reach: every SkewNormal cell starts on
+the raw GBDT scale — leaf-averaged, dynamic-range-compressed (refs [3][4][30]) — and on
+moderate/severe cells the miss is *shape* or *location*, not pure scale. The count families get
+`dispersion_cal` too, but the original objective was CRPS, not PIT-KS (re-targeted in §7.1).
+
+**Which axis fixes a given cell is not assumed — the honest search adjudicates (§5–§6).** The
+headroom is real: on Gate-4-only cells the g1 margins are comfortable (snapshot: NBA AST `ci_hi`
+−0.028, WNBA DREB −0.064) — the blend already ties-or-beats the book on a proper score; only the
+predictive shape that prices alt-lines is too tight. The mirror-image risk: over-widening pushes
+probabilities toward 0.5 and can *reduce* Brier skill (g1) and shift ECE (g5) — so every width
+fix is fit to a calibration target and guard-railed on g1/g5 (§7.1 go/no-go).
+
+### 4.4 Lever verdicts — what is dead, what is alive
+
+| Lever | Verdict | Evidence |
+|---|---|---|
+| Centered-target normalization (`centered_additive_mean10`) | **Alive & shipping** — out-calibrates `ratio_meanyr` on Gate 4 for several cells the scalar width fix can't reach (run the §2 shipped-counts block; several cells carry it in `stat_meta.json` today). The old P1 "dead" call judged it as a *mean-compression* fix under the pre-PIT-KS gate — superseded | refs §2 + sweep board |
+| `init_score` warm-start baseline | **Dead** — byte-identical to plain NegBin | refs §3 |
+| ZTNB-hurdle likelihood | **Refuted** — incompatible with the derived-π decode; would regress the shipped hurdle markets | refs §6 |
+| T5 multiplicative factorization (volume × efficiency) | **Killed** — Goodman variance-of-products gives +27% predictive-variance inflation on the priced cell | refs §9 |
+| Family build (CMP / GenPoisson; SHASH / JSU; skew-t) | **On the table — research-gated** (§7.6). Top-decile *mean* compression is family-invariant (the leaf average itself), but a both-directions count family fixes the over-covering count cells NegBin can't, and SHASH/JSU fixes heavy-kurtosis continuous cells | refs §7 |
+| HurdleZINB (per-cell `zinb_mode`) | **Alive & shipped** — 6/8 NBA ZINB markets | refs §4 |
+| Post-hoc mean correction (`roe_mean` / `isotonic_mean`) | **Alive & shipped** — `MEAN_STAGE` in [`posthoc.py`](../src/sportstradamus/training/posthoc.py); use skeptically (§7.1 Rung A) | refs §8 |
+| Post-hoc probability recalibration (`prob_recal_*`) | **Alive** — `PROB_STAGE` built, available per-cell | posthoc.py |
+| Post-hoc scale/dispersion (joint `(c, skew_cal)` vs PIT-KS) | **Shipped** — route 1a-hybrid; Levi closed-form σ-scaling is a dead end (diverges 5–7000× on skewed cells) | §7.1 Rung B |
+| Player-level features (expanding-mean, EB-shrunk, opp-defense) | **Alive, unbuilt** — RANK 2/3 in the breadth verdict; §7.3 M-1 | refs §8 |
+| Per-position model split (NFL, T11) | **Alive, on the table** — a live lever now, not held for Ship-90 | refs §9 |
+
+## 5. The four axes and the strategy search
+
+A served predictive is built in four independently-swappable stages,
+`normalization → model/loss → blend → calibration`
+(`target_normalization ⊥ {dist_training_loss, variance_reg} ⊥ {blending_loss_fn, fused_loc/BLP, book-recovery} ⊥ {posthoc, dispersion_cal, skew_cal}`):
+
+| Axis | Values | Executable today | Unbuilt |
+|---|---|---|---|
+| **Normalization** (retrain) | `ratio_meanyr`, `centered_additive_mean10`, `centered_additive_eb_meanyr_k10`, `ratio_projvol` | 3 of 4 carry a Gate-4 SkewNormal decode (`scorecard._decode_sn_loc_scale`; EB off the dumped `GlobalMean`) | `ratio_projvol` (§7.2) |
+| **Model/loss** (retrain) | dist-loss `nll`/`crps`; variance / soft-cal regularizer | dist-loss via `--dist-training-loss` | variance / MMD-to-uniform-PIT regularizer (§7.5) |
+| **Blend** (retrain weight + research-gated structure) | blend-loss `nll`/`crps`; `fused_loc` pool; book recovery; BLP wrapper; p_book noise | blend-loss via `--blending-loss-fn` (`fit_model_weight_crps` built); current `fused_loc` pool | density-LOP fix, power de-vig, book recovery, BLP, p_book noise, free post-hoc `w`-refit (§7.5) |
+| **Calibration** (auto-fit, not searched) | location (`roe_mean`/`isotonic_mean`); scale+shape (`dispersion_cal` + joint `skew_cal`); full-CDF (isotonic-PIT / IDR) | location + scale+shape shipped, baked into the dump, read by the gate | isotonic-PIT / IDR full-CDF recal (§7.1 Rung C) |
+
+**The search interface.** The per-market searcher is
+`training/model_strategy_driver.py` (entry point `model-strategy-driver`;
+`model_strategy_search.py` underneath). `--board` searches the covered-league board and appends
+the ranked result to `data/research/strategy_research_board.csv` after each cell (an interrupt
+keeps partial progress); `--league L --market M [--out PATH]` runs one cell. Each corner trains
+one `meditate --deterministic --target-normalization … --dist-training-loss {nll|crps}
+--blending-loss-fn {nll|crps} --bypass-withholding`; `--deterministic` pins RNGs and fixed fast
+hyperparameters and writes to a sandbox (`research/models/deterministic/` +
+`data/test_sets/deterministic/`) so a trial never clobbers a production market.
+
+> **Branch asymmetry — check before you start.** The driver pair lives on the
+> `model-research` branch only (`ls src/sportstradamus/training/model_strategy_driver.py`).
+> On `devel` the fallback is manual ranking from `model_stats.csv` (sort withheld cells by
+> min-gate slack / `pit_ks` distance to threshold) plus per-cell `meditate --deterministic`
+> A/Bs via the scorecard CLI. Porting the driver to devel is a §7.0 task — until it lands,
+> board generation happens on model-research and ships are confirmed wherever the cell will
+> ship from.
+
+The driver searches only the **retrain** axes (normalization × dist-loss × blend-loss) as an
+Optuna `GridSampler` grid (≤12 discrete corners, exhaustive and deterministic; the
+`[kind, spec, stage]` `SEARCH_SPACE` flips to TPE the moment a continuous axis lands).
+Calibration is auto-fit per corner — a post-hoc transform fit in milliseconds never sits in the
+training loop; that cost asymmetry is the design's core. The objective is the negative
+**min-gate slack**: a single scalar, positive iff the corner ships, larger with more headroom
+across all five gates at once — it optimizes "ships, with margin," not Gate 4 alone.
+
+Each corner is scored by the **honest val-fit→test gate row**
+(`model_strategy_search._score_normalization`): the deterministic dump already carries the
+pipeline's own validation-fit joint calibration, so the ranker calls `scorecard.gate_row` on it —
+the *same* code production ships on. No test re-fit (an earlier build re-fit calibration on test
+rows and oversold the screen; removed in `10306ee`). The driver is a faithful fixed-HP replica of
+the production HPO pipeline; the only differences are fixed hyperparameters and sandbox write
+locations.
+
+**Nothing is deferred. Every withheld cell and every lever is a live Ship-75 candidate.** The
+old `deferred-90` / "defer" / lever-cap tags are retired — they were per-axis verdicts (almost
+always the calibration axis under a single normalization), and the honest sweep showed cells
+stamped `deferred-90` ship under a *different* normalization. A cell leaves the board **only**
+on matrix-wide exhaustion (§9) or the operator's explicit, documented denominator call.
+
+**Two caveats on "wire in a new parameter."** (a) **Research-gate** — a parameter that changes a
+*distribution family or dispersion mechanism* needs a `research-analyst` brief before it is wired
+or built (§10); a plain knob (a normalization slug, a loss choice) does not. (b) **Wiring an
+axis-value ≠ it sweeps.** A value can sit in `SEARCH_SPACE` yet not sweep until its machinery
+exists, and its cost tier can shift once it does (`blending_loss_fn` carried `crps` before
+`fit_model_weight_crps` existed; building it made it sweepable — on the *retrain* tier, because
+the deterministic dump doesn't carry the pre-blend components a free `w`-refit needs). "Wire it
+in" is sometimes "wire the axis, build the value, decide the tier — then it sweeps."
+
+## 6. The operating loop (per cell)
+
+The deterministic study only **ranks**; the real-HPO scorecard **ships**. Fixed workflow:
+
+1. **Board = candidate generator.** `model-strategy-driver` (or the devel manual fallback, §5)
+   returns the ranked board, one deterministic train per corner, scored on the honest
+   val-fit→test gate row. A `ships=True` row is a *candidate flag*, never a ship.
+
+2. **Carry forward the top-K (2–3) production-reproducible corners — including near-misses.**
+   Include corners that *fail* the deterministic gate by ≤3% of threshold
+   (`min_gate_slack ≥ −0.03`): the val→test discount tips knife-edge cells in *either* direction
+   (a board passer can fail HPO; a board near-miss can clear it). **Reproducible** means the
+   corner survives the server's plain `meditate`: `target_normalization`, `posthoc`, and
+   `blending` persist per-cell in `stat_meta.json`, but `--dist-training-loss` does **not** — so
+   for a SkewNormal cell only the family-default `crps` dist-loss is shippable; an `nll`-dist
+   corner can clear the run yet will silently retrain to `crps` on the server. The top board
+   corner is not always the one that survives HPO (evidence: NBA DREB — `eb` topped the board,
+   `mean10` is the corner that shipped), which is why the list is walked, not just its head.
+
+3. **Withheld cell → real-HPO confirm → ship to devel.** Set the corner's
+   `target_normalization`, `posthoc`, and `blending` in `stat_meta.json` **before** the full-HPO
+   `meditate` — `scorecard._resolve_decode_strategy` reads `stat_meta.json`, not the CLI flag, so
+   a stale strategy there yields a spurious Gate-4 miss. Pass the corner's
+   `--target-normalization` / `--blending-loss-fn` flags to match during the confirm. Read the
+   official scorecard (`model_stats.csv`). A clean **5/5** → flip
+   `shipped: "withheld" → "devel"`. Walk down the reproducible top-K, shipping the first that
+   clears; list exhausted ⇒ route the cell to the calibration ladder (§7.1) and record the axis
+   attempt (§9). If the winner is the cell's current default strategy it is a straight confirm
+   (no strategy edit). Knife-edge cells (g4 within ~0.003 of 0.05) are exactly where the
+   val→test discount bites — the confirm is mandatory; never ship the deterministic score.
+
+4. **Incumbent cell with a better corner → supersede.** The higher bar of §3 (S1+S2+S3) applies.
+   Sweep the **whole** board, shipped cells included — a shipped cell may have a better corner
+   than the scale-only default it settled for.
+
+Exploration runs always use `meditate --deterministic` (sandboxed writes) with `--market`
+scoping; full-league retrains are expensive — don't run one to answer a one-cell question. Every
+target cell that is withheld needs `--bypass-withholding` or the run silently skips it.
+
+## 7. The progression — ordered stage ladder
+
+Stages are ordered cheapest-first; **every stage ships per cell on a clean re-score** the moment
+it produces a passer (ship-incrementally — stages are not batches to complete before shipping).
+Work stages concurrently where they don't share a surface (e.g., Stage 3 feature batches can run
+while Stage 1 calibration cells confirm), but a single session works one stage's scope. Each
+stage names its **entry**, **steps**, **acceptance**, and **if-it-fails** branch. Research-gated
+items are flagged.
+
+### §7.0 Stage 0 — Bookkeeping & trust (standing + one-time, all small)
+
+Entry: none — most of this recurs.
+
+1. **Free-passer re-score sweep (standing, monthly).** The Gate-4 redefinition was applied as
+   demotions only; cells the old gate killed but the new gate passes were never auto-promoted
+   (the 2026-06 sweep found three WNBA cells, since promoted). After any lever or data change
+   and at least monthly — ideally alongside the `gate-status` cron run — re-read
+   `model_stats.csv` for `ship == True` rows still `shipped: "withheld"`, re-confirm on the
+   official scorecard, and flip them. If the official scorecard disagrees with a sweep pass,
+   that disagreement is a scorer bug to chase before anything else ships.
+   *Acceptance:* no `ship == True ∧ withheld` rows older than a month.
+2. **Hole #0b decision packet — Gate-4 baseline hysteresis (owner call, prepare don't flip).**
+   A fresh re-score fails several `devel` cells by a hair (a finite-sample KS statistic is a
+   step function at the hard 0.05 cutoff). Options: (a) asymmetric hysteresis band — demote a
+   baselined cell only at `pit_ks ≥ 0.055` (first-ship stays strict 0.05), pinned by a golden
+   test and reconciled with the monthly auto-demote; (b) ship the §7.1 scale fit first (moves
+   salvageable cliff cells to comfortable margin), re-score, accept the genuine demotions.
+   **Recommendation: (b) first** — it needs no gate-policy change; revisit (a) only if
+   demote/promote churn persists across two monthly cycles. Prepare the packet (cells, slacks,
+   churn count); the owner flips.
+3. **Stale-importances purge (QW-2/C-4, one-time + golden).** 155 `Player Player *_asof` rows in
+   `feature_importances.csv` are residue of a fixed double-prefix bug. Batch-rebuild via
+   `see_features()` ([`training/shap.py`](../src/sportstradamus/training/shap.py)) so rows derive
+   only from current model pickles; add a golden assert that no `Player Player ` rows exist.
+   *Acceptance:* §2 hygiene block reports 0 stale rows; golden test pins it.
+4. **Train/live parity harness (build-first — blocks all Stage-3/4 feature work).** No harness
+   exists comparing `get_training_matrix` vs `get_stats` on a frozen gameday. Build the golden
+   test: one frozen gameday, both paths, assert column sets and values match for the shared
+   surface. *Acceptance:* test in `tests/golden/`, green on the current feature set, and every
+   later feature batch extends it. Until this exists, no new feature ships.
+5. **Pre-register the NFL g1×dispersion experiment (hole #4 — the difference between NFL
+   reaching 10 and reaching 15).** Before/after paired Brier-CI on the five g1+g4 NFL volume
+   cells (attempts, carries, completions, receiving-yards, rushing-yards) under a candidate
+   §7.1 scale fit: does calibrating dispersion pull the marginal `ci_hi` (0.007–0.018 at the
+   2026-06-03 snapshot) under 0.005 as a side effect? Run it as soon as a candidate fit exists
+   for one of the five — the answer reorders the NFL queue (§8), so measure early, not when NFL
+   stalls. *Registered decision rule:* if ≥3 of 5 cells move `ci_hi` below threshold → NFL path
+   runs through Stage 1 alone; if ≤1 does → pull Stage 3 features and §7.6 per-position forward
+   for NFL immediately.
+6. **Port the strategy driver to devel (small code PR, separate session).**
+   `model_strategy_driver.py` + `model_strategy_search.py` are research-branch-only (§5);
+   porting removes the branch asymmetry and lets devel sessions generate boards. Until then the
+   manual fallback applies.
+
+### §7.1 Stage 1 — Calibration axis: the post-hoc ladder (location → scale+shape → full-CDF)
+
+Post-hoc transforms on the served predictive, free or near-free (fit on validation, applied to
+the disjoint test split). Close to exhausted as a *breadth* lever alone — it fixes
+width/shape/location, never signal — but it is the cheapest move on every too-narrow cell and
+the prerequisite measurement for hole #4.
+
+Entry: cell fails g4 (either direction) or g2/g3.
+
+- **Rung A — location (`roe_mean` / `isotonic_mean`, shipped).** Affine ROE / isotonic
+  `MEAN_STAGE` correctors, selected per cell via `posthoc` in `stat_meta.json`. Targets g2/g3
+  bias failures. At NFL count means use affine ROE only (isotonic tails overfit at low base
+  rates, ref [48]). **Operator note — skeptical:** post-hoc correction of the *predicted mean*
+  edits the central tendency the model is supposed to learn; prefer fixing location at the
+  source (normalization §7.2, features §7.3), carry mean correction as last resort, and ship a
+  mean-corrected cell only if it also holds the g1 BSS guardrail and survives the val→test
+  discount.
+- **Rung B — scale + shape (joint `(c, skew_cal)`, shipped).** Per-cell scale `c` fit so the
+  served predictive PIT is Uniform, inside
+  [`pipeline._step_calibrate_dispersion`](../src/sportstradamus/training/pipeline.py) with
+  objective `scorecard._randomized_pit_ks`, applied via
+  [`model_prob._dispersion_calibrate`](../src/sportstradamus/prediction/model_prob.py). The
+  additive skew `skew_cal` on the served SkewNormal `alpha` is fit *jointly* with `c` against
+  the same PIT-KS — additive not multiplicative because the direct parameterization has a
+  Fisher-information singularity at `alpha = 0` (Hallin & Ley 2014), so `alpha × k` injects no
+  skew; joint strictly dominates sequential on the binding under-skew cells. Fit in
+  centered-skewness space (clamp `|s| ≤ 3`), warm-start `(c, 0)`, ship at val
+  `pit_ks < 0.040` (val→test discount +0.008–0.010). Fit, dump, and gate all act on the *served*
+  (model × book) predictive, re-encoded to normalized space so the scorecard decode recovers it
+  byte-for-byte.
+- **Rung B′ — re-target the count objective (build).** The count-branch `dispersion_cal`
+  minimized CRPS, but the gate is PIT-KS — re-targeting the fit to PIT-KS is the one change
+  that tightens the whole over-wide count branch (snapshot: all 21 ZINB/NegBin cells
+  over-covered). Minimizing CRPS does not guarantee a calibrated PIT.
+- **Rung C — full CDF (isotonic-PIT / IDR, build, free).** The scalar `(c, s)` is the bottom of
+  an expressiveness ladder: a monotone spline on the PIT (Kuleshov 2018) or isotonic
+  distributional regression (Henzi, Ziegel & Gneiting 2021) recalibrates the *whole* predictive
+  CDF — the entire alt-line ladder — not just the single-line over-probability
+  `prob_recal_isotonic` fixes. It acts on `Z = F(Y|X)` (randomized PIT for counts) so it ports
+  to both heads unchanged. Prefer isotonic/IDR over conformal *calibration* on the count lattice
+  — conformal yields discontinuous randomized CDFs (Marx 2022), bad for pricing a ladder.
+  (Conformal *predictive distributions* are separately deferred — roadmap v3 §8.)
+
+**Acceptance (per cell, on validation, before ship):** `pit_ks` below `max(0.05, 1.358/√n)`
+**and** g1 Brier-skill drop ≤ 0.01 **and** g5 ECE < 0.075. Any served calibration object (scale,
+skew, Rung-C map) must be written to the test-CSV dump (`_step_persist_artifacts`) and applied
+identically at inference — pickle key + legacy fallback + byte-identical round-trip test
+(§11.3).
+
+**If it fails:** widening flips g4 but breaks g1/g5, or `pit_ks` won't move because the
+mislocation is mean/skew not scale → route bias-direction cells (g2/g3) through Rung A; route
+cells trading g4 for g1 to features (§7.3 — signal, not width); residual *shape* the SkewNormal
+can't reach by `(c, s)` → normalization (§7.2) and blend (§7.5); family rebuild (§7.6) only on
+matrix-wide exhaustion. Do not pre-tag cells dead.
+
+### §7.2 Stage 2 — Strategy sweep: normalization × loss
+
+Entry: driver (or fallback) available; cell on the board.
+
+The retrain axes, searched per §5–§6. Normalization is **often decisive over calibration**: the
+honest sweep ships moderate/severe cells under `centered_additive_mean10` that no scalar width
+fix reaches — a centered/rate target reshapes the residual so the predictive is calibratable at
+all. The EB / hierarchical-shrinkage strategy (`centered_additive_eb_meanyr_k10`) is built and
+decode-tested. Training loss `nll` vs `crps` per cell: min-CRPS is more robust to
+misspecification, max-likelihood slightly more efficient under correct specification
+(Gebetsberger 2018) — keep the per-cell winner, subject to the §6 reproducibility rule
+(dist-loss does not persist; only the family default ships).
+
+**Build: `ratio_projvol` (the most likely NFL volume unlock).** Modeling `points` (or
+`points/season-mean`) conflates *efficiency × opportunity*. Target = `y / projected-volume`
+(per-minute / per-carry / per-target rate), decode = `rate × projected-volume`; on the count
+side use `log(volume)` as a GLM offset and delta-method (or Monte-Carlo) back to totals scale
+for the gate. The volume projections **already exist** (`proj_*` features: projected
+carries/targets/minutes) — used as features today, never as the denominator. A `rushing-yards`
+g1 block is plausibly a volume/efficiency conflation the book prices and we don't. Decode +
+leakage tests before any ship (§11.3 new-strategy row).
+
+**Acceptance:** per §6 — official 5/5 on the full-HPO confirm (withheld) or S1–S3 (incumbent).
+**If it fails:** the cell records the normalization axis as tried (§9) and routes to features
+(§7.3) or blend (§7.5).
+
+### §7.3 Stage 3 — Feature batch 1: quick wins + the pre-registered build
+
+Entry: §7.0 parity harness green. Targets the cells that need *signal*, not width: the NFL
+g1+g4 volume five, WNBA STL, NBA PF — Gate-4 under-dispersion belongs to §7.1/§7.2, and feature
+work complements, never replaces it.
+
+All items follow the §11.2 validation protocol (leakage test → parity → regen → deterministic
+A/B → real-HPO confirm) and the batching policy (features land per-league in batches — one regen
+per league per batch, never one feature at a time; regen costs hours per league board). The
+inert-revert rule applies to every item: SHAP importance < 0.001 ⇒ inert ⇒ revert; never carry
+dead columns.
+
+1. **QW-1 — spread, opponent implied total, game total, blowout flag (all leagues).** Game
+   script conditions volume markets; the model sees only own-team `Moneyline`/`Total`. Zero new
+   data: [`moneylines.py`](../src/sportstradamus/moneylines.py) stores archive `Totals` as the
+   implied team total (`(game_total + team_spread)/2`), so `Spread = Total(team) − Total(opp)`
+   and `GameTotal = Total(team) + Total(opp)` come from two `archive.get_total()` calls,
+   leakage-safe via the existing `at=target_at` mechanism. Implement in `_game_context` —
+   **both** branches (historical gamelog + upcoming archive lookups); `Blowout = |Spread| >
+   threshold` with the threshold a named per-league module-level constant (build-time operator
+   decision, no magic numbers); register columns in the `Common` bucket of
+   [`feature_filter.json`](../src/sportstradamus/data/config/feature_filter.json).
+2. **QW-4 — NFL schedule context.** `weekday` / `gametime` are fetched and discarded
+   ([`nfl.py`](../src/sportstradamus/stats/nfl.py)). Emit `Weekday`, `PrimeTime`, short-week
+   rest differential.
+3. **QW-5 / A-1 — harvest more from the existing comp pool (NBA/WNBA/NFL/NHL).** The pool
+   already computes pairs + distances (`_comp_pairs`, cached); emitting more aggregates is
+   near-free. In `_apply_comp_features` / `_nonmlb_comp_features` add: distance-weighted comp
+   **std**, comp **trend** (weighted mean of comps' `growth`), opponent-conditional comp mean on
+   the **raw scale** (today only the z-score is emitted), recency weighting of comp outcomes in
+   the opponent merge. Evidence: `comps z` is a stable top-15 feature at ~10% importance —
+   informative and under-harvested.
+4. **M-1 / B-3 — the pre-registered player-level build (highest confidence; NFL first).**
+   `MeanYr_expanding_shifted` = `groupby(player_id).expanding().mean().shift(1)`, plus a
+   `× opponent` variant and EB / James-Stein shrinkage where expanding is sparse (shrinkage
+   strength cross-validated, landed as a named constant — do not invent a value); plus
+   opponent-defense × player interaction columns (`profile_market`) and the blowout flag from
+   QW-1. Mirrored exactly in training and `get_stats` (strict `<` date filter); extend
+   [`test_meanyr_mean10_leakage.py`](../tests/test_meanyr_mean10_leakage.py) before any ship.
+   Pre-registered targets: NFL volume five, WNBA STL, NBA PF.
+
+WNBA lands every shared-base item in the same PR as NBA (shared `base.py` machinery; EB-shrunk
+variants preferred at half the games). **Acceptance:** per §11.2 step 5. **If it fails:** a
+feature that doesn't carry g1 for an NFL cell escalates to the per-position split (§7.6); a cell
+the model still can't improve leans harder on the book in the blend — rides the sharp line and
+ships if calibration holds; never "unwinnable."
+
+### §7.4 Stage 4 — Feature batch 2 + the feature-count ablation
+
+Entry: Stage-3 batch confirmed (its regen + parity infrastructure is reused).
+
+1. **M-2 / B-2 — EWMA recency family (all leagues).** `Avg1/3/5` are high-variance tail
+   snapshots; exponentially-weighted mean/std at 2–3 half-lives adds a continuous recency axis
+   to the family that already dominates SHAP. In `_rolling_features` (leakage-safe by
+   construction). Expect some EWMA columns to displace `Avg3/Avg5` — fine.
+2. **M-3 / B-4 — schedule-derived fatigue.** B2B, 3-in-4, opponent-rest differential,
+   travel/timezone — zero-scrape derivables from schedules already fetched + one new static
+   stadium lat/lon/dome table under `src/sportstradamus/data/`. Order: NBA/WNBA/NHL first
+   (schedule density), then NFL/MLB. The stadium table is also D-4's dependency.
+3. **M-4 / D-3 — NBA/WNBA starter flag.** nba_api boxscores carry `START_POSITION`
+   historically, so it backfills leakage-clean; emit starter flag + "starters missing" count.
+   Both leagues in one PR.
+4. **M-5 / A-2 — comp-weight re-optimization with the stability gate.** Idle tooling exists:
+   [`comp_feature_stability.py`](../src/sportstradamus/scripts/comp_feature_stability.py) (YoY
+   keep/transform/drop), [`evaluate_comp_features.py`](../src/sportstradamus/scripts/evaluate_comp_features.py)
+   (greedy add/remove), [`optimize_comp_weights.py`](../src/sportstradamus/scripts/optimize_comp_weights.py)
+   (differential evolution on Spearman). Run stability → evaluate → optimize per league; extend
+   the optimizer to co-optimize K (currently min 5 / max 15–20) and the distance-kernel exponent
+   (`1/(1+d)`). Spearman is in-sample to the comp objective — the arbiter is the §11.2
+   deterministic A/B. Revert = restore prior `playerCompStats.json` (versioned).
+5. **M-8 — the NFL small-n ablation (pre-registered; settles "too many features?").** 2–3
+   small-n NFL cells from the g1-blocked volume five: full candidate set vs per-cell top-K
+   |SHAP| (K ∈ {50, 100}) vs family-pruned, under `meditate --deterministic` at fixed HP, scored
+   on the honest val→test gate row. **Decision rule, registered now:** adopt per-cell top-K only
+   if it beats full on g1 `ci_lo` across the tested cells **and** survives a real-HPO confirm;
+   otherwise record the verdict here and close the axis. Context: the no-filter rewire stands —
+   70–92% near-zero-SHAP features is the expected signature of a healthy wide-candidate GBDT;
+   the measured cost is wall-time, the small-n variance cost is a hypothesis. **Do not re-add
+   global pre-train filtering.** The durable answer is addition discipline (the inert-revert
+   rule), not subtraction; `feature_correlations.csv` feeds a redundancy audit — collapse
+   |ρ| > 0.98 pairs only where one column is derived from the other by construction, and only
+   through the standard A/B.
+
+### §7.5 Stage 5 — Structural width fixes: blend rebuild + training-time regularizer (research-gated)
+
+Entry: a cell where §7.1–§7.3 left the served predictive miscalibrated, or NFL needs the
+blend-side escalation (§8). **Structure changes here alter the dispersion mechanism →
+`research-analyst` brief first (§10).**
+
+**Why the blend is the under-built axis.** `fused_loc`
+([`helpers/distributions.py`](../src/sportstradamus/helpers/distributions.py)) blends summary
+*parameters*, with five measured immaturities: (1) parameter blend ≠ density pool — the NegBin
+path log-blends `(μ, r)` but a true logarithmic opinion pool multiplies the PMFs pointwise and
+renormalizes (parameter-blending coincides with the LOP only in the Gaussian case, so the
+SkewNormal loc/σ precision-blend is correct, NegBin/ZINB is an approximation wearing the label);
+(2) the book side is a crude symmetric `N(ev_b, (ev_b·cv)²)` with a single per-cell `cv` from
+`stat_calibration.json`, skew forced to 0; (3) skew is a linear shrink (`w·model_skew`); (4) the
+pool can only sharpen, never widen — widening is bolted on afterward as the scalar `c_opt`; (5)
+no noise model on `p_book`. The de-vig (`no_vig_odds`) is proportional, and one-sided lines
+fabricate a flat 6.5% under.
+
+**Fitting half — turn one de-vigged point into a distribution.** (a) Replace proportional
+de-vig with the **power (logarithmic) method** — preserves [0,1], handles favourite-longshot
+bias on asymmetric / anytime-TD lines (Clarke, Kovalchik & Ingram 2017); flag cells with
+`|p_over − 0.5| > 0.3` for extra downstream shrinkage. (b) Recover the book *distribution* by
+fixing the model's shape `(σ̂, α̂)` / `(θ̂, π̂)` and solving the single location so the
+model-shaped CDF passes through the de-vigged point (1-D root-find; the line is a *median*, not
+a mean — that is why skew matters). (c) Count tail case (anytime-TD): `λ = −log(1−p)` / NegBin
+`μ = θ((1−p)^(−1/θ)−1)` are ill-conditioned as p→1 — regularize toward the model's `μ̂` and cap
+`|μ_book − μ̂| ≤ K·SD`.
+
+**Pooling half.** (a) Keep the log pool as base operator but fix NegBin/ZINB to a **real density
+LOP** (grid-multiply the PMFs, renormalize). (b) Add the **beta-transformed linear pool (BLP)**
+wrapper `F^BLP = B_{α,β}(w·F_model + (1−w)·F_book)` (Ranjan & Gneiting 2010): flexibly
+dispersive — narrows *or* widens, learned from history — fit **outside** the five gate
+calculations. This is the principled under-dispersion fix that supersedes the bolt-on scalar
+widener. **Do not** substitute a raw *linear* pool: its widening is disagreement-driven and
+degrades sharpness and the KS/ECE gates (Gneiting & Ranjan 2013; Hora 2004). (c) Conjugate noise
+on `p_book`: treat `logit(p_book)` as a Gaussian observation on the model's logit-CDF at the
+line, per-cell variance from residual studies → precision weight. (d) Learn `w` by CRPS
+(continuous) / log-score (count), shrunk per-cell toward a global prior ∝ 1/n_cell; never
+hard-code book = truth. (e) Time-varying `w_book` ramp toward close (the de-vigged close is the
+best probability estimate, but at close). The CLV-edge dashboard defers to roadmap v3 §8; the
+weight schedule lives here.
+
+**Model/loss adjunct (research-gated — dispersion mechanism).** The training-time variance /
+soft-calibration regularizer (untried, not refuted): an MMD-to-uniform-PIT penalty (Chung 2021)
+or held-out variance penalty that widens σ where the model is overconfident — attacking
+under-dispersion at the source. Pick it up if normalization + blend leave a cell overconfident.
+CRPS-stacking the model's own CDF variants across loss × transform via a log / beta-transformed
+pool (never raw linear) is the cheap cousin. Honest caveat for both: LightGBMLSS's CRPS path
+sets the Hessian to 1 (first-order), which is why a properly-curved CRPS head (NGBoost-style) is
+a narrow-use Hail-Mary, not the default.
+
+**Acceptance:** `pit_ks` below threshold with g1 BSS drop ≤ 0.01 and g5 < 0.075, on validation,
+before ship; an inference-path round-trip test for every new served object (de-vig method,
+recovered book params, BLP coefficients — §11.3). **If it fails:** a cell the blend can't widen
+into calibration without a g1 hit is signal-starved → features (§7.3) or normalization (§7.2); a
+genuine heavy tail the BLP can't reach → family (§7.6).
+
+### §7.6 Stage 6 — Research-gated escalations: family, hierarchical, per-position
+
+Entry: per-cell, when the cheaper axes are recorded-tried (§9); for NFL, when §8's escalation
+fires. **Every family / dispersion item needs a `research-analyst` brief before build (§10).**
+Each family swap is a one-field `stat_meta.json` edit + retrain behind `supersede_verdict()`.
+
+- **Continuous family ladder, escalating expressiveness.** (a) **Centered-parametrization
+  SkewNormal / skew-t** (Arellano-Valle & Azzalini 2008) — a loss-function change that removes
+  the `alpha = 0` Fisher-information singularity at the source (distinct from, complementary to,
+  the post-hoc `skew_cal` patch); try first; fixes the singularity, **not** the tails. (b)
+  **SHASH / Johnson-SU** (Jones & Pewsey 2009) — 4-parameter, separate skew and kurtosis — for
+  heavy-kurtosis cells the centered family leaves too thin. (c) **skew-t / Student-t** for the
+  heaviest tails. Tweedie / generalized-gamma for zero-mass continuous cells (NFL RB2 rush
+  yards).
+- **Count family — the structural ceiling.** Over-covering count cells that won't narrow under
+  recalibration (NegBin variance ≥ mean) need a both-directions family: **COM-Poisson** (Sellers
+  & Shmueli 2010; truncate and round-trip-test the infinite `Z(λ,ν)`), **Generalized Poisson**
+  (Harris 2012 — cheaper, no infinite normalizing constant), or **Double Poisson** (Efron 1986).
+  Run a per-cell **plain-NB vs hurdle vs ZINB vs COM-Poisson screen** on the honest val→test
+  PIT; stop defaulting ZINB on cells that aren't genuinely zero-inflated (a ZINB mixture
+  inflates variance to fit zeros a single process explains, feeding the over-coverage). Hurdle
+  already exists per-cell via `zinb_mode`. Re-entry evidence bar from the §7a pre-check
+  (refs §7): build a count family only on a cell that still kills after the cheap fixes AND
+  conditional Dunn–Smyth RQR variance < 0.70 AND a Poisson GBM tracks the top decile while NB
+  compresses.
+- **Small-sample / hierarchical layer (the NFL wall), cheapest-first.** Partial pooling
+  dominates no-pooling and complete-pooling at n ≈ 300–1000/group (Gelman & Hill 2007).
+  (a) **EB-shrink the distributional parameters** (μ, σ, ν, τ) per player toward a per-position
+  mean, cross-validated shrinkage — stays in the LightGBMLSS stack. (b) **TabPFN v2
+  head-to-head** on the small-n NFL/WNBA cells (Hollmann 2025): native full predictive
+  distribution, no per-cell tuning, sweet-spot ≤ ~10k rows; recalibrate through the existing
+  PIT gate; judge on the same honest val→test criterion; try *before* the full hierarchical
+  build. GBDTs stay the backbone (Grinsztajn 2022; McElfresh 2023). (c) **Hierarchical-Bayes**
+  (player ⊂ position ⊂ team) — escalation if (a)+(b) are insufficient. (The multi-task
+  shared-trunk NN defers to roadmap v3 §8.)
+- **Per-position model split (T11, NFL).** Train separate model per (position, market) where
+  eligible-position marginals diverge materially (rushing-yards QB-scramble ~19 vs RB-workhorse
+  ~37); selective, never wholesale — tight receiving stays pooled; min-row guard + fallback to
+  pooled+categorical. Enabled by the Stage-A1.6 position-scoping work (refs §9).
+- **Monotone priors** (`monotone_priors.json`, layered default→league→market) for NFL small-n
+  volume cells — commit only priors with mechanical meaning; a wrong-sign prior is worse than
+  none.
+- **Research-brief-flagged feature items** (the brief settles the leakage / information-boundary
+  design before any build): **C-3 line-movement & book-disagreement features**
+  (`Archive.get_movement()` / `get_ev_history()` exist, never fed to models; brief must
+  pre-register whether g1 gain may come from book echo — the X/B-frame boundary is deliberate —
+  and resolve at `target_at`, never scrape-time; depends on B-5 or a per-feature NaN exemption).
+  **B-5 missing-value semantics** (both fill sites `fillna(0)` — training matrix tail in
+  `base.py`, live fill in `model_prob.py`; exempting a curated subset (H2H, comps, movement) is
+  strictly more expressive but changes every cell's input distribution → brief + per-league
+  deterministic A/B on 2–3 cells first; both files in one PR — parity rule). **L-3
+  injuries/inactives + usage vacuum** (brief must settle report-timestamp leakage —
+  announcement time vs `target_at` — and backfill honesty). **D-4 weather** (brief-note level:
+  Open-Meteo free, NFL/MLB outdoor; train on realized, archive forecasts forward, document the
+  forecast-vs-realized serve skew; needs the M-3 stadium table). **D-5 referee/umpire** (lowest
+  priority; single-cell targets — MLB K/BB umpire zones, NBA PF crew rates — only after the
+  owning league's medium items are exhausted).
+
+### §7.7 Stage 7 — Foundation leagues (MLB / NHL)
+
+Entry: matrix/feature builds proceed **now**; training ships only post-D1 (MLB) / post-D2 (NHL)
+— gates owned by [`handoffs/mlb-nhl-activation.md`](handoffs/mlb-nhl-activation.md) (data
+freshness, book honesty, GO/NO-GO; not restated here).
+
+MLB/NHL are not "efficient cells with nothing to learn" — they are starved of inputs (raw
+`stat_types`: MLB 13, NHL 14, vs NBA 138; ~100–120 matrix columns vs ~460–480). Closing that
+input gap is this stage:
+
+1. **L-1 / D-1 — MLB statcast breadth via pybaseball (the MLB parity centerpiece, XL).** Barrel%,
+   exit velocity, xBA/xwOBA, hard-hit%, whiff%, chase%, pitcher arsenal/usage/velocity — free,
+   historical, event-dated, so point-in-time aggregates are leakage-clean by construction. New
+   ingest module patterned on the FP loader family
+   ([`nfl_fp_loader.py`](../src/sportstradamus/stats/nfl_fp_loader.py)); extend `stat_types`;
+   join through the existing `_join_fp_player_features` / `_join_fp_team_features` base hooks.
+2. **QW-3 / C-1 — MLB batting order reaches the matrix (S, after a 30-min verification).**
+   Batting order and `starting batter` are already stored per gamelog row and reach
+   `playerProfile["depth"]` — but `_join_defense_and_parks` then overwrites
+   `Player depth = Player position` for MLB. Verify what `Player position` holds, stop the
+   overwrite so batting order survives (keep a separate position flag). Document the skew:
+   training sees the realized same-day lineup, live sees announced-or-mode.
+3. **A-3 / L-2 — time-gated MLB comps (depends on L-1).** The one documented open comp leakage
+   (`TODO(comp-leakage-mlb)` in `_ensure_comps`): MLB reuses today-state Savant affinity CSVs
+   across every training gameday. Build MLB comp profiles from as-of statcast aggregates, add an
+   MLB block to `playerCompStats.json`, retire the affinity CSVs to cold-start fallback; extend
+   the comp week-gating tests.
+4. **M-9 / D-2 — NHL foundation: goalie quality + xG breadth (greenfield).** The scraping
+   already exists (dobbersports predicted goalies → `upcoming_games`, `opponent goalie` per
+   gamelog row, MoneyPuck CSVs pulled); the gap is **joining** opponent-goalie SV/GSAx features
+   into the matrix and widening skater/team `stat_types` with MoneyPuck xG aggregates. Validate
+   NHL comps (machinery + `playerCompStats.json[NHL]` exist). **Greenfield rule: start lean** —
+   there is no incumbent baseline, the first scorecard IS the baseline; do not import NFL-width
+   column counts without SHAP evidence.
+
+Anti-drift guard: foundation leagues have slow feedback (no trained cells until D1/D2) while
+refinement leagues confirm fast — hold the equal-effort budget (§0) so effort does not silently
+flow to wherever feedback is quickest.
+
+### §7.8 Stage 8 — D5 → the Ship-90 rung
+
+Entry: §0 Ship-75 targets met on a fresh scorecard (run the §2 block — never prose).
+
+Ship-90 is the same operation at a higher bar (NBA ≥ 19/21, WNBA ≥ 17/18, NFL ≥ 18/20) — the
+lever stack does not change; the remaining cells are by construction the ones that resisted the
+most axes. The session's job at this stage is the **D5 decision packet** for the owner
+(roadmap v3 §7); the owner flips the rung. The packet contains:
+
+1. **Standings + resistance map.** Per-league fresh scorecard; for every still-withheld cell,
+   the axes tried and verdicts (§9 records) — the Ship-90 queue is ordered by what is *left*
+   per cell, mostly §7.5/§7.6 structural items by then.
+2. **Gate-tightening proposal (owner-only).** Candidates: G2/G3 z-bound 0.5 → 0.3; G5 ECE
+   0.075 → 0.05. Decide tighten-early (forces some Ship-75 graduates back into queue) vs
+   tighten-late. **Before proposing any tightening, run the profit-sim** (`dashboard` pages
+   3/4/6 over resolved history): are profitable cells currently locked out that tightening
+   would lock out harder? Never tighten on aesthetics.
+3. **Live-drift readiness.** By D5 the Gate-2 soak archive should hold months of live per-cell
+   metrics (`data/live_metrics_per_market.parquet`, 7d/30d windows) — report whether
+   drift/regime detection (e.g., league-wide 3PA trends) is signal-worthy yet.
+4. **Branch-ladder question.** Ship-75 ships per-cell from research → devel via the curator. If
+   Ship-90's tightened gates need a more disciplined staging pipeline, the
+   `devel-foundation` buffer branch is the named option — owner decides.
+5. **Inference-cost check.** Per-cell calibration objects accrete (pickle keys: `temperature`,
+   `dispersion_cal`, `skew_cal`, Rung-C maps, BLP coefficients…); measure `prophecize` load
+   time before the rung adds more.
+
+Out of scope at any rung: changing the LightGBMLSS framework upstream; adding new leagues
+(MLB/NHL have their own activation lane); replacing the GBDT base learner wholesale (until the
+full §7 ladder is exhausted on every cell — not the case while zero cells are matrix-exhausted).
+
+## 8. Per-league routing
+
+Live counts: §2 block. Per-cell gate numbers and current candidates: `model_stats.csv` + the
+sweep board. What follows is the durable routing — which lever classes plausibly flip which
+cell classes — not a snapshot.
+
+### NBA — comfortable
+
+- **Calibration (§7.1) / sweep (§7.2)** on the Gate-4-only cells (snapshot examples: DREB,
+  FG3A, FGM, FTM, STL, TOV; AST shipped via the centered normalization, MIN and RA via the
+  scale fit).
+- **Rung A then Rung B (§7.1)** on the g2-bias + g4 cells (FGA, fantasy-points-prizepicks).
+- **Features (§7.3)** on PF (g1+g5 — the one genuinely hard NBA cell; also a D-5 referee
+  candidate, last).
+- Verdict: five of the seven calibration-class cells clear the target; FGA/FP/PF are backups,
+  not load-bearing.
+
+### WNBA — achievable
+
+- **Free promotes** banked (§7.0 sweep — BLK, FG3M, TOV shipped 2026-06).
+- **Calibration (§7.1) / normalization (§7.2)** on the Gate-4-only cells (snapshot: AST, BLST,
+  DREB, FTM, OREB, PTS, RA, REB, fantasy-points-prizepicks); cells the calibration axis can't
+  reach route to `centered_additive_mean10` in the sweep — current candidate status is the
+  sweep board, never an in-sample floor.
+- **Features (§7.3)** on STL (g1 edge). Small-n caveats: half NBA's games — EB-shrunk feature
+  variants preferred, affine ROE over isotonic (§11.4).
+- Verdict: six of the eight realistic calibration/normalization cells.
+
+### NFL — the binding league, with a real failure mode
+
+- **Calibration (§7.1), g1 already passes:** passing-tds, passing-yards, yards,
+  fantasy-points-underdog, sacks-taken (snapshot); receptions screened severe on the calibration
+  axis but stays live with normalization (§7.2 `ratio_projvol`) and blend (§7.5) untried.
+- **Calibration + edge — the crux:** the continuous-volume five (attempts, carries, completions,
+  receiving-yards, rushing-yards) + qb-tds fail g4 plus a *marginal* g1. Whether the §7.1 scale
+  fit pulls g1 under threshold as a side effect is **hole #4 — pre-registered in §7.0.5 with
+  its decision rule**; run it early.
+- **Escalation ladder, in order:** §7.1 scale fit → hole-#4 verdict → §7.3 features (M-1
+  primary) → §7.2 `ratio_projvol` → §7.5 blend rebuild → §7.6 per-position split / monotone
+  priors / TabPFN. Hardest cells (qb-yards, passing-first-downs multi-gate; receptions severe)
+  sit at the ladder's deep end.
+- For any cell the model can't improve: lean harder on the book in the blend — rides the sharp
+  line, ships if calibration holds. No cell is shelved (§9); never loosen a gate.
+
+### MLB / NHL — foundation, then activation
+
+Feature foundations are §7.7 and proceed now; training/shipping is gated on D1/D2
+([`handoffs/mlb-nhl-activation.md`](handoffs/mlb-nhl-activation.md)). First targets when active:
+MLB hitter volume markets (batting order), Ks later (umpire); NHL goalie SV + skater
+shots/points.
+
+## 9. Failure protocol & matrix exhaustion
+
+- **Per-lever:** every §7 stage carries a go/no-go and an if-it-fails branch. When a lever's
+  go/no-go fails on a cell, record it (lever-attempt +1, with the axis named) and take the
+  branch. Do not grind a dead lever.
+- **Per-cell:** push every cell until it ships or has actually failed across the **whole
+  matrix** — all four axes (normalization × model/loss × blend × calibration) **plus** the
+  family and hierarchical tracks. Four failed calibration/feature levers is *not* an exit: the
+  cell moves to the next axis with a one-line note naming the axes tried. The only ways off the
+  board are genuine matrix-wide exhaustion (true of **zero** cells today) or the operator's
+  explicit, documented denominator call. The heaviest tail-head rebuilds (spliced/Pareto,
+  MZINB) are deferred long-shots (roadmap v3 §8), tried only after the cheaper §7.6 moves.
+- **Operation-level: failure is not an option.** §8 shows NBA and WNBA clear on §7.0+§7.1
+  alone, with backups; NFL's escalation ladder is deep enough to reach 15, and the terminal
+  fallback (ride the book line, calibrated) ships.
+- **Never loosen a gate to hit breadth.** Gate constants are effect-size floors (vig-scale),
+  not breadth knobs. Standing rule: any search over bet-definition knobs must be
+  multiplicity-corrected before it informs a ship, and never gate on a model-conditioned
+  statistic.
+- **Grind detector:** two consecutive sessions with no acceptance criterion moving is a hard
+  stop — escalate to the owner; a cell that resists an axis moves to the next axis, never gets
+  re-ground.
+- **Park & pivot:** if blocked (e.g., NFL Gate-2 soak needs live games that won't exist until
+  September), append a §12 ledger line with the reason, set `BLOCKED (on: …)` in the status
+  line, flip the roadmap v3 §4 row, and point the owner at the swimlane index.
+
+## 10. Research holes & research-first triggers
+
+**Dispatch `research-analyst` before** (CLAUDE.md research-first; the research-gate hook
+enforces the file-level cases): any §7.6 family/distribution change; any §7.5 blend-structure
+change or training-time dispersion regularizer; §7.6 hierarchical/TabPFN escalation; the
+§7.6-flagged feature items C-3 / B-5 / L-3 (D-4 brief-note level); any hole below before
+betting the plan on it. Plain knobs (normalization slug, loss choice, ordinary features) need
+no brief. To proceed without a brief on a hook-gated edit, write a one-line justification to
+`.claude/.state/research_waiver`.
+
+**Open holes:**
+
+- **#0b — Gate-4 baseline hysteresis** (highest priority; owner call). §7.0.2 carries the
+  decision packet and the recommendation (ship the scale fit first; hysteresis only if churn
+  persists). It gates trust in the ship-incrementally premise.
+- **#4 — do the marginal NFL g1s improve when dispersion is calibrated?** Pre-registered as
+  §7.0.5 with its decision rule. The difference between NFL reaching 10 and reaching 15.
+- **#6 — the block-bootstrap / clustered-g1 backlog.** Test-set CSVs still lack `game_date` on
+  combined-stat cells, blocking the player-clustered Gate-1 recheck and a closing-line-value
+  gate. The concrete method is CPCV + a player/date embargo (López de Prado 2018) — a
+  validation refinement, not a gate change; the one principled selection-style criterion worth
+  building.
+
+**Resolved (one-liners; detail in references doc):** post-hoc scale moves PIT-KS without
+breaking g1/g5, but only under the right normalization and with a cell-specific val→test
+discount; the SkewNormal dispersion-cal exclusion was an a-priori skip, not a tested negative;
+the count branch needed the PIT-KS re-target (coverage was the wrong objective); the
+severe-coverage cells were a decode artifact + plain under-dispersion, not a new-tail-head
+problem — they ship under the centered normalization; the in-sample 2-parameter screen oversells
+the honest val→test gate (nothing ships on an in-sample floor); normalization is a first-class
+ship axis, often decisive; the variance regularizer is untried, not refuted.
+
+## 11. Validation, ship mechanics & session rules
+
+### 11.1 Always-on gates
+
+```bash
+poetry run ruff check src/sportstradamus/
+poetry run pytest tests/golden/          # incl. scorecard / gate tests
+poetry run pytest -m integration -n0     # fake-mode, no network; then:
+touch .claude/.state/integration_green
+```
+
+The determinism gate ([`test_determinism_gate.py`](../tests/integration/test_determinism_gate.py))
+must stay green; extend it to WNBA + NFL before any cross-league lever ship (§11.4.5).
+Cross-league testing policy: smoke (1–2 markets/league) before full verification; a smoke
+regression is a hard stop.
+
+### 11.2 Feature validation protocol (every §7.3/§7.4/§7.7 item)
+
+1. **Leakage test first.** Extend
+   [`test_meanyr_mean10_leakage.py`](../tests/test_meanyr_mean10_leakage.py): temporal features
+   assert strict `<` date visibility; as-of/external features assert the training value is
+   reconstructable from data observable at `game_time − TRAINING_LOOKBACK`.
+2. **Train/live parity test per batch** (the §7.0.4 harness). Paired surfaces change in one PR —
+   the two fill sites, any new context column's historical + upcoming branches.
+3. **Regen + deterministic A/B.** Two verified `pipeline.py` facts force the ordering:
+   `--deterministic` **never rebuilds the matrix** (cache-only load; parquet write skipped), and
+   a **plain `meditate` publishes production artifacts** (only `--deterministic` redirects to
+   the sandbox). So a new feature is invisible until the cache parquet is rebuilt, and the
+   rebuild must never go through a plain run mid-experiment. Recipe per cell: (i) preserve
+   baselines *before* the code change — copy the cache parquet aside, run a baseline
+   deterministic train; (ii) land the feature edit, training + live mirror together; (iii)
+   rebuild the cache **directly** — delete the parquet, call `get_training_matrix` +
+   `trim_matrix` and write it yourself (worked example below); (iv) run the candidate
+   deterministic train with flags identical to the baseline; (v) compare the two sandbox CSVs
+   with the scorecard CLI (writes a sandbox scorecard CSV, never `model_stats.parquet`).
+4. **Inert-revert rule:** SHAP importance < 0.001 ⇒ inert ⇒ revert. Never carry dead columns.
+5. **Ship path.** Deterministic A/B improvement ⇒ full-HPO `meditate` ⇒ official 5-gate
+   scorecard; incumbents additionally need `supersede_verdict()`. Never ship on in-sample
+   screens.
+6. **Batching.** One regen per league per batch, never one feature at a time (regen costs hours
+   per league board). Quality gates before any push.
+7. **Cache-append inertness (highest structural risk).** New columns are NaN over cached rows →
+   pruned → silently inert. Control: mandatory per-cell parquet delete + full regen per batch;
+   golden test that a sentinel new column survives `_prune_uninformative_features` after regen.
+   Verify regen feasibility per league first (the 850-day window must be resolvable from the
+   archive — §2 archive block) before deleting any cache.
+
+**Worked example — QW-1 on NFL `carries`, end-to-end.** Read the cell's `target_normalization`
+from `stat_meta.json` (`carries` → `ratio_meanyr`) and pass it explicitly so baseline and
+candidate match production config — identical flags on both runs; withheld cells need
+`--bypass-withholding` or they are silently skipped:
+
+```bash
+# 0. baseline insurance + baseline deterministic run (BEFORE any code change)
+cp src/sportstradamus/data/training_data/NFL_carries.parquet /tmp/NFL_carries.cache.bak
+poetry run meditate --league NFL --market carries --deterministic \
+    --bypass-withholding --target-normalization ratio_meanyr
+cp src/sportstradamus/data/test_sets/deterministic/ratio_meanyr/NFL_carries.csv \
+    /tmp/NFL_carries.baseline.csv
+
+# 1. implement the feature in BOTH paths (historical + upcoming branches),
+#    extend the leakage test, run quality gates.
+
+# 2. rebuild the cache with the new columns (direct — NOT via plain meditate)
+rm src/sportstradamus/data/training_data/NFL_carries.parquet
+poetry run python - <<'EOF'
+from sportstradamus.stats import StatsNFL
+from sportstradamus.training.data import trim_matrix
+s = StatsNFL(); s.load(); s.update()   # update(): gamelog must be current
+M = trim_matrix(s.get_training_matrix("carries"), 15000)
+M.to_parquet("src/sportstradamus/data/training_data/NFL_carries.parquet",
+             compression="zstd", index=True)
+EOF
+
+# 3. candidate deterministic run (identical flags) + scorecard comparison
+poetry run meditate --league NFL --market carries --deterministic \
+    --bypass-withholding --target-normalization ratio_meanyr
+poetry run python -m sportstradamus.training.scorecard \
+    --baseline /tmp/NFL_carries.baseline.csv \
+    --candidate src/sportstradamus/data/test_sets/deterministic/ratio_meanyr/NFL_carries.csv
+
+# 4. decide: gate-row improvement => real-HPO confirm (11.2 step 5);
+#    SHAP < 0.001 or regression => restore /tmp/NFL_carries.cache.bak, revert edit.
+```
+
+Executor notes: the deterministic CSV subdir is the normalization slug
+(`{target_normalization}{_hurdle?}`); the parquet snippet mirrors what
+`_step_persist_matrix_and_comps` writes (same `trim_matrix(…, 15000)`, same compression);
+`update()` requires league-API access — run after the daily jobs or accept a slightly stale
+gamelog on both sides (fine: the A/B only needs both sides identical).
+
+### 11.3 Inference-path compatibility checklist (per change type)
+
+Every change lands its inference-side mirror **in the same PR, before promotion**. Gate 1 lets a
+change into the test window; this checklist makes the window safe.
+
+| Change type | Inference-side work | Precedent |
+|---|---|---|
+| Training-only (loss change, monotone constraint, per-parameter Optuna, reweighting) | None — output schema unchanged | Stage B1 ZTNB attempt |
+| New target / baseline strategy | Inverse decode in `model_prob._decode_skewnormal` via `baselines.STRATEGY_REGISTRY[strategy].decode_loc/decode_scale`; matching `*_Ratio` feature in `get_stats`; `target_strategy` + `offset_meta` keys round-trip | P1 `centered_additive_*` |
+| New distribution head (SHASH, CMP, MZINB, PGBM, MEGB, gbex) | (a) decode block in `model_prob.py`; (b) `get_ev` / `get_odds` / `fused_loc` / `set_model_start_values` accept the new `dist`; (c) `dist` in `_build_filedict` + legacy fallback; (d) live-path test mirroring [`test_zinb_hurdle_live_path.py`](../tests/integration/test_zinb_hurdle_live_path.py) | P2.B HurdleZINB |
+| Post-hoc calibration object (Rung-C map, CQR, `bias_correction`) | Pickle as a new key; load in `model_prob`, apply after decode (before/after `fused_loc` per what's calibrated); byte-identical round-trip test | `temperature` field |
+| New player-level feature | Column in BOTH `get_training_matrix` and `get_stats`, computed identically, leakage-safe; same dtype/index; `feature_filter.json` registration | `MeanYr` / `Mean10` / `*_Ratio` |
+| Multi-head factorization | N pickles/market, Monte-Carlo combine, multi-output blend — **largest inference-side change in plan**; T5 is killed, so only relevant if a future factorization survives a brief | none in-repo |
+| Different model class (CatBoost, MEGB, GPBoost, TabPFN) | New `is_*` flag; `model_prob` + `prediction/__init__.py` load-path branch; determinism gate extended; adapt if no LSS `predict(pred_type="parameters")` API | P2.B `is_hurdle` |
+
+**Hard ship gate:** any change requiring inference-side work must have a passing live-path
+integration test under `tests/integration/` before promotion.
+
+**Pickle-schema discipline:** every new field needs (1) a reader site in `model_prob.py`, (2) a
+legacy default fallback (`filedict.get("new_key", default)`), (3) a round-trip test asserting
+byte-identical predictions. Fields written by `_build_filedict` as of the consolidation:
+`model`, `step`, `stats`, `metrics`, `diagnostics`, `params`, `distribution`, `cv`, `std`,
+`temperature`, `dispersion_cal`, `weight`, `r_book`, `hist_gate`, `shape_ceiling`, `normalized`,
+`offset_meta`, `target_strategy`, `zinb_mode`, `is_hurdle`, `expected_columns` — verify against
+the code before relying on the list.
+
+### 11.4 Cross-league caveats (read before any cross-league A/B)
+
+1. NFL sample sizes are an order of magnitude smaller than NBA (~17 vs ~82
+   games/player/season); re-derive EB shrinkage `K = σ²_within / σ²_between` per league.
+2. NFL stats are position-locked (`Player position` categorical; per-position scoping shipped) —
+   cross-player models per market may not transfer.
+3. WNBA shares NBA's structure at half the games/season; verify EB K. WNBA has no `FGM` or
+   `FG3A` markets.
+4. The scorecard harness is league-agnostic; file paths are league-specific
+   (`data/training_data/{LEAGUE}_{market}.parquet`,
+   `data/test_sets/deterministic/{strategy}/{LEAGUE}_{market}.csv`).
+5. The determinism gate covers NBA only (NBA_FGA + NBA_FG3M) — add parallel WNBA + NFL
+   assertions before any cross-league change, else the verdict is noise.
+6. Low-mean NFL markets (interceptions ~0.5): asymptotic Vuong degrades badly; trust only
+   Wilson-Einbeck's non-asymptotic zero-inflation test.
+7. Track-parallelism across leagues is fine; the shared resource is the read-only scorecard
+   harness.
+8. Low-mean conditional-dispersion diagnostics need the Dunn–Smyth RQR, not Pearson, at mean
+   ≲ 0.11 (they diverge badly there); bootstrap the RQR variance.
+9. Post-hoc bias correctors at NFL count means must be affine ROE, not isotonic/per-decile
+   (low-base-rate overfit, ref [48]); reserve isotonic for higher-mean NBA/WNBA count cells.
+
+### 11.5 Ship & session mechanics
+
+- **Ship to devel = one-line `stat_meta.json` edit** (`shipped: "withheld" → "devel"`) the human
+  commits; `generate-ship-config --branch devel` validates + summarizes. Promotion to `main` is
+  the monthly `gate-status` cron's PR. Never train or ship on `main`; production tracks `devel`.
+- **Never push `devel` directly** — the `devel-ship-curator` agent carves every devel-bound ship
+  PR and enforces the dev-only denylist (`zinb-routing-diagnostics`, `icc-diagnostics`,
+  statsmodels, /tmp harnesses never ship). Confirm its denylist covers any new research
+  scaffolding.
+- **`refactoring-specialist`** runs on every touched Python file before any push / PR / review
+  (CLAUDE.md hard rule, five triggers).
+- **Module footprint:** `sportstradamus.training` (pipeline, scorecard, report, calibration,
+  strategy driver), `sportstradamus.stats` (feature columns), `data/config/{stat_meta.json,
+  ship_config.json}`, `tests/golden/`. Prediction-side edits only via §11.3.
+- **Stop and ask the owner:** gate-constant or test-tolerance changes (always); smoke
+  regression; gates red at session start through no fault of yours; anything touching cron,
+  credentials, or paid APIs; the §9 grind detector.
+- **Session definition of done:** refactoring-specialist ran on every touched `.py`; the three
+  §11.1 gates clean; one §12 ledger line appended; status line updated on stage boundaries;
+  durable non-obvious lesson → offer a memory capture.
+
+## 12. Doc map & ledger
+
+| Fact | Canonical home |
+|---|---|
+| Gate thresholds g1–g5, Gate-2, S1–S3, tighten/loosen | [`ship_gate.md`](ship_gate.md) |
+| Release surface per cell | `stat_meta.json` `shipped` (git carries flip history) |
+| Per-cell gate numbers | `data/training/model_stats.csv` (mirror of the parquet) |
+| Lever stack, stages, per-league routing, session rules | **this doc** |
+| Research verdicts, citations [1]–[71], commit refs | [`operation_ship_references.md`](operation_ship_references.md) |
+| Program index, other lanes, decision gates D1–D7, deferred register | [`sportstradamus_roadmap_v3.md`](sportstradamus_roadmap_v3.md) |
+| Ship mechanics how-to, package map | `CONTRIBUTING.md` |
+| Session law (gates, subagents, hard rules) | `CLAUDE.md` |
+
+### Ledger (append-only, newest first, cap ~15)
+
+- 2026-06-12 · consolidation · doc created from operation_ship_75 + operation_ship_90 +
+  feature_improvement_plan + model-track brief, with the model-research operating-loop
+  refinements folded in · next: §7.0 Stage 0 (free-passer sweep, hole-#0b packet, parity
+  harness, hole-#4 pre-registration)
+- 2026-06-10 · created (as handoffs/model-track.md) · brief drafted from roadmap-v3 migration ·
+  next: free-passer re-score sweep
+
+### Changelog
+
+- 2026-06-12 consolidated four docs into one ordered progression; MR loop deltas folded in.

--- a/docs/operation_ship_references.md
+++ b/docs/operation_ship_references.md
@@ -1,13 +1,15 @@
-# Operation Ship 75 — References
+# Model Improvement Track — References
 
-> **Preserves the load-bearing facts from the deprecated
+> **The evidence appendix for [`model_improvement_track.md`](model_improvement_track.md):**
+> research verdicts (P0–A1.6), branch/commit refs, the critical-files map, and citations
+> [1]–[71]. Preserves the load-bearing facts from the deprecated
 > [`gbdt_mean_regression_plan.md`](archive/gbdt_mean_regression_plan.md) /
-> [`gbdt_mean_regression_context.md`](archive/gbdt_mean_regression_context.md)**
-> so future sessions don't lose context after the new plan
-> ([`operation_ship_75.md`](operation_ship_75.md)) supersedes them. Full
+> [`gbdt_mean_regression_context.md`](archive/gbdt_mean_regression_context.md); full
 > prose for any item below lives in the archived docs at the line
 > citations. Research briefs cited as `/tmp/researcher_*.md` are
-> distilled here; their full bodies are not preserved (scratch).
+> distilled here; their full bodies are not preserved (scratch). The
+> *operational* checklists that used to live here (§12 inference-path,
+> §13 cross-league caveats) moved to the consolidated doc — pointers remain.
 
 ## Table of contents
 
@@ -341,11 +343,12 @@ primary build (deferred behind 75% breadth).
   [`scripts/prune_nfl_matrix_positions.py`](../src/sportstradamus/scripts/prune_nfl_matrix_positions.py):
   passing-yards 15000 → 2646 rows, mean 38.1 → 215.9.
 - New Stage A4 entry **T11**: per-position model-split bias experiment
-  (deferred to Ship 90 — see [`operation_ship_90.md`](operation_ship_90.md)).
+  (originally deferred to Ship 90; now a live lever —
+  [`model_improvement_track.md`](model_improvement_track.md) §7.6).
 
 ## 10. Branch / PR / commit refs
 
-- **Active branch (Operation Ship 75):** `model-research`.
+- **Active branch (model improvement track):** `model-research`.
 - **Prior PR:** #46 → `devel`; HEAD before Ship 75 rework `fbec3cc`.
 - **Earlier breadth-led docs rework HEAD:** `6e913b1`.
 - **Latest shipped via old plan:** 13 NBA + 10 WNBA + 13 NFL baselines
@@ -355,8 +358,8 @@ primary build (deferred behind 75% breadth).
   spec (absolute bias + BSS ≥ 0). Under the new five-gate scorecard
   ([`training/scorecard.py`](../src/sportstradamus/training/scorecard.py),
   adds G4 IQR ratio and G5 ECE), some of these no longer ship. See
-  Step 0 audit in
-  [`operation_ship_75.md`](operation_ship_75.md).
+  the gate-audit table in
+  [`model_improvement_track.md`](model_improvement_track.md) §4.1.
 
 ## 11. Critical files map
 
@@ -379,87 +382,16 @@ last-verified against `fbec3cc` (HEAD before Ship 75 rework):
 
 ## 12. Per-change-type inference-path checklist
 
-Every change must land its inference-side mirror in the same PR before
-promotion. Gate 1 lets a change into the test window; this checklist is
-what makes that window safe. Copy from the deprecated plan §Inference
-path:
-
-| Change type | Inference-side work | Precedent |
-|---|---|---|
-| **Training-only** (loss change, monotone constraint, ZTNB likelihood, per-parameter Optuna, sample reweighting) | None. Output schema unchanged. | Stage B1 ZTNB attempt: only loss changed. |
-| **New target / baseline strategy** | Inverse decode in `model_prob.py` `_decode_skewnormal` via `baselines.STRATEGY_REGISTRY[strategy].decode_loc/decode_scale`; matching `*_Ratio` feature in `get_stats`; `target_strategy` + `offset_meta` keys round-trip. | P1 `centered_additive_*`. |
-| **New distribution head** (T3 spliced/Pareto, MZINB, CMPμ, PGBM, MEGB, gbex) | (a) new decode block in [`model_prob.py:259-272`](../src/sportstradamus/prediction/model_prob.py); (b) `get_ev` / `get_odds` / `fused_loc` / `set_model_start_values` accept the new `dist`; (c) `dist` in `_build_filedict` + legacy fallback; (d) new live-path test mirroring [`test_zinb_hurdle_live_path.py`](../tests/integration/test_zinb_hurdle_live_path.py). | P2.B HurdleZINB. |
-| **Post-hoc calibration object** (isotonic on loc, CQR/LCMQR, **`bias_correction` from Ship 75 Step 1**) | Pickle as a new key (`isotonic` / `cqr` / `temperature` / `bias_correction` precedent); load in `model_prob`, apply after decode (before/after `fused_loc` per what's calibrated); byte-identical round-trip test. | `temperature` field in `_build_filedict`. |
-| **New player-level feature** (Ship 75 Step 2 expanding-mean, Step 3 opponent-defense) | Column in BOTH `get_training_matrix` and `get_stats`, computed identically, leakage-safe; same dtype/index; add to `feature_filter.json` whitelist. | `MeanYr` / `Mean10` / `*_Ratio` (`base.py:676-702`), `test_meanyr_mean10_leakage.py`. |
-| **Multi-head factorization** (T5, deferred) | `prophecize` loads N pickles/market; `model_prob` Monte Carlos; `fused_loc` multi-output blend; new `factor_pickles: dict[str, Path]` on parent pickle; new live-path test. **Largest inference-side change in plan.** | None in-repo. |
-| **Different model class** (CatBoost ordered TS, MEGB, GPBoost) | New `is_catboost`/`is_gpboost` flag; `model_prob` + `prediction/__init__.py` load path branch; determinism gate extended; adapt if no LSS `predict(pred_type="parameters")` API. | P2.B `is_hurdle`. |
-
-**Hard ship gate:** any change requiring inference-side work must have
-a passing live-path integration test under `tests/integration/`
-**before promotion to production**.
-
-**Pickle-schema discipline:** every new field needs (1) reader site in
-`model_prob.py`, (2) legacy default fallback
-(`filedict.get("new_key", default)`), (3) round-trip test asserting
-byte-identical predictions. Current fields written by
-`_build_filedict`: `model`, `step`, `stats`, `metrics`, `diagnostics`,
-`params`, `distribution`, `cv`, `std`, `temperature`, `dispersion_cal`,
-`weight`, `r_book`, `hist_gate`, `shape_ceiling`, `normalized`,
-`offset_meta`, `target_strategy`, `zinb_mode`, `is_hurdle`,
-`expected_columns`. Ship 75 adds: `bias_correction`.
+Moved — the checklist is operational, not historical. Canonical home:
+[`model_improvement_track.md`](model_improvement_track.md) §11.3 (table, the
+hard ship gate, and the pickle-schema discipline).
 
 ## 13. Cross-league caveats
 
-Copy from the deprecated plan §Cross-league caveats. Read before
-running any cross-league A/B:
-
-1. **NFL sample sizes are an order of magnitude smaller than NBA**
-   (~17 vs ~82 games/player/season). EB(MeanYr, K=10) is aggressive
-   shrinkage at that size — re-derive `K = σ²_within / σ²_between`
-   per league. NFL K may be much lower (or EB transform may fail on
-   form-volatile NFL markets).
-2. **NFL stats are position-locked.** `Player position` is already a
-   categorical (`pipeline.py:_step_build_splits`). Cross-player models
-   per market may not transfer cleanly (QB vs WR don't share "passing
-   yards"); per-position scoping shipped in Stage A1.6 for NFL.
-3. **WNBA shares NBA's structure but has half the games / season.**
-   EB K=10 probably fine but verify. The per-100-poss factorization
-   (T5-basketball) is KILLED so the transfer point is moot. WNBA has
-   no `FGM` or `FG3A` markets (confirmed against the `stat_dist`
-   config view of `stat_meta.json`);
-   `FTM_per_FGA` + `FG3M_per_FGA` are the available efficiency
-   factors for ICC diagnostics.
-4. **The scorecard A/B harness is league-agnostic but file
-   paths are league-specific.** Cached parquets at
-   `data/training_data/{LEAGUE}_{market}.parquet`; deterministic test
-   sets at `data/test_sets/deterministic/{strategy}/{LEAGUE}_{market}.csv`.
-5. **Determinism gate currently covers NBA only.** Two
-   `test_deterministic_mode_*` tests use NBA_FGA + NBA_FG3M
-   ([`tests/integration/test_determinism_gate.py:37,102`](../tests/integration/test_determinism_gate.py)).
-   Before a cross-league change, add parallel assertions on WNBA_FGA
-   + WNBA_FG3M + a representative NFL market — else the cross-league
-   verdict is noise.
-6. **For low-mean NFL markets** (interceptions ~0.5, sacks ~1.5),
-   the ZINB diagnostic formulae may need to compute on `log(1+Y)`
-   [22]; the asymptotic Vuong degrades badly at very low means.
-   Wilson-Einbeck's non-asymptotic test should be the only one trusted
-   for NFL interceptions / sacks.
-7. **Two-track parallelism holds across leagues.** Track A and B
-   touch different distribution branches and markets; workable in
-   parallel per league. Shared resource is the read-only
-   `scorecard` harness.
-8. **Low-mean conditional-dispersion diagnostics need a non-Pearson
-   estimator — trust the Dunn–Smyth RQR over Pearson at mean ≲ 0.11.**
-   In B1.5 the df-corrected Pearson and RQR variance diverged at very
-   low NFL means (rushing-tds: Pearson 0.57 vs RQR 0.96; interceptions:
-   Pearson 1.38 vs RQR 1.04). A future low-mean NFL pass should
-   bootstrap the RQR variance and/or use deviance-based dispersion.
-9. **Post-hoc bias correctors at NFL count means must be affine ROE,
-   not isotonic / per-decile.** At interceptions ~0.5 and TD zero-rates
-   0.78–0.92, isotonic tails and per-bin (multicalibration) correctors
-   overfit; percent-calibration error is worst in low-base-rate groups
-   [48]. Reserve isotonic / per-decile for the higher-mean NBA / WNBA
-   count cells.
+Moved — canonical home: [`model_improvement_track.md`](model_improvement_track.md)
+§11.4. The B1.5 numeric evidence behind its caveat 8 (Pearson-vs-RQR divergence at
+very low NFL means: rushing-tds Pearson 0.57 vs RQR 0.96; interceptions 1.38 vs
+1.04) stays preserved here.
 
 ## 14. References
 
@@ -503,7 +435,7 @@ Renumbered from the deprecated context doc.
 [47] Efron, B., Morris, C. (1973). Stein's estimation rule and its competitors — James-Stein / empirical-Bayes shrinkage.
 [48] Roelofs, R., et al. (2022). Mitigating bias in calibration error estimation — low-base-rate sensitivity.
 
-*Added by the full-distribution audit (marginal-breadth levers folded into [`operation_ship_75.md`](operation_ship_75.md) §5):*
+*Added by the full-distribution audit (marginal-breadth levers folded into [`model_improvement_track.md`](model_improvement_track.md) §5–§7):*
 
 [49] Czado, C., Gneiting, T., Held, L. (2009). Predictive model assessment for count data. *Biometrics* 65(4), 1254–1261.
 [50] Hallin, M., Ley, C. (2014). Skew-symmetric distributions and Fisher information — the double sin of the skew-normal. *Bernoulli* 20(3), 1432–1462. *(arXiv:1209.4177)*

--- a/docs/pipeline_diagrams.md
+++ b/docs/pipeline_diagrams.md
@@ -3,7 +3,7 @@
 High-level flowcharts for the training and inference pipelines. The authoritative
 narrative is [CONTRIBUTING.md](../CONTRIBUTING.md) §Data Flow and §Modifying the
 Training Pipeline; the offline ship-gate detail is in
-[docs/operation_ship_75.md](operation_ship_75.md) and
+[docs/model_improvement_track.md](model_improvement_track.md) and
 [docs/ship_gate.md](ship_gate.md).
 
 ## Training Pipeline (`meditate` → `training/pipeline.py:train_market`)
@@ -15,7 +15,7 @@ flowchart TD
     C --> D["SkewNormal: normalize target by mean<br/>count families train on raw counts"]
     D --> E["hyperparams.warm_start_hyper_opt<br/>Optuna search, seeded from prior best"]
     E --> F["LightGBMLSS.fit<br/>per-row distribution parameters"]
-    F --> G["dispersion calibration<br/>minimize_scalar(CRPS) on validation<br/>(count families; SkewNormal scale tracked in operation_ship_75 §5 L1)"]
+    F --> G["dispersion calibration on validation<br/>count: minimize_scalar(CRPS) · SkewNormal: joint (c, skew) vs PIT-KS<br/>(ladder: model_improvement_track §7.1)"]
     G --> H["temperature scaling<br/>fit T on validation Brier"]
     H --> I["diagnostics baked into the model pickle"]
     I --> J["save pickle<br/>data/models/{LEAGUE}_{market}.pkl"]

--- a/docs/ship_gate.md
+++ b/docs/ship_gate.md
@@ -16,8 +16,9 @@ ground truth:
 - **Shipped count (the numerator):** the `shipped` field in
   [`stat_meta.json`](../src/sportstradamus/data/config/stat_meta.json) —
   `"devel"` / `"main"` ship; `"withheld"` does not.
-- **Standings + the push to 75%:** [`operation_ship_75.md`](operation_ship_75.md)
-  §"Current standings".
+- **The track that ships against these gates:**
+  [`model_improvement_track.md`](model_improvement_track.md) (standings are
+  never prose — its §2 ground-truth commands).
 - **Per-cell gate pass/fail:** a fresh `python -m sportstradamus.training.scorecard`
   sweep (`model_stats.parquet` can lag a gate redefinition).
 

--- a/docs/sportstradamus_roadmap_v3.md
+++ b/docs/sportstradamus_roadmap_v3.md
@@ -12,11 +12,11 @@ lever detail, stage detail, or per-cell anything — those have canonical homes
 
 A full toolset to profit on DFS pick'em apps — **Underdog and Sleeper** — by
 handing their parlay builders better-calibrated probabilities than the apps'
-implied prices (the lens of [`operation_ship_75.md`](operation_ship_75.md)
-§Purpose: beat the apps, blend with the sharp books, calibration is the
-product). Model correctness leads; draft products (Best Ball) target the 2027
-season. Non-normative background vision:
-[`underdog_edge_suite.md`](underdog_edge_suite.md).
+implied prices (the lens of
+[`model_improvement_track.md`](model_improvement_track.md) §1: beat the apps,
+blend with the sharp books, calibration is the product). Model correctness
+leads; draft products (Best Ball) target the 2027 season. Non-normative
+background vision: [`underdog_edge_suite.md`](underdog_edge_suite.md).
 
 ## 2. Ground truth — run, don't read
 
@@ -35,7 +35,7 @@ git fetch origin && git log --oneline origin/devel -5
 ```
 
 Breadth targets are stable: NBA ≥ 16/21 · WNBA ≥ 14/18 · NFL ≥ 15/20
-([`operation_ship_75.md`](operation_ship_75.md) §North Star). MLB and NHL have
+([`model_improvement_track.md`](model_improvement_track.md) §0). MLB and NHL have
 cells in `stat_meta.json` but no breadth target until their gates (D1/D2) decide.
 
 ## 3. Foundations already shipped
@@ -68,7 +68,7 @@ an exception. A session works one lane and reads that lane's brief.
 
 | Lane | Mission | Status | Entry gate | Brief |
 |---|---|---|---|---|
-| `model-track` | Ship-75 breadth → Ship-90; the lead lane | ACTIVE | — | [handoffs/model-track.md](handoffs/model-track.md) |
+| `model-track` | Ship-75 breadth → Ship-90; the lead lane | ACTIVE | — | [model_improvement_track.md](model_improvement_track.md) |
 | `sim-bettor-ledger` | Pre-registered paper-trading ledger + circuit breakers | QUEUED | D6 policy sign-off | [handoffs/sim-bettor-ledger.md](handoffs/sim-bettor-ledger.md) |
 | `sleeper-parity` | Full Sleeper decision-layer parity | QUEUED | stage-0 product verification | [handoffs/sleeper-parity.md](handoffs/sleeper-parity.md) |
 | `parlay-dependence` | Copula on PIT residuals — biggest product-EV lever | BLOCKED (on: D3) | D3 | [handoffs/parlay-dependence.md](handoffs/parlay-dependence.md) |
@@ -102,8 +102,8 @@ Everything not listed here is pivot-free.
 
 Setbacks are expected: methods fail, apps change their products, plans change.
 Three failure classes, each with a standing response — failure is per-lever,
-never per-operation (ship_75 §North Star: every lane carries more levers than
-it has cells to flip).
+never per-operation (model_improvement_track.md §0: every lane carries more
+levers than it has cells to flip).
 
 - **Method fails** (a lever doesn't move its metric): record the verdict +
   evidence pointer in the brief's ledger, take the stage's if-it-fails branch
@@ -128,7 +128,7 @@ flip a gate.
 | D2 | NHL activation go/no-go | stage-0 NHL packet | ~Sep 2026, before puck drop |
 | D3 | Start `parlay-dependence` | ≥2 leagues at target + Opus research brief + sleeper-parity merged | when inputs exist |
 | D4 | Start `bestball-2027` | calendar ≥ ~Nov 2026 + model-track health | before 2027 drafts open |
-| D5 | Declare Ship-90 | Ship-75 targets met; [`operation_ship_90.md`](operation_ship_90.md) open questions | at 75% breadth |
+| D5 | Declare Ship-90 | Ship-75 targets met; [`model_improvement_track.md`](model_improvement_track.md) §7.8 decision packet | at 75% breadth |
 | D6 | Ledger policy spec v1 sign-off | `sim-bettor-ledger` stage-0 spec | unblocks the lane |
 | D7 | Real-stake scaling | ledger CLV/ROI over a meaningful sample | outside repo scope; named so the ledger has a customer |
 
@@ -148,7 +148,8 @@ sketches live in the archived v2.
   `sim-bettor-ledger`; do not resurrect (archived v2 §2.2/2.3).
 - **Model speculative tail** — conformal ladder + CQR, CLV-CRPS dashboard,
   TabPFN-as-platform, multi-task NN, spliced/Pareto tails, MZINB — deferred
-  behind breadth; pointers in ship_75 §5.6/§5.9 and archived v2 §Phase 6.
+  behind breadth; pointers in model_improvement_track.md §7.6/§9 and archived
+  v2 §Phase 6.
 - **Streamlit → FastAPI rewrite** — only if real-time push ever becomes the
   product (archived v2 §Suggestions).
 - **Idea backlog** — archived v2 §Suggestions for Further Improvement.
@@ -159,9 +160,9 @@ sketches live in the archived v2.
 |---|---|
 | Shipped counts / release surface | `src/sportstradamus/data/config/stat_meta.json` (`shipped`) |
 | Gate thresholds g1–g5, Gate 2 | [`ship_gate.md`](ship_gate.md) |
-| Model lever stack, per-league path, stop rules | [`operation_ship_75.md`](operation_ship_75.md) §5–§7 |
+| Model lever stack, per-league path, stop rules | [`model_improvement_track.md`](model_improvement_track.md) §5–§9 |
 | Per-cell gate numbers | `data/training/model_stats.csv` (mirror of the parquet) |
-| Lane procedure, locked decisions, status | `docs/handoffs/{lane}.md` |
+| Lane procedure, locked decisions, status | `docs/handoffs/{lane}.md` (model track: [`model_improvement_track.md`](model_improvement_track.md)) |
 | Package map, ship mechanics, league/market how-to | `CONTRIBUTING.md` |
 | Session law (gates, subagents, hard rules) | `CLAUDE.md` |
 | Code style | `docs/STYLE_GUIDE.md` |
@@ -169,4 +170,5 @@ sketches live in the archived v2.
 
 ## Changelog
 
+- model-track lane consolidated: ship75/ship90/feature-plan/brief merged into `model_improvement_track.md`; lane row + doc map repointed.
 - v3 replaces v2: swimlane structure, briefs in `docs/handoffs/`, change-absorption protocol, Sleeper parity + ledger + league-activation lanes added.


### PR DESCRIPTION
## What this is

The model improvement track lived across six documents (`operation_ship_75.md`, `operation_ship_90.md`, `operation_ship_references.md`, `feature_improvement_plan.md`, `sportstradamus_roadmap_v3.md`, `handoffs/model-track.md`). A session had to bounce between all of them. This PR merges the track into **one ordered, executor-grade progression**: [`docs/model_improvement_track.md`](../blob/claude/intelligent-ramanujan-37u1mt/docs/model_improvement_track.md) — written so a Sonnet-class session can follow it without error (exact commands, decision rules, acceptance criteria, if-it-fails branches, per-stage research-gate flags).

## Consolidation map

| Old home | New home |
|---|---|
| ship75 §Purpose / §North Star | §1 lens / §0 mission + targets |
| ship75 §1a–1d, §2–§4 (audits, archive repair, diagnosis, lever verdicts) | §4 state of the board |
| ship75 §5 intro + operating loop | §5 axes & search, §6 operating loop |
| ship75 §5.1–§5.9 lever stack + feature plan workstreams A–E / §12 roadmap | §7 stage ladder (Stages 0–8, ordered cheapest-first) |
| ship75 §6 per-league + feature plan §10 | §8 per-league routing |
| ship75 §7 + §5.9 + brief §8 | §9 failure protocol & matrix exhaustion |
| ship75 §8 + feature plan §11.7 | §10 research holes & research-first triggers |
| feature plan §11 (validation + worked example) + ship75 §9 + **references §12/§13 (moved)** + brief §5–§9 | §11 validation, ship & session mechanics |
| ship90 stub | §7.8 D5 → Ship-90 decision-packet stage |

Archived with supersession banners (roadmap-v2 precedent): `docs/archive/{operation_ship_75, operation_ship_90, feature_improvement_plan, model-track-brief}.md`. Kept canonical: `ship_gate.md` (thresholds), `operation_ship_references.md` (now a pure evidence + citations appendix), roadmap v3 (program index — lane row + doc map repointed). Every live cross-reference retargeted: CLAUDE.md research-first bullet, ship_gate, pipeline_diagrams, 6 lane briefs + template, 3 agent definitions.

## Improvements baked in (per your "bake everything in" call)

1. **Single ordered stage ladder** — the levers and the feature roadmap are one queue now, cheapest-first, ship-per-cell-as-you-go.
2. **model-research operating-loop hardening folded into the canonical doc** (§6): production-reproducible corners (`--dist-training-loss` does not persist in `stat_meta.json`), set `target_normalization`/`posthoc`/`blending` in stat_meta **before** the full-HPO confirm (`_resolve_decode_strategy` reads stat_meta, not the flag), walk the top-K incl. near-misses (`min_gate_slack ≥ −0.03`; NBA DREB precedent).
3. **Branch asymmetry explicit** (§5): the strategy driver exists only on `model-research`; devel fallback documented; **Stage-0 task to port it to devel**.
4. **Hole #4 pre-registered early** (§7.0.5): paired Brier-CI on the 5 NFL g1+g4 volume cells before/after a §7.1 scale fit, with a registered decision rule that reorders the NFL queue.
5. **Hole #0b decision packet** (§7.0.2) with recommendation: ship the scale fit first, re-score, accept genuine demotions; hysteresis only if churn persists.
6. **Parity harness promoted** to an explicit Stage-0 deliverable that blocks all feature work (was buried prose in feature plan §11.2).
7. **Ship-90 stub rewritten** as the D5 decision-packet spec (§7.8); stale `deferred-90` / excluded-markets / "Steps 0–4" language reconciled with the standing no-defer policy.
8. **Stale facts corrected in place**: WNBA BLK/FG3M/TOV free-passers already shipped; NBA AST ships under `centered_additive_mean10`; the 40-cell census is labeled a dated evidence snapshot with the regenerate command.
9. **Free-passer re-score made a standing monthly task** (§7.0.1), suggested to pair with the `gate-status` cron run (doc directs; no cron edit here).
10. **References §12/§13 relocated** into the working doc (§11.3/§11.4); pointers remain at the old anchors.
11. **One canonical conflict order** stated once (§0).

## Verification

- `poetry run ruff check src/sportstradamus/` — clean.
- `poetry run pytest tests/golden/` — 465 passed, 16 skipped (after staging the CI fixture stubs per `.github/workflows/ci.yml` — fresh container lacks gitignored `creds/keys.json` + config JSONs).
- `poetry run pytest -m integration -n0` — 2 passed, 12 skipped (data-dependent tests skip in a fresh container), 0 failed.
- Link sweep: no live reference to the four archived docs remains outside `docs/archive/`, `docs/superpowers/` (historical plans), and the intentional historical mentions in STYLE_GUIDE §16.1 / `docs-style.py`. Python comments naming "Operation Ship 75" were left untouched (operation name, not a doc path; no `.py` touched in this PR).

A sibling PR applies the same consolidation to `model-research` and converges that branch's doc ecosystem (roadmap v3 + handoffs were absent there).

Pre-consolidation text recoverable via `git show 805cea7:docs/operation_ship_75.md` etc.

https://claude.ai/code/session_01ANzMpZkmxQ6r6BnYZBtfhq

---
_Generated by [Claude Code](https://claude.ai/code/session_01ANzMpZkmxQ6r6BnYZBtfhq)_