### PR TITLE
ship(stat_meta): §6.2 strategy-board confirms — +3 net-new (NBA FG3A, NBA+WNBA fantasy-pp), −1 demote (NFL receiving-tds)

### DIFF
--- a/src/sportstradamus/data/config/stat_meta.json
+++ b/src/sportstradamus/data/config/stat_meta.json
@@ -174,8 +174,8 @@
         },
         "FG3A": {
             "dist": "SkewNormal",
-            "shipped": "withheld",
-            "target_normalization": "ratio_meanyr",
+            "shipped": "devel",
+            "target_normalization": "centered_additive_eb_meanyr_k10",
             "posthoc": "none"
         },
         "FG3M": {
@@ -271,9 +271,10 @@
         },
         "fantasy points prizepicks": {
             "dist": "SkewNormal",
-            "shipped": "withheld",
-            "target_normalization": "none",
-            "posthoc": "none"
+            "shipped": "devel",
+            "target_normalization": "centered_additive_mean10",
+            "posthoc": "none",
+            "blending": "crps"
         }
     },
     "NFL": {
@@ -345,7 +346,7 @@
         },
         "receiving tds": {
             "dist": "ZINB",
-            "shipped": "devel",
+            "shipped": "withheld",
             "target_normalization": "none",
             "posthoc": "none"
         },
@@ -602,7 +603,7 @@
         },
         "fantasy points prizepicks": {
             "dist": "SkewNormal",
-            "shipped": "withheld",
+            "shipped": "devel",
             "target_normalization": "ratio_meanyr",
             "posthoc": "none"
         }


### PR DESCRIPTION
**Source:** Operation Ship-75 §6.2 normalization×loss strategy board (first full sweep) + real-HPO confirms. The board only *ranks* corners on the val-fit→test gate row; each ship below cleared the official **6-gate offline scorecard at full HPO**, not the deterministic board score.

### +3 net-new ships (withheld → devel), each 6/6 gates
- **NBA FG3A** — `centered_additive_eb_meanyr_k10`. brier_skill +0.044, g4 PIT-KS 0.043.
- **NBA fantasy points prizepicks** — `centered_additive_mean10` + `blending: crps`. brier_skill +0.044, g4 0.041. Required *both* the normalization and the CRPS-blend axes; NLL-only and uncentered corners failed Gate 4.
- **WNBA fantasy points prizepicks** — `ratio_meanyr`. brier_skill +0.110, g4 within cap.

### −1 demote (devel → withheld)
- **NFL receiving tds** — full-HPO re-confirm **regressed**: Gate-2 star σ-match z 0.83 (> 0.5 cap). Demoted so `meditate`'s serve-iff-ship prunes it from the next production pickle. Owner fork pending: §6.1 `roe_mean` affine-ROE (keep features, patch bias) vs per-cell M-1 feature exclusion.

### No supersede
- **WNBA RA** — the `centered_additive_mean10` candidate beat the `ratio_meanyr` incumbent on Brier (S2 d_mean +0.0259, CI excludes 0) but failed the paired-Sharpe test (S3 z +0.33 < 1.645). HOLD; incumbent unchanged (not in this PR).

### Net
devel served **19 → 21** (NBA 10→12, WNBA 6→7, NFL 3→2). No league at the 75% threshold yet (NBA short 4, WNBA short 7, NFL short 13).

**Production delta:** one file, one commit — `stat_meta.json` (4 cell flips). No Python, no deps, no dev scaffolding. devel code already executes all three normalizations (incl. `blending:crps`) from the Phase-B foundation arc (#81).

**Caveat:** confirms ran against the research-branch training data/archive; the server's next `meditate` retrains the flipped cells and serve-iff-ship prunes any that don't reproduce `ship=True` on server data (standard research→devel flow).

Gates (research branch): ruff clean, golden suite green modulo 2 pre-existing nondeterministic real-NBA correlation tests (stash-verified unrelated), integration 17 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
